### PR TITLE
Set beam type to URI

### DIFF
--- a/pfb/parser/hci.yaml
+++ b/pfb/parser/hci.yaml
@@ -114,7 +114,7 @@ inputs:
     info:
       Gridding precision
   beam-model:
-    dtype: str
+    dtype: URI
     info:
       Path to beam model as an xarray dataset backed by zarr
   field-of-view:


### PR DESCRIPTION
beam-model was not getting mounted correctly, has to be URI type