### PR TITLE
round coords when create dummy ds to avoid roudning errors. change ch…

### DIFF
--- a/pfb/utils/stokes2im.py
+++ b/pfb/utils/stokes2im.py
@@ -223,6 +223,8 @@ def stokes_image(
         new_ra_rad = np.deg2rad(c.ra.value)
         new_dec_rad = np.deg2rad(c.dec.value)
         radec_new = np.array((new_ra_rad, new_dec_rad))
+
+        # print(c.ra.value, c.dec.value, cell_deg)
         
         from pfb.utils.astrometry import synthesize_uvw
         uvw_new = synthesize_uvw(antpos, time, ant1, ant2, radec_new)
@@ -535,14 +537,19 @@ def stokes_image(
     # set corr coords (removing duplicates and sorting)
     corr = "".join(dict.fromkeys(sorted(opts.product)))
 
+    out_ras = ra_deg + np.arange(nx//2, -(nx//2), -1) * cell_deg
+    out_decs = dec_deg + np.arange(-(ny//2), ny//2) * cell_deg
+    out_ras = np.round(out_ras, decimals=12)
+    out_decs = np.round(out_decs, decimals=12)
+
     # save outputs
     if opts.output_format == 'zarr':
         coords = {
             'FREQ': (('FREQ',), np.array([freq_out])),
             'TIME': (('TIME',), np.mean(utime, keepdims=True)),
             'STOKES': (('STOKES',), list(corr)),
-            'X': (('X',), ra_deg + np.arange(nx//2, -(nx//2), -1) * cell_deg),
-            'Y': (('Y',), dec_deg + np.arange(-(ny//2), ny//2) * cell_deg),
+            'X': (('X',), out_ras),
+            'Y': (('Y',), out_decs),
         }
         # X and Y are transposed for compatibility with breifast
         data_vars = {}


### PR DESCRIPTION
I was getting an error when writing to the stacked dataset from one of the workers. For some reason the `X` coordinates come out slight differently (1e-14 level) when computing them in the dummy run compared to computing them inside the worker. Weirdly, the `Y` coordinate does not suffer from the same problem. I can get around this by rounding the coordinates

https://github.com/ratt-ru/pfb-imaging/blob/3342a5109c1d8692145aaf0b1c3cf84985cdfb59/pfb/workers/hci.py#L634

but now sure why this should be necessary. I've only seen this on a single dataset so far. Will keep an eye on it through https://github.com/ratt-ru/pfb-imaging/issues/155.

Also change `chan_widths` to `channel_width` and remove the `channel_width` attribute as requested by @o-smirnov 