### PR TITLE
Tweak logging

### DIFF
--- a/pfb/utils/logging.py
+++ b/pfb/utils/logging.py
@@ -29,7 +29,13 @@ class PFBLogger(logging.Logger):
     with Rich formatting capabilities.
     """
 
-    def error_and_raise(self, message: str, exception_type: Type[Exception] = Exception, *args, **kwargs) -> None:
+    def error_and_raise(
+        self,
+        message: str,
+        exception_type: Type[Exception] = Exception,
+        *args,
+        **kwargs
+    ) -> None:
         """
         Log an error message and raise an exception.
 
@@ -290,12 +296,14 @@ def log_options_dict(logger: PFBLogger, options: Dict[str, Any], title: str = "O
     for key, value in options.items():
         options_table.add_row(f"[green]{key}[/green]", "|", f"[white]{value}[/white]")
 
+    # We cannot log the table neatly, so instead we use console's print command directly
+    # and capture the output so we can add an unformatted version to the log.
     with rich_console.capture() as capture:
-        rich_console.print(Panel(options_table, style="cyan", title="Inputs"))
+        rich_console.print(Panel(options_table, style="cyan", title=title))
 
     str_output = Text.from_ansi(capture.get())
-    rich_console.print(str_output.markup)
-    logger.debug(str_output)
+    rich_console.print(str_output.markup)  # Display in terminal.
+    logger.debug(f"\n{str_output}")  # Print to log - will display twice if log level is DEBUG.
 
 def create_timestamped_log_file(log_directory: Union[str, Path], component_name: str) -> str:
     """

--- a/pfb/utils/logging.py
+++ b/pfb/utils/logging.py
@@ -22,9 +22,6 @@ rich_console = Console()
 
 install_rich_traceback(console=rich_console, show_locals=False)
 
-# define log message format
-str_fmt = "%(asctime)s - %(name)-15s - %(levelname)-8s - %(funcName)s:%(lineno)d - %(message)s"
-
 class PFBLogger(logging.Logger):
     """
     Enhanced logger class that provides pyscilog-compatible interface
@@ -98,9 +95,8 @@ class LoggingManager:
         )
         console_handler.setLevel(log_level)
 
-        # NOTE(JSKenyon): Removed the formatter for now as the RichHandler defaults seem sensible.
         formatter = logging.Formatter(
-            fmt=str_fmt,
+            fmt="%(asctime)s - %(name)-15s - %(levelname)-8s - %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S"
         )
         console_handler.setFormatter(formatter)
@@ -146,7 +142,7 @@ class LoggingManager:
 
         # File formatter (more detailed than console)
         file_formatter = logging.Formatter(
-            fmt=str_fmt,
+            fmt="%(asctime)s - %(name)-15s - %(levelname)-8s - %(funcName)s:%(lineno)d - %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S"
         )
         file_handler.setFormatter(file_formatter)

--- a/pfb/utils/logging.py
+++ b/pfb/utils/logging.py
@@ -299,7 +299,7 @@ def log_options_dict(logger: PFBLogger, options: Dict[str, Any], title: str = "O
     # We cannot log the table neatly, so instead we use console's print command directly
     # and capture the output so we can add an unformatted version to the log.
     with rich_console.capture() as capture:
-        rich_console.print(Panel(options_table, style="cyan", title=title))
+        rich_console.print(Panel(options_table, style="cyan", title=f"[cyan]{title}[/cyan]"))
 
     str_output = Text.from_ansi(capture.get())
     rich_console.print(str_output.markup)  # Display in terminal.

--- a/pfb/utils/logging.py
+++ b/pfb/utils/logging.py
@@ -6,215 +6,157 @@ formatting using the Rich library for better console output.
 """
 
 import logging
-import sys
 import time
 from pathlib import Path
 from typing import Optional, Dict, Any, Type, Union
 from functools import wraps
 
-try:
-    from rich.console import Console
-    from rich.logging import RichHandler
-    from rich.text import Text
-    from rich.traceback import install as install_rich_traceback
-    RICH_AVAILABLE = True
-    # Install rich traceback handling
-    install_rich_traceback(show_locals=False)
-except ImportError:
-    RICH_AVAILABLE = False
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.traceback import install as install_rich_traceback
+from rich.table import Table, Column
+from rich.panel import Panel
+from rich.text import Text
+
+rich_console = Console()
+
+install_rich_traceback(console=rich_console, show_locals=False)
 
 
-class PFBLogger:
+class PFBLogger(logging.Logger):
     """
     Enhanced logger class that provides pyscilog-compatible interface
     with Rich formatting capabilities.
     """
-    
-    def __init__(self, name: str, app_name: str = 'pfb'):
-        self.name = name
-        self.app_name = app_name
-        self.logger = logging.getLogger(f"{app_name}.{name}")
-        # self._console = Console(width=120, force_terminal=True) if RICH_AVAILABLE else None
-        self._console = Console(force_terminal=True) if RICH_AVAILABLE else None
-        
-    def info(self, message: str, *args, **kwargs) -> None:
-        """Log an info message."""
-        self.logger.info(message, *args, **kwargs)
-    
-    def debug(self, message: str, *args, **kwargs) -> None:
-        """Log a debug message."""
-        self.logger.debug(message, *args, **kwargs)
-    
-    def warning(self, message: str, *args, **kwargs) -> None:
-        """Log a warning message."""
-        self.logger.warning(message, *args, **kwargs)
-        
-    def warn(self, message: str, *args, **kwargs) -> None:
-        """Alias for warning for compatibility."""
-        self.warning(message, *args, **kwargs)
-    
-    def error(self, message: str, *args, **kwargs) -> None:
-        """Log an error message."""
-        self.logger.error(message, *args, **kwargs)
-    
-    def critical(self, message: str, *args, **kwargs) -> None:
-        """Log a critical message."""
-        self.logger.critical(message, *args, **kwargs)
-        
-    def exception(self, message: str, *args, **kwargs) -> None:
-        """Log an exception with traceback."""
-        self.logger.exception(message, *args, **kwargs)
-    
+
     def error_and_raise(self, message: str, exception_type: Type[Exception] = Exception, *args, **kwargs) -> None:
         """
         Log an error message and raise an exception.
-        
+
         This provides compatibility with pyscilog's error_and_raise method.
-        
+
         Args:
             message: The error message to log and include in the exception
             exception_type: The type of exception to raise (default: Exception)
             *args: Additional arguments for the logger
             **kwargs: Additional keyword arguments for the logger
         """
-        # Format the message with bold text if Rich is available
-        if RICH_AVAILABLE:
-            bold_message = f"[bold red]{message}[/bold red]"
-            self.logger.error(bold_message, *args, **kwargs)
-        else:
-            self.logger.error(message, *args, **kwargs)
+
+        bold_message = f"[bold red]{message}[/bold red]"
+        self.error(bold_message, *args, **kwargs)
+
         raise exception_type(message)
 
+# Any logger created hereafter will be an instance of PFBLogger.
+logging.setLoggerClass(PFBLogger)
 
-class PFBLoggingManager:
+class LoggingManager:
     """
     Global logging manager that handles initialization and configuration.
     """
-    
-    def __init__(self):
-        self._initialized = False
-        self._app_name = 'pfb'
-        self._loggers: Dict[str, PFBLogger] = {}
-        self._log_files: Dict[str, str] = {}
-        self._console = Console(width=120, force_terminal=True) if RICH_AVAILABLE else None
-        self._root_logger = logging.getLogger(self._app_name)
-        
-    def init(self, app_name: str = 'pfb', log_level: Union[str, int] = logging.INFO) -> None:
+
+    def __init__(self, app_name: str, log_level: Union[str, int] = logging.INFO) -> None:
         """
         Initialize the logging system.
-        
+
         Args:
-            app_name: Name of the application (default: 'pfb')
-            log_level: Logging level (default: INFO)
+            app_name: Name of the application
+            log_level: Logging level of the default console handler.
         """
-        if self._initialized:
-            return
-            
         self._app_name = app_name
-        self._root_logger = logging.getLogger(app_name)
-        
-        # Set up the root logger
-        self._root_logger.setLevel(log_level)
-        
+        self._loggers: Dict[str, PFBLogger] = {}
+        self._log_files: Dict[str, str] = {}
+        self._console = rich_console
+        self._root_logger = logging.getLogger(self._app_name)
+
+        # Set up the root logger - this should always be set to DEBUG level to ensure that all
+        # log messages are dispatched to the relevant handlers.
+        self._root_logger.setLevel(logging.DEBUG)
+
         # Remove existing handlers to avoid duplicates
-        for handler in self._root_logger.handlers[:]:
+        for handler in self._root_logger.handlers:
             self._root_logger.removeHandler(handler)
-        
-        # Create console handler with Rich formatting if available
-        if RICH_AVAILABLE:
-            console_handler = RichHandler(
-                console=self._console,
-                show_time=False,  # Disable Rich's built-in time formatting
-                show_level=False,  # Disable Rich's built-in level formatting
-                show_path=False,  # Disable path to save space for longer messages
-                rich_tracebacks=True,
-                tracebacks_show_locals=True,
-                markup=True
-            )
-            console_handler.setLevel(log_level)
-            
-            # Custom format for longer lines with prominent timestamp and aligned levels
-            formatter = logging.Formatter(
-                fmt="%(asctime)s - %(name)-15s - %(levelname)-8s - %(message)s",
-                datefmt="%Y-%m-%d %H:%M:%S"
-            )
-            console_handler.setFormatter(formatter)
-        else:
-            # Fallback to standard handler if Rich is not available
-            console_handler = logging.StreamHandler(sys.stdout)
-            console_handler.setLevel(log_level)
-            
-            formatter = logging.Formatter(
-                fmt="%(asctime)s - %(name)-15s - %(levelname)-8s - %(message)s",
-                datefmt="%Y-%m-%d %H:%M:%S"
-            )
-            console_handler.setFormatter(formatter)
-        
+
+        # Create console handler with Rich formatting. The RichHandler has limited configuration
+        # options. If needed, it is possible to subclass it and modify its methods.
+        console_handler = RichHandler(
+            console=self._console,
+            show_time=True,
+            show_level=True,
+            show_path=False,
+            rich_tracebacks=True,
+            tracebacks_show_locals=True,
+            markup=True
+        )
+        console_handler.setLevel(log_level)
+
+        # NOTE(JSKenyon): Removed the formatter for now as the RichHandler defaults seem sensible.
+        # formatter = logging.Formatter(
+        #     fmt="%(asctime)s - %(name)-15s - %(levelname)-8s - %(message)s",
+        #     datefmt="%Y-%m-%d %H:%M:%S",
+        #     style="{"
+        # )
+        # console_handler.setFormatter(formatter)
+
         self._root_logger.addHandler(console_handler)
-        
-        # Prevent propagation to avoid duplicate messages
+
+        # Prevent propagation from the application logger into the Python root logger i.e.
+        # the application logger is the final authority.
         self._root_logger.propagate = False
-        
-        self._initialized = True
-    
+
+
     def get_logger(self, component_name: str) -> PFBLogger:
         """
         Get a logger for a specific component.
-        
+
         Args:
             component_name: Name of the component
-            
+
         Returns:
             PFBLogger instance
         """
-        if not self._initialized:
-            self.init()
-            
         if component_name not in self._loggers:
-            self._loggers[component_name] = PFBLogger(component_name, self._app_name)
-            
+            self._loggers[component_name] = logging.getLogger(name=f"{self._app_name}.{component_name}")
+
         return self._loggers[component_name]
-    
+
     def log_to_file(self, filename: Union[str, Path], component_name: Optional[str] = None) -> None:
         """
         Add file logging to the specified file.
-        
+
         Args:
             filename: Path to the log file
             component_name: Optional component name to restrict file logging to specific component
         """
-        if not self._initialized:
-            self.init()
-            
         filename = Path(filename)
-        
+
         # Create directory if it doesn't exist
         filename.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Create file handler
         file_handler = logging.FileHandler(filename, mode='a')
         file_handler.setLevel(logging.DEBUG)  # File gets all messages
-        
+
         # File formatter (more detailed than console)
         file_formatter = logging.Formatter(
             fmt="%(asctime)s - %(name)-15s - %(levelname)-8s - %(funcName)s:%(lineno)d - %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S"
         )
         file_handler.setFormatter(file_formatter)
-        
+
         # Add to appropriate logger
-        if component_name:
+        if component_name:  # Do we want to support this?
             # Add to specific component logger
             logger = self.get_logger(component_name)
             logger.logger.addHandler(file_handler)
         else:
             # Add to root logger (affects all components)
             self._root_logger.addHandler(file_handler)
-        
+
         # Store the file reference
         key = component_name if component_name else 'root'
         self._log_files[key] = str(filename)
-        
+
         # Log that we've started logging to file
         if component_name:
             logger = self.get_logger(component_name)
@@ -223,61 +165,50 @@ class PFBLoggingManager:
             # For root logger, log directly to avoid duplication
             # since child loggers will inherit the file handler
             self._root_logger.info(f"Logging to file: {filename}")
-    
+
     def set_log_level(self, level: Union[str, int]) -> None:
         """
         Set the logging level for all loggers.
-        
+
         Args:
             level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
         """
         if isinstance(level, str):
             level = getattr(logging, level.upper())
-            
-        self._root_logger.setLevel(level)
-        
-        # Update all handlers
+
+        self._root_logger.setLevel(level)  # Should the application logger ever change level?
+
+        # Update all handlers which are not instances of logging.FileHandler.
         for handler in self._root_logger.handlers:
             if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
                 handler.setLevel(level)
-    
+
     def get_log_files(self) -> Dict[str, str]:
         """Get dictionary of active log files."""
         return self._log_files.copy()
-    
+
     def close_log_files(self) -> None:
         """Close all file handlers."""
         for handler in self._root_logger.handlers[:]:
             if isinstance(handler, logging.FileHandler):
                 handler.close()
                 self._root_logger.removeHandler(handler)
-        
+
         # Clear file references
         self._log_files.clear()
 
 
 # Global manager instance
-_logging_manager = PFBLoggingManager()
-
-# Public API functions for pyscilog compatibility
-def init(app_name: str = 'pfb', log_level: Union[str, int] = logging.INFO) -> None:
-    """
-    Initialize the logging system.
-    
-    Args:
-        app_name: Name of the application (default: 'pfb')
-        log_level: Logging level (default: INFO)
-    """
-    _logging_manager.init(app_name, log_level)
+_logging_manager = LoggingManager("pfb")
 
 
 def get_logger(component_name: str) -> PFBLogger:
     """
     Get a logger for a specific component.
-    
+
     Args:
         component_name: Name of the component
-        
+
     Returns:
         PFBLogger instance
     """
@@ -287,7 +218,7 @@ def get_logger(component_name: str) -> PFBLogger:
 def log_to_file(filename: Union[str, Path], component_name: Optional[str] = None) -> None:
     """
     Add file logging to the specified file.
-    
+
     Args:
         filename: Path to the log file
         component_name: Optional component name to restrict file logging to specific component
@@ -298,7 +229,7 @@ def log_to_file(filename: Union[str, Path], component_name: Optional[str] = None
 def set_log_level(level: Union[str, int]) -> None:
     """
     Set the logging level for all loggers.
-    
+
     Args:
         level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
     """
@@ -319,7 +250,7 @@ def close_log_files() -> None:
 def log_function_call(logger: PFBLogger):
     """
     Decorator to log function calls with arguments.
-    
+
     Args:
         logger: PFBLogger instance to use for logging
     """
@@ -328,7 +259,7 @@ def log_function_call(logger: PFBLogger):
         def wrapper(*args, **kwargs):
             # Log function entry
             logger.debug(f"Calling {func.__name__} with args={args}, kwargs={kwargs}")
-            
+
             try:
                 result = func(*args, **kwargs)
                 logger.debug(f"Function {func.__name__} completed successfully")
@@ -343,32 +274,44 @@ def log_function_call(logger: PFBLogger):
 def log_options_dict(logger: PFBLogger, options: Dict[str, Any], title: str = "Options") -> None:
     """
     Log a dictionary of options in a formatted way.
-    
+
     Args:
         logger: PFBLogger instance to use for logging
         options: Dictionary of options to log
         title: Title for the options section
     """
-    logger.info(f'{title}:')
-    for key, value in options.items():
-        logger.info(f'     {key:>25s} = {value}')
 
+    name_col = Column(justify="left")
+    spacer_col = Column(justify="center")
+    val_col = Column(justify="left")
+
+    options_table = Table.grid(name_col, spacer_col, val_col, expand=True)
+
+    for key, value in options.items():
+        options_table.add_row(f"[green]{key}[/green]", "|", f"[white]{value}[/white]")
+
+    with rich_console.capture() as capture:
+        rich_console.print(Panel(options_table, style="cyan", title="Inputs"))
+
+    str_output = Text.from_ansi(capture.get())
+    rich_console.print(str_output.markup)
+    logger.debug(str_output)
 
 def create_timestamped_log_file(log_directory: Union[str, Path], component_name: str) -> str:
     """
     Create a timestamped log file path compatible with pyscilog pattern.
-    
+
     Args:
         log_directory: Directory where log files should be stored
         component_name: Name of the component for the log file
-        
+
     Returns:
         Path to the log file
     """
     timestamp = time.strftime("%Y%m%d-%H%M%S")
     log_directory = Path(log_directory)
     log_directory.mkdir(parents=True, exist_ok=True)
-    
+
     logname = log_directory / f'{component_name}_{timestamp}.log'
     return str(logname)
 
@@ -376,20 +319,20 @@ def create_timestamped_log_file(log_directory: Union[str, Path], component_name:
 # Context manager for temporary log file
 class TemporaryLogFile:
     """Context manager for temporary log file setup."""
-    
+
     def __init__(self, log_directory: Union[str, Path], component_name: str):
         self.log_directory = log_directory
         self.component_name = component_name
         self.log_file = None
         self.logger = None
-        
+
     def __enter__(self):
         self.log_file = create_timestamped_log_file(self.log_directory, self.component_name)
         self.logger = get_logger(self.component_name)
         log_to_file(self.log_file, self.component_name)
         return self.logger
-        
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is not None:
             self.logger.error(f"Error occurred: {exc_val}")
-        self.logger.info(f"Logging session ended")
+        self.logger.info("Logging session ended")

--- a/pfb/workers/degrid.py
+++ b/pfb/workers/degrid.py
@@ -75,10 +75,7 @@ def degrid(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     # we need the collections
     from pfb import set_client

--- a/pfb/workers/degrid.py
+++ b/pfb/workers/degrid.py
@@ -3,12 +3,10 @@ from pfb.workers.main import cli
 import time
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('DEGRID')
-
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('DEGRID')
 
 
 @cli.command(context_settings={'show_default': True})
@@ -230,13 +228,13 @@ def _degrid(**kw):
         output_schema = ['XX', 'XY', 'YX', 'YY']
     else:
         output_schema = ['RR', 'RL', 'LR', 'LL']
-    
+
     writes = []
     for ms in opts.ms:
         xds = xds_from_ms(ms,
                           chunks=ms_chunks[ms],
                           group_cols=group_by)
-        
+
 
         for i, mask in enumerate(masks):
             out_data = []
@@ -314,14 +312,14 @@ def _degrid(**kw):
 
                 # convert to single precision to write to MS
                 vis = vis.astype(np.complex64)
-                
+
                 if ncorr==1:
                     out_schema = output_schema[0]
                 elif ncorr==2:
                     out_schema = [output_schema[0], output_schema[-1]]
                 else:
                     out_schema = output_schema
-                
+
                 vis = convert(vis, input_schema, out_schema, implicit_stokes=True)
 
                 if opts.accumulate:

--- a/pfb/workers/fluxtractor.py
+++ b/pfb/workers/fluxtractor.py
@@ -46,10 +46,7 @@ def fluxtractor(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     from pfb.utils.naming import xds_from_url
 

--- a/pfb/workers/fluxtractor.py
+++ b/pfb/workers/fluxtractor.py
@@ -3,11 +3,10 @@ from contextlib import ExitStack
 from pfb.workers.main import cli
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('FLUXTRACTOR')
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('FLUXTRACTOR')
 
 
 @cli.command(context_settings={'show_default': True})

--- a/pfb/workers/grid.py
+++ b/pfb/workers/grid.py
@@ -58,10 +58,7 @@ def grid(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     from pfb import set_envs
     from ducc0.misc import resize_thread_pool, thread_pool_size

--- a/pfb/workers/grid.py
+++ b/pfb/workers/grid.py
@@ -2,11 +2,11 @@
 from pfb.workers.main import cli
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('GRID')
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('GRID')
+
 
 @cli.command(context_settings={'show_default': True})
 @clickify_parameters(schema.grid)
@@ -463,7 +463,7 @@ def _grid(**kw):
                 model = None
         else:
             model = None
-        
+
         fut = client.submit(image_data_products,
                             dsl,
                             out_ds_name,
@@ -519,7 +519,7 @@ def _grid(**kw):
             psfparsn[timeid] = fitcleanbeam(psf_mfs[timeid])
         else:
             psfparsn = None
-        
+
         residual_mfs[timeid] /= wsum[timeid][:, None, None]
         for c in range(ncorr):
             rms = np.std(residual_mfs[timeid][c])
@@ -529,12 +529,12 @@ def _grid(**kw):
             rmax = np.abs(residual_mfs[timeid][c]).max()
             log.info(f"Time ID {timeid}: {corrs[c]} - resid max = {rmax:.3e}, "
                   f"rms = {rms:.3e}")
-            
+
     # put these in the dds for future reference
     if psfparsn is not None:
         cache_opts(psfparsn,
                    dds_store.url,
                    protocol,
                    name='psfparsn_mfs.pkl')
-    
+
     return psfparsn

--- a/pfb/workers/hci.py
+++ b/pfb/workers/hci.py
@@ -85,10 +85,7 @@ def hci(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     from pfb import set_envs
     from ducc0.misc import resize_thread_pool

--- a/pfb/workers/init.py
+++ b/pfb/workers/init.py
@@ -2,12 +2,11 @@
 from pfb.workers.main import cli
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('INIT')
 import time
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('INIT')
 
 
 @cli.command(context_settings={'show_default': True})

--- a/pfb/workers/init.py
+++ b/pfb/workers/init.py
@@ -61,10 +61,7 @@ def init(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     from pfb import set_envs
     from ducc0.misc import resize_thread_pool

--- a/pfb/workers/kclean.py
+++ b/pfb/workers/kclean.py
@@ -38,14 +38,7 @@ def kclean(**kw):
     logname = f'{str(opts.log_directory)}/kclean_{timestamp}.log'
     pfb_logging.log_to_file(logname)
 
-    # TODO - prettier config printing
-    pfb_logging.log_options_dict(log, opts, "Input options:")
-
-    import ipdb; ipdb.set_trace()
-
-    # log.info('Input Options:')
-    # for key in opts.keys():
-    #     log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     from pfb.utils.naming import xds_from_url, get_opts
 

--- a/pfb/workers/kclean.py
+++ b/pfb/workers/kclean.py
@@ -3,11 +3,10 @@ from pfb.workers.main import cli
 from omegaconf import OmegaConf
 import time
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('KCLEAN')
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('KCLEAN')
 
 
 @cli.command(context_settings={'show_default': True})
@@ -38,12 +37,15 @@ def kclean(**kw):
     timestamp = time.strftime("%Y%m%d-%H%M%S")
     logname = f'{str(opts.log_directory)}/kclean_{timestamp}.log'
     pfb_logging.log_to_file(logname)
-    log.info(f'Logs will be written to {logname}')
 
     # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts, "Input options:")
+
+    import ipdb; ipdb.set_trace()
+
+    # log.info('Input Options:')
+    # for key in opts.keys():
+    #     log.info('     %25s = %s' % (key, opts[key]))
 
     from pfb.utils.naming import xds_from_url, get_opts
 

--- a/pfb/workers/model2comps.py
+++ b/pfb/workers/model2comps.py
@@ -40,10 +40,7 @@ def model2comps(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     with ExitStack() as stack:
         ti = time.time()

--- a/pfb/workers/model2comps.py
+++ b/pfb/workers/model2comps.py
@@ -3,12 +3,10 @@ from contextlib import ExitStack
 from pfb.workers.main import cli
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('MODEL2COMPS')
-
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('MODEL2COMPS')
 
 
 @cli.command(context_settings={'show_default': True})
@@ -333,7 +331,7 @@ def _model2comps(**kw):
                   fits_name,
                   hdr,
                   overwrite=True)
-        
+
 def _model2comps_fits(**kw):
     opts = OmegaConf.create(kw)
     OmegaConf.set_struct(opts, True)
@@ -618,7 +616,7 @@ def _model2comps_fits(**kw):
     else:  # we just write it back at input frequencies as a sanity check
         hdr = set_wcs(cell_deg, cell_deg, nx, ny, [ra, dec],
                       mfreqs, GuassPar=(1, 1, 0), casambm=False)
-                      
+
     save_fits(modelo[:, None, :, :],
               fits_name,
               hdr,

--- a/pfb/workers/restore.py
+++ b/pfb/workers/restore.py
@@ -40,10 +40,7 @@ def restore(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     with ExitStack() as stack:
         if opts.nworkers > 1:

--- a/pfb/workers/restore.py
+++ b/pfb/workers/restore.py
@@ -3,11 +3,10 @@ from contextlib import ExitStack
 from pfb.workers.main import cli
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('RESTORE')
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('RESTORE')
 
 
 @cli.command(context_settings={'show_default': True})
@@ -99,7 +98,7 @@ def _restore(**kw):
         protocol = dds_store.url.split('://')[0]
     else:
         protocol = 'file'
-    
+
     # get MFS PSF PARS
     try:
         psfpars_mfs = get_opts(dds_store.url,
@@ -109,7 +108,7 @@ def _restore(**kw):
         log.error_and_raise("Could not load MFS PSF pamaters. "
                             "Run grid worker with psf=true to remake.",
                             RuntimeError)
-    
+
     if opts.drop_bands is not None:
         ddso = []
         ddso_list = []

--- a/pfb/workers/sara.py
+++ b/pfb/workers/sara.py
@@ -3,11 +3,10 @@ import concurrent.futures as cf
 from pfb.workers.main import cli
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('SARA')
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('SARA')
 
 
 @cli.command(context_settings={'show_default': True})
@@ -151,7 +150,7 @@ def _sara(**kw):
                             NotImplementedError)
 
     nx, ny = dds[0].x.size, dds[0].y.size
-    
+
     nx_psf, ny_psf = dds[0].x_psf.size, dds[0].y_psf.size
     lastsize = ny_psf
     freq_out = []

--- a/pfb/workers/sara.py
+++ b/pfb/workers/sara.py
@@ -40,10 +40,7 @@ def sara(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     from pfb.utils.naming import xds_from_url, get_opts
 

--- a/pfb/workers/smoovie.py
+++ b/pfb/workers/smoovie.py
@@ -1,11 +1,11 @@
 from pfb.workers.main import cli
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('SMOOVIE')
 import time
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('SMOOVIE')
 
 
 @cli.command(context_settings={'show_default': True})
@@ -21,13 +21,13 @@ def smoovie(**kw):
 
     import psutil
     ncpu = psutil.cpu_count(logical=False)
-    # to prevent flickering 
+    # to prevent flickering
     opts.nthreads = 1
     remprod = opts.product.upper().strip('IQUV')
     if len(remprod):
         log.error_and_raise(f"Product {remprod} not yet supported",
                             NotImplementedError)
-    
+
     timestamp = time.strftime("%Y%m%d-%H%M%S")
     logname = f'{str(opts.log_directory)}/smoovie_{timestamp}.log'
     pfb_logging.log_to_file(logname)
@@ -143,7 +143,7 @@ def _smoovie(**kw):
             fds_dict[b].append(ds)
 
         for b, dslist in fds_dict.items():
-            
+
             log.info(f"Writing movie to {basename}_band{b}_{idfy}.{outfmt}")
             rmss = [ds.rms for ds in dslist]
             medrms = np.median(rmss)

--- a/pfb/workers/smoovie.py
+++ b/pfb/workers/smoovie.py
@@ -34,10 +34,7 @@ def smoovie(**kw):
     log.info(f'Logs will be written to {logname}')
     OmegaConf.set_struct(opts, True)
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     from pfb import set_envs
     set_envs(opts.nthreads, ncpu)

--- a/pfb/workers/spotless.py
+++ b/pfb/workers/spotless.py
@@ -54,10 +54,7 @@ def spotless(**kw):
     pfb_logging.log_to_file(logname)
     log.info(f'Logs will be written to {logname}')
 
-    # TODO - prettier config printing
-    log.info('Input Options:')
-    for key in opts.keys():
-        log.info('     %25s = %s' % (key, opts[key]))
+    pfb_logging.log_options_dict(log, opts)
 
     with ExitStack() as stack:
         from pfb import set_client

--- a/pfb/workers/spotless.py
+++ b/pfb/workers/spotless.py
@@ -3,11 +3,10 @@ from contextlib import ExitStack
 from pfb.workers.main import cli
 from omegaconf import OmegaConf
 from pfb.utils import logging as pfb_logging
-pfb_logging.init('pfb')
-log = pfb_logging.get_logger('SPOTLESS')
-
 from scabha.schema_utils import clickify_parameters
 from pfb.parser.schemas import schema
+
+log = pfb_logging.get_logger('SPOTLESS')
 
 
 @cli.command(context_settings={'show_default': True})


### PR DESCRIPTION
While doing some experiments with pfb I noticed that there were some easy improvements to be made to the logging. I think my changes make it a little simpler overall. I opted to purge the logic which reasons about the availability of `rich` as I couldn't really think of a situation where that would be necessary. 

I only tested this with `kclean` so while I don't think the changes will have broken anything, it is worth checking. 

Options are now displayed as follows in the terminal, but this is easy to change:
<img width="1128" height="1183" alt="image" src="https://github.com/user-attachments/assets/80237060-551a-4297-bd58-da4e79afbf2c" />

The log file will look something like:
<img width="1128" height="899" alt="image" src="https://github.com/user-attachments/assets/bf4723d0-6c57-40f4-a15d-6d3fedc6e2c3" />

 