### PR TITLE
fix(imager): use the effective band frequency for labels and beams

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -116,7 +116,9 @@ path. Design rationale, `concat_row` semantics and known risks: `docs/wiki/image
    band node, and writes the `.dt` tree. FITS via `utils/fits.dt2fits`/`rdt2fits`.
 
 **Tree layout** (`<out>_<PRODUCT>.dt`): one node per output image
-`band{b:04d}_time{t:04d}`; one child `part{p:04d}` per data partition identified by
+`band{b:04d}_time{t:04d}` (attrs `freq_out` = the effective wsum-weighted frequency of the
+channels actually gridded, `freq_nominal` = the band-edge midpoint used only for band
+assignment — wiki D28); one child `part{p:04d}` per data partition identified by
 `(msid, field, spw, baseline_group)` (`baseline_group` is a single `"all"` group for now,
 extensible for MeerKAT+ per-antenna-pair Mueller beams). Band nodes hold the summed image-space
 products (`DIRTY`, `BDIRTY` — the beam-attenuated `Σ_p B_p·dirty_p`, the model-free term of the
@@ -161,9 +163,10 @@ local repro harness: `docs/wiki/memory-and-ray.md`.
 using differential measures-synthesized UVW (the systematic vs the MS's own UVW cancels);
 `--target` is an in-plane image-centre offset carried as `l0/m0` attrs and a CRPIX shift in the
 FITS. Band/partition attrs: `ra/dec` = tangent point, `ra0/dec0` = field pointing. Beams are
-evaluated (katbeam or `BeamWizard` band names U/L/S0/S4) about the field pointing and reprojected
-onto the image grid **in pass 1** (#281); scratch/partition `BEAM` is `(corr, ny, nx)` and pass 2
-consumes it as is. The stored `BEAM` is the **effective response `B/n`** — the wgridder n-term is
+evaluated (katbeam or `BeamWizard` band names U/L/S0/S4) about the field pointing, at the piece's
+**effective frequency** (wiki D28 — not the band-edge centre), and reprojected
+onto the image grid **in pass 1** (#281); scratch/partition `BEAM` is `(corr, ny, nx)`, and pass 2
+reduces a partition's pieces to one `BEAM` as a `wsum_nat`-weighted mean (`_concat_pieces`, D28). The stored `BEAM` is the **effective response `B/n`** — the wgridder n-term is
 folded into it and every ducc call stays `divide_by_n=False` (wiki D22; the fold is an exact
 operator identity and keeps the PSF-convolution Hessian at its baseline accuracy, unlike
 `divide_by_n=True` which a convolution cannot represent). The deconvolved MODEL is intrinsic flux.

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -795,8 +795,8 @@ update it (and this page's `last_verified_commit`) in the same session.
   `BeamWizard` (evaluated with the piece's own timestamps). That path is not exercised by
   current data — `timeid` is keyed on `(scan_name, block)`, so a `(band, time)` node holds
   one scan — but is deliberate future-proofing for MeerKAT+ baseline groups.
-  **Still open:** FITS cubes keep a linear `CRVAL3`/`CDELT3` and so cannot represent a
-  non-uniform frequency axis; per-plane `FREQ%04d` cards (or `--fits-split-bands`) are a
+  **Still open (#302):** FITS cubes keep a linear `CRVAL3`/`CDELT3` and so cannot represent
+  a non-uniform frequency axis; per-plane `FREQ%04d` cards (or `--fits-split-bands`) are a
   separate follow-up.
 - **Source:** issue #296; `src/pfb_imaging/utils/stokes2vis_msv4.py` (`stokes_vis`);
   `src/pfb_imaging/core/imager.py` (`_concat_pieces`, `_grid_image`, `band_centres`);

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-03T00:00:00Z
-last_verified_commit: 94aa96f
+timestamp: 2026-08-04T00:00:00Z
+last_verified_commit: 5111b13
 ---
 
 # Design decisions, known debt and recurring gotchas
@@ -752,6 +752,58 @@ update it (and this page's `last_verified_commit`) in the same session.
   `src/pfb_imaging/core/imager.py` (`_grid_image` accumulators, MFS PSF reduction);
   `src/pfb_imaging/utils/stokes2im.py` (the hci path's `real_type`, the pattern this
   restores); `tests/test_imager_precision.py`.
+
+### D28 — `freq_out` is the effective (weighted) frequency, reduced at three levels
+
+- **Context:** `freq_out` was the band-edge midpoint from a `linspace` over the frequency
+  span, but channels are sliced *by count* and assigned to the nearest midpoint, so the
+  label was wrong by up to half a channel whenever `nband` did not divide `nchan` (#296).
+  Worse, `stokes_vis` evaluated the **primary beam** at that same value: the beam was being
+  *computed* at the wrong frequency, not merely reported at one. Flagging makes it worse
+  still — a fully flagged channel moves a band's centre of mass by a whole channel width,
+  which a frequency-uniform grid cannot represent at all.
+- **Decision:** `freq_out` means the **weight-weighted mean frequency of the channels
+  actually gridded**, reduced at three levels:
+  1. **piece** (`stokes_vis`, pass 1) — `Σ w·mask·ν / Σ w·mask` over the post-averaging
+     channel axis, using **natural** weights. This value evaluates the beam *and* is stored.
+  2. **partition** (`_concat_pieces`, pass 2) — `wsum_nat`-weighted mean of the pieces'
+     frequencies, and of their `BEAM`s.
+  3. **band** (`_grid_image`, pass 2) — weighted by the **imaging** `prod["WSUM"]`.
+  The band-edge midpoints keep their sole remaining role, band *assignment*, renamed
+  `band_centres` (driver) / `freq_nominal` (parameters and attrs) so one name no longer
+  means two things. `freq_nominal` is also the fallback when no weight survives.
+- **Rationale:** A band product is the wsum-weighted sum of its partitions, so its effective
+  frequency is the wsum-weighted mean of theirs — the identical reduction `beam_sum` already
+  performs, which is *why* level 3 must use the imaging weights: `BEAM` and `freq_out` must
+  not be weighted by different quantities at the same level. Level 2 uses natural weights
+  because it runs before gridding, where robust weights do not exist; obtaining them would
+  mean holding every piece's `BEAM` resident through gridding instead of freeing it
+  (~67 MB per piece at 4096² f4), against `memory-and-ray.md`, to correct a beam that varies
+  slowly with frequency. **The mixed basis is deliberate — do not "fix" it into a
+  regression.** `freq_out` stays scalar, reduced with corr-summed weights, matching what
+  `dt2fits` already does for `freq_mfs`; per-correlation flagging differences are
+  second-order for continuum and a per-Stokes frequency axis has no home in FITS.
+- **Consequences:** Band frequencies **change value** for uneven splits — measured on
+  `tests/data/test_ascii_1h60.0s.MS` at `--channels-per-image 3`: +16.5, +99.9 and
+  +33.2 MHz on 100 MHz channels (the middle band dominated by one fully flagged channel).
+  Anything comparing against an older `.dt` or FITS will see it. Frequency accumulators are
+  **f8 regardless of `--precision`** (f4 resolves 1e9 Hz only to ~64 Hz — cf. D27, where
+  everything else follows the data dtype). `dt2fits` orders cube planes by `bandid`, not
+  `freq_out`, because data-dependent frequencies could otherwise invert and silently
+  reorder planes. `_concat_pieces` also fixes a latent bug independent of #296: the
+  partition used to inherit piece 0's `BEAM` wholesale, which was already wrong for
+  `BeamWizard` (evaluated with the piece's own timestamps). That path is not exercised by
+  current data — `timeid` is keyed on `(scan_name, block)`, so a `(band, time)` node holds
+  one scan — but is deliberate future-proofing for MeerKAT+ baseline groups.
+  **Still open:** FITS cubes keep a linear `CRVAL3`/`CDELT3` and so cannot represent a
+  non-uniform frequency axis; per-plane `FREQ%04d` cards (or `--fits-split-bands`) are a
+  separate follow-up.
+- **Source:** issue #296; `src/pfb_imaging/utils/stokes2vis_msv4.py` (`stokes_vis`);
+  `src/pfb_imaging/core/imager.py` (`_concat_pieces`, `_grid_image`, `band_centres`);
+  `src/pfb_imaging/utils/fits.py` (`dt2fits` sort key); commits 44bfbab, 090711e, 39cfb6c,
+  5111b13; `tests/test_imager.py::test_stokes_vis_beam_follows_effective_freq`,
+  `::test_imager_effective_freq_uneven_bands`,
+  `tests/test_imager_pass2.py::test_concat_pieces_weighted_beam_and_freq`.
 
 ## Known debt
 

--- a/docs/wiki/imager-pipeline.md
+++ b/docs/wiki/imager-pipeline.md
@@ -3,8 +3,8 @@ type: Subsystem Notes
 title: MSv4 DataTree imager pipeline
 description: Why the imager writes a DataTree, the two-pass data flow, the .dt layout, counts/weight-grouping and concat_row semantics, and the operator split that downstream deconvolution relies on.
 tags: [imager, msv4, datatree, weighting, gridding, mosaic]
-timestamp: 2026-08-03T00:00:00Z
-last_verified_commit: 94aa96f
+timestamp: 2026-08-04T00:00:00Z
+last_verified_commit: 5111b13
 ---
 
 # MSv4 DataTree imager pipeline
@@ -44,8 +44,11 @@ no-op later: just another `part{p}` child with its own `BEAM`.
   (root attrs) pfb-imaging-version, product, nband, ntime,
                nx, ny, nx_psf, ny_psf, cell_rad, max_blength, max_freq
   band{b:04d}_time{t:04d}/            # ONE OUTPUT IMAGE / Hessian summation domain
-      attrs:  bandid, timeid, freq_out, time_out, ra, dec, cell_rad,
+      attrs:  bandid, timeid, freq_out, freq_nominal, time_out, ra, dec, cell_rad,
               robustness (omitted when natural), niters
+              # freq_out = effective (wsum-weighted) frequency of the channels
+              # actually gridded; freq_nominal = band-edge midpoint, assignment
+              # grid only (D28)
       vars:   DIRTY, BDIRTY, BEAM (corr, y, x),                    # (Y, X), D20
               PSF (corr, y_psf, x_psf), PSFPARSN (corr, bpar),     # only with --psf
               WSUM (corr,)
@@ -55,7 +58,7 @@ no-op later: just another `part{p}` child with its own `BEAM`.
               # gradient (D23) -- not derivable from the summed DIRTY
               # MODEL / RESIDUAL / BRESIDUAL / NOISE added later by the deconv consumer
       part{p:04d}/                    # ONE DATA PARTITION
-          attrs:  msid, field_name, spw_name, baseline_group,
+          attrs:  msid, field_name, spw_name, baseline_group, freq_out,
                   ra, dec, l0, m0, wsum
           vis-space:   VIS, WEIGHT (corr, row, chan), MASK (row, chan),
                        UVW (row, three), FREQ (chan,)
@@ -95,7 +98,9 @@ legacy `.dds` is MJD seconds — `utils/fits.set_wcs(time_is_unix=…)`).
 
 1. **Pass 1** (`utils/stokes2vis_msv4.stokes_vis`, one Ray task per fine piece): load the
    node subset, column arithmetic (`dc1 [+|-] dc2`), Stokes conversion via `weight_data`,
-   channel-average/BDA, beam on the small grid, write the piece keyed
+   channel-average/BDA, the piece's **effective frequency** (natural-weight-weighted mean
+   over surviving channels — this is what the beam is evaluated at, D28), beam on the
+   small grid, write the piece keyed
    `(ms, field, spw, baseline_group, scan, band, time)` into `.scratch`, and return the
    piece's uv `COUNTS` contribution. Fine granularity (per scan /
    `integrations_per_image`) is needed because pass 1 reads raw unaveraged data.
@@ -108,12 +113,14 @@ legacy `.dds` is MJD seconds — `utils/fits.set_wcs(time_is_unix=…)`).
    uv grid is commensurate across bands (fixed cell + padding via `set_image_size`).
    Natural weighting is `robustness None` or `> 2`: counts are skipped entirely.
 3. **Pass 2** (`core/imager._grid_image`, one Ray task per output image): group scratch
-   pieces by partition key, concat scans along `row` (keeping the first piece's
-   `BEAM`/`FREQ` — exact because all of a band's pieces share `freq_out` and the global
-   beam grid), apply `counts_to_weights` per partition, grid each partition with
-   `operators/gridder.grid_partition`, sum image-space products into the band node,
-   write the `.dt`. Each `(band, part)` is an independent zarr group path, so workers
-   write concurrently without contention.
+   pieces by partition key, reduce each group with `_concat_pieces` (rows concatenated
+   along `row`; `BEAM` and `freq_out` combined as `wsum_nat`-weighted means — pieces may
+   differ in both, so piece 0's beam is *not* representative, D28), apply
+   `counts_to_weights` per partition, grid each partition with
+   `operators/gridder.grid_partition`, sum image-space products into the band node
+   (including the band's `freq_out` as the imaging-wsum-weighted mean of the partition
+   frequencies), write the `.dt`. Each `(band, part)` is an independent zarr group path,
+   so workers write concurrently without contention.
 
 ## `concat_row` semantics
 
@@ -126,6 +133,10 @@ pays one full DIRTY+PSF gridding per scan even at `integrations_per_image=-1`.
 - Rows are only concatenatable when they share phase centre and `FREQ` axis; this holds
   by construction within a partition key and is guarded by an assert. Different
   fields/spws are separate partitions: **summed, never concatenated**.
+- Pieces within a concat group may still differ in `BEAM` and effective frequency
+  (different times ⇒ different `BeamWizard` beams; different flagging ⇒ different
+  effective frequency), so `_concat_pieces` reduces both as `wsum_nat`-weighted means
+  rather than taking the first piece's (D28).
 - Counts are auto-coerced to band granularity, with a warning for time-resolved
   groupings: `per-band-time → per-band`, `per-time → mfs`.
 - `time_out` of the collapsed node is the mean of the constituents' `time_out`.

--- a/scripts/compare_wsclean.py
+++ b/scripts/compare_wsclean.py
@@ -78,7 +78,9 @@ weighting in play.  pfb's reduced counts grid is never written to the ``.dt``, s
 it is re-summed from the ``.scratch`` per-piece ``COUNTS`` -- hence
 ``--keep-scratch`` in the generated pfb command.  Note that natural weighting
 makes ``W_k = 1`` on every sampled cell, so a natural-weighted grid comparison
-only tests the cell support, not the density.
+only tests the cell support, not the density -- and the index transform of
+point 6 is then selected on support agreement too, since the values themselves
+carry no information.
 
 Metrics per product (computed on the aligned overlap, in float64):
 
@@ -903,9 +905,21 @@ def match_weight_grids(w_pfb, wf, transform="auto"):
     scored and the winner reported: the fftshift/reflection convention is
     *established* here, not assumed.
 
+    Scoring is normally the rms difference relative to the reference's own rms.
+    That breaks down under **natural** weighting, where every sampled cell is
+    exactly 1.0: the reference rms is 0, every candidate scores ``inf``, and the
+    sort silently leaves candidate 0 (``flipu=0``) on top -- the wrong transform,
+    which made the whole natural-weighted grid comparison meaningless, cell
+    support included.  When the values carry no information the only thing left
+    that can discriminate is which cells are sampled, so the score falls back to
+    the fraction of the union of the two supports on which they disagree
+    (0 = identical support).  On the sgra 700-800 MHz subset that picks
+    ``flipu=1`` at exactly 0, against 0.878 for ``flipu=0``.
+
     Returns:
         ``(pfb_half, wsc_half, best, scores)`` -- both grids cropped to the
-        populated ``v >= 0`` half in ``(v, u)`` display order.
+        populated ``v >= 0`` half in ``(v, u)`` display order.  Each score dict
+        carries the ``metric`` used, since the two are not comparable.
     """
     nv = w_pfb.shape[1]
     half = slice(nv // 2, nv)
@@ -917,12 +931,18 @@ def match_weight_grids(w_pfb, wf, transform="auto"):
     else:
         cands = [(f, r) for f in (False, True) for r in (0, -1, 1, nv // 2)]
 
+    denom = mad_rms(ref)
+    metric = "rms diff / rms" if denom > 0 else "support disagreement"
     scores = []
     for flipu, rollv in cands:
         trial = wsclean_grid_to_uv(wf, flipu, rollv)[:, half]
-        denom = mad_rms(ref)
-        score = float(np.sqrt(np.mean((trial - ref) ** 2)) / denom) if denom > 0 else np.inf
-        scores.append({"flipu": flipu, "rollv": rollv, "score": score})
+        if denom > 0:
+            score = float(np.sqrt(np.mean((trial - ref) ** 2)) / denom)
+        else:
+            sa, sb = ref != 0, trial != 0
+            union = int((sa | sb).sum())
+            score = float((sa ^ sb).sum() / union) if union else np.inf
+        scores.append({"flipu": flipu, "rollv": rollv, "score": score, "metric": metric})
     scores.sort(key=lambda s: s["score"])
     best = scores[0]
     return (
@@ -964,13 +984,14 @@ def weight_grid_pair(a, pfb_prefix, wsc_wpath, bandid, verbose=True):
         counts_to_weight_grid(counts, a.robustness), wf, a.grid_transform
     )
     if verbose:
-        print("  transform scores (rms diff / rms, lower is better):")
+        print(f"  transform scores ({best['metric']}, lower is better):")
         for s in scores:
             mark = " <- used" if s is best else ""
             print(f"    flipu={int(s['flipu'])} rollv={s['rollv']:>4d}  {s['score']:.4e}{mark}")
     extra = {
         "uv grid size": str(counts.shape[0]),
         "grid transform": f"flipu={int(best['flipu'])} rollv={best['rollv']}",
+        "grid transform score": f"{best['score']:.4e} ({best['metric']})",
         "density sum (pfb)": f"{counts.sum():.9g}",
     }
     return pfb_half, wsc_half, extra

--- a/scripts/compare_wsclean.py
+++ b/scripts/compare_wsclean.py
@@ -58,7 +58,10 @@ Multi-band imaging (``--nband``) adds the frequency axis:
    opposite ends -- pfb's short piece lands in the **last** band, wsclean's in the
    **first** -- so the bands cover different channels.  ``--nband`` therefore exits
    with the list of even splits unless ``--allow-uneven-bands`` is given, and the
-   band-alignment table quantifies the damage either way.
+   band-alignment table quantifies the damage either way.  That table compares
+   pfb's ``freq_nominal`` (the assignment grid) against wsclean's ``CRVAL3``, which
+   is the same quantity; pfb's ``freq_out`` is the *effective* weighted frequency
+   as of issue #296 and separates from both under flagging, by design.
 8. **Frequency weighting mode.**  pfb's band-resolved groupings (``per-band``, and
    ``per-band-time`` which ``concat_row`` collapses to it) pair with wsclean's
    default ``-no-mf-weighting``: one density grid per output band.  The
@@ -395,10 +398,13 @@ def _band_plan(a):
     the output band with the nearest centre, where the centres come from a
     ``linspace`` over the *frequency* span.  When ``nband`` divides ``nchan`` the
     two coincide exactly; when it does not, the slicing leaves a short final piece
-    and the frequency-uniform centres no longer sit at the channel-group centres,
-    so band *labels* drift even if the channel sets happen to match.  pfb also
-    derives its band count as ``ceil((fmax-fmin)/(width*cpi)) = ceil((nchan-1)/cpi)``,
-    which is checked rather than assumed.
+    that lands in pfb's **last** band while wsclean's remainder goes in its
+    **first**, so the two cover different *channel sets* -- which no amount of
+    relabelling fixes.  (pfb's reported band frequency is the effective weighted
+    one as of issue #296, so it no longer drifts with the split; the channel-set
+    difference is the real remaining hazard.)  pfb also derives its band count as
+    ``ceil((fmax-fmin)/(width*cpi)) = ceil((nchan-1)/cpi)``, which is checked
+    rather than assumed.
     """
     if a.nband == 1:
         return -1, None
@@ -411,9 +417,9 @@ def _band_plan(a):
         ok = [d for d in range(1, nchan + 1) if nchan % d == 0]
         msg = (
             f"{nchan} channels do not divide into {a.nband} bands: pfb slices "
-            f"{cpi}-channel pieces (the last one short) while its band centres stay "
-            f"uniform in frequency, so band labels and possibly channel sets differ "
-            f"from wsclean's equal-count split. Even splits: {ok}."
+            f"{cpi}-channel pieces and puts the short remainder in its LAST band, "
+            f"while wsclean's equal-count split puts it in the FIRST, so the bands "
+            f"cover different channel sets. Even splits: {ok}."
         )
         if not a.allow_uneven_bands:
             sys.exit(f"{msg} Pass --allow-uneven-bands to compare anyway.")
@@ -628,31 +634,50 @@ def product_list(a, pfb_pre, wsc_pre):
 def band_report(a, pfb_pre, wsc_pre):
     """Per-band centre frequency and wsum -- the channel-slicing test.
 
-    Frequencies come from pfb's ``.dt`` band-node ``freq_out`` attrs (its
-    ``band_edges`` centres) against each wsclean per-band image's ``CRVAL3``;
-    wsums from the pfb cube's ``WSUM<n>`` cards against wsclean's ``WSCNORMF``.
-    Both agreeing is what says the two imagers put the same channels in the same
-    band -- a frequency match with a wsum mismatch would mean equal band centres
-    over unequal channel sets.
+    The pass/fail comparison is pfb's ``freq_nominal`` -- the band-edge midpoint
+    that decides which channels belong to the band -- against each wsclean per-band
+    image's ``CRVAL3``, which is the same quantity: on an even split they agree to
+    0 Hz.  pfb's ``freq_out`` is the *effective* frequency, the weighted mean over
+    the channels that survive flagging (issue #296, wiki D28); it is reported
+    alongside but deliberately not compared, because wsclean does not weight its
+    label the same way and any flagging separates the two legitimately.  Comparing
+    it here would report MISMATCH on data that is perfectly fine.
+
+    wsums come from the pfb cube's ``WSUM<n>`` cards against wsclean's
+    ``WSCNORMF``.  Frequency and wsum agreeing *together* is what says the two
+    imagers put the same channels in the same band -- a frequency match with a
+    wsum mismatch would mean equal band centres over unequal channel sets.
+
+    Nodes are ordered by ``bandid``, matching the plane order ``dt2fits`` writes
+    the cube (and hence the ``WSUM<n>`` cards) in.  Sorting by ``freq_out`` would
+    be wrong now that it is data-dependent: asymmetric flagging can invert two
+    bands, pairing the wrong wsum card and wsclean file with a node.
     """
     import xarray as xr  # deferred: heavy import, only needed for the band check
 
     dt = xr.open_datatree(f"{os.path.abspath(pfb_pre)}_{a.product.upper()}.dt", engine="zarr", chunks=None)
     nodes = [dt[n].ds for n in dt.children if n.startswith("band")]
-    nodes = sorted((ds for ds in nodes if int(ds.attrs["timeid"]) == a.timeid), key=lambda d: d.attrs["freq_out"])
+    nodes = sorted((ds for ds in nodes if int(ds.attrs["timeid"]) == a.timeid), key=lambda d: int(d.attrs["bandid"]))
     cube_hdr = fits.getheader(pfb_fits(pfb_pre, a.product, "DIRTY", a.timeid, mfs=False))
 
     print(f"\n=== band alignment ({a.nband} bands, {band_plan(a)[0]} channels each) ===")
-    print(f"  {'band':>4s} {'pfb freq (Hz)':>18s} {'wsclean freq (Hz)':>18s} {'df (Hz)':>10s} {'wsum ratio':>13s}")
+    print(
+        f"  {'band':>4s} {'pfb nominal (Hz)':>18s} {'wsclean freq (Hz)':>18s} {'df (Hz)':>10s}"
+        f" {'pfb effective (Hz)':>20s} {'wsum ratio':>13s}"
+    )
     for b, ds in enumerate(nodes):
-        fp = float(ds.attrs["freq_out"])
+        # .get: a .dt written before #296 has no freq_nominal, and --run none is
+        # routinely pointed at products already on disk
+        fp = float(ds.attrs.get("freq_nominal", ds.attrs["freq_out"]))
+        feff = float(ds.attrs["freq_out"])
         whdr = fits.getheader(f"{wsc_pre}-{b:04d}-dirty.fits")
         fw = float(whdr["CRVAL3"])
         ratio = float(cube_hdr[f"WSUM{b + 1}"]) / float(whdr["WSCNORMF"])
         # an even split must agree exactly, so the tolerance is tight: a drifting
-        # band centre means the labels disagree, a drifting wsum means the data does
+        # band centre means the channel sets disagree, a drifting wsum means the
+        # data does. freq_out is informational -- flagging moves it by design.
         flag = "   <- MISMATCH" if abs(fp - fw) > 1.0 or abs(ratio - 1) > 1e-3 else ""
-        print(f"  {b:>4d} {fp:>18.3f} {fw:>18.3f} {fp - fw:>+10.3g} {ratio:>13.9f}{flag}")
+        print(f"  {b:>4d} {fp:>18.3f} {fw:>18.3f} {fp - fw:>+10.3g} {feff:>20.3f} {ratio:>13.9f}{flag}")
 
 
 def wcs_offset(ha, hb):

--- a/scripts/max_gamma.py
+++ b/scripts/max_gamma.py
@@ -451,7 +451,9 @@ def main():
             nx,
             ny,
             meta["radec"],
-            float(np.mean(meta["freq_out"])),
+            # wsum-weighted, matching dt2fits' freq_mfs: bands carry unequal
+            # weight, and freq_out is itself an effective frequency (wiki D28)
+            float(np.sum(meta["freq_out"] * wsums) / wsum_tot),
             casambm=False,
             l0=meta["l0"],
             m0=meta["m0"],

--- a/src/pfb_imaging/core/imager.py
+++ b/src/pfb_imaging/core/imager.py
@@ -93,6 +93,67 @@ def _partition_fits(fits_dir, out_name, pid, field_name, prod, meta, freq_out, c
         save_fits(prod["BEAM"], stem.format(var="beam"), hdr, yx_order=True)
 
 
+def _concat_pieces(plist):
+    """Reduce a partition's scratch pieces to a single Dataset.
+
+    Rows are concatenated; BEAM and the effective frequency are combined as
+    ``wsum_nat``-weighted means. Pieces of a partition can differ in both --
+    BeamWizard evaluates the beam at the piece's own timestamps, and post-#296
+    at its own effective frequency -- so taking piece 0's beam, as this used
+    to, silently discarded every other piece (wiki D28).
+
+    The weights are the *natural* wsum because this runs before gridding, where
+    the robust imaging weights do not yet exist. Getting them would mean
+    passing row offsets into grid_partition and holding every piece's BEAM
+    resident through gridding instead of freeing it at the caller's ``del
+    plist`` -- ~67 MB per piece at 4096 squared float32 -- against the memory
+    discipline in docs/wiki/memory-and-ray.md, for a correction to a beam that
+    varies slowly with frequency. The band-level reduction in _grid_image does
+    use the imaging weights; see wiki D28 for why the mixed basis is correct.
+
+    Args:
+        plist: scratch-piece Datasets of one partition, all sharing a FREQ axis.
+
+    Returns:
+        The merged partition Dataset, carrying the weighted ``freq_out`` and
+        the summed ``wsum_nat`` in its attrs. A single-piece list is returned
+        unchanged.
+    """
+    if len(plist) == 1:
+        return plist[0]
+
+    # rows are only concatenatable when they share the freq axis (same
+    # spw + band channel-chunk); guard the invariant before concat
+    f0 = plist[0].FREQ.values
+    for p in plist[1:]:
+        assert np.array_equal(p.FREQ.values, f0), "concat group has mismatched FREQ; cannot concatenate rows"
+
+    w = np.array([float(p.attrs["wsum_nat"]) for p in plist], dtype=np.float64)
+    wsum_nat = float(w.sum())
+    if wsum_nat > 0:
+        freqs = np.array([float(p.attrs["freq_out"]) for p in plist], dtype=np.float64)
+        freq_out = float((w * freqs).sum() / wsum_nat)
+        # accumulate rather than stack: one buffer, not npiece of them
+        beam = np.zeros(plist[0].BEAM.shape, dtype=np.float64)
+        for wi, p in zip(w, plist):
+            beam += wi * p.BEAM.values
+        beam /= wsum_nat
+    else:
+        freq_out = float(plist[0].attrs["freq_out"])
+        beam = plist[0].BEAM.values
+
+    rowvars = ["VIS", "WEIGHT", "MASK", "UVW"]
+    cat = xr.concat([p[rowvars] for p in plist], dim="row", coords="minimal", compat="override")
+    part = plist[0].drop_vars(rowvars)
+    for v in rowvars:
+        part[v] = cat[v]
+    del cat
+    part["BEAM"] = (part.BEAM.dims, beam.astype(part.BEAM.dtype))
+    part.attrs["freq_out"] = freq_out
+    part.attrs["wsum_nat"] = wsum_nat
+    return part
+
+
 @ray.remote
 def _grid_image(
     scratch_store,
@@ -161,23 +222,7 @@ def _grid_image(
 
     for pid, key in enumerate(list(sorted(groups))):
         plist = groups.pop(key)
-        # concat scans of the same partition along row (beam/freq identical across scans)
-        if len(plist) == 1:
-            part = plist[0]
-        else:
-            # rows are only concatenatable when they share the freq axis (same
-            # spw + band channel-chunk); guard the invariant before concat
-            f0 = plist[0].FREQ.values
-            for p in plist[1:]:
-                assert np.array_equal(p.FREQ.values, f0), (
-                    f"concat group {key} has mismatched FREQ; cannot concatenate rows"
-                )
-            rowvars = ["VIS", "WEIGHT", "MASK", "UVW"]
-            cat = xr.concat([p[rowvars] for p in plist], dim="row", coords="minimal", compat="override")
-            part = plist[0].drop_vars(rowvars)
-            for v in rowvars:
-                part[v] = cat[v]
-            del cat
+        part = _concat_pieces(plist)
         # release the pre-concat originals before gridding (concat copied them)
         del plist
 

--- a/src/pfb_imaging/core/imager.py
+++ b/src/pfb_imaging/core/imager.py
@@ -628,7 +628,10 @@ def imager(
     log.info(f"Number of output bands determined to be {nband} based on channel width and freq range")
     band_edges = np.linspace(all_freqs.min() - min_chan_width / 2, all_freqs.max() + min_chan_width / 2, nband + 1)
     half_band_width = (band_edges[1] - band_edges[0]) / 2
-    freq_out = band_edges[0:-1] + half_band_width
+    # Band-edge midpoints. These define which channels belong to which band and
+    # nothing else -- the band's reported frequency is the effective (weighted)
+    # one reduced in pass 2 (issue #296, wiki D28).
+    band_centres = band_edges[0:-1] + half_band_width
 
     # shared imaging geometry (also fixes the padded uv-grid used for COUNTS)
     max_freq = float(all_freqs.max())
@@ -688,7 +691,7 @@ def imager(
                 # flow/fhigh index the freq-range-trimmed axis; isel below acts
                 # on the unsliced node, so shift by the selection offset chan0
                 nu_index = slice(chan0 + flow, chan0 + fhigh)
-                bandid = int(np.argmin(np.abs(freq_out - freqs_node[flow:fhigh].mean())))
+                bandid = int(np.argmin(np.abs(band_centres - freqs_node[flow:fhigh].mean())))
 
                 # slice out subset of node
                 subdt = node.isel(time=t_index, frequency=nu_index)
@@ -709,7 +712,7 @@ def imager(
                     bandid=bandid,
                     timeid=timeid,
                     msid=ims,
-                    freq_out=freq_out[bandid],
+                    freq_nominal=band_centres[bandid],
                     precision=precision,
                     sigma_column=sigma_column,
                     weight_column=weight_column,
@@ -920,7 +923,7 @@ def imager(
             nx_psf,
             ny_psf,
             cell_rad,
-            freq_out[meta["bandid"]],
+            band_centres[meta["bandid"]],
             meta,
             robustness=robustness,
             nx_pad=nx_pad,

--- a/src/pfb_imaging/core/imager.py
+++ b/src/pfb_imaging/core/imager.py
@@ -166,7 +166,7 @@ def _grid_image(
     nx_psf,
     ny_psf,
     cell_rad,
-    freq_out,
+    freq_nominal,
     meta,
     robustness=None,
     nx_pad=None,
@@ -219,6 +219,9 @@ def _grid_image(
     beam_sum = np.zeros((ncorr, ny, nx), dtype=real_type)
     bdirty_sum = np.zeros((ncorr, ny, nx), dtype=real_type)
     wsum_sum = np.zeros(ncorr, dtype=real_type)
+    # float64 regardless of --precision: the tree may be single-precision
+    # (wiki D27) and float32 resolves 1e9 Hz only to ~64 Hz
+    freq_sum = np.zeros(ncorr, dtype=np.float64)
 
     for pid, key in enumerate(list(sorted(groups))):
         plist = groups.pop(key)
@@ -268,6 +271,7 @@ def _grid_image(
                 "field_name": key[1],
                 "spw_name": key[2],
                 "baseline_group": key[3],
+                "freq_out": float(part.attrs["freq_out"]),
                 "ra": meta["ra"],
                 "dec": meta["dec"],
                 "ra0": float(part.attrs.get("ra0", meta["ra"])),
@@ -291,7 +295,7 @@ def _grid_image(
                 key[1],
                 prod,
                 meta,
-                freq_out,
+                float(part.attrs["freq_out"]),
                 cell_rad,
                 do_psf=do_psf,
                 do_beam=part_fits_beam,
@@ -306,11 +310,24 @@ def _grid_image(
         if do_psf:
             psf_sum += prod["PSF"]
         wsum_sum += prod["WSUM"]
+        freq_sum += prod["WSUM"].astype(np.float64) * float(part.attrs["freq_out"])
 
+    # Level-2 reduction: the band product is the wsum-weighted sum of its
+    # partitions, so its effective frequency is the wsum-weighted mean of the
+    # partition frequencies -- the identical reduction beam_sum uses below.
+    # That is why these weights must be the imaging prod["WSUM"] and not the
+    # natural wsum_nat used inside _concat_pieces: they are what actually
+    # determines each partition's contribution to the summed image, and BEAM
+    # and freq_out must not be weighted by different quantities at the same
+    # level (wiki D28). Reduced with corr-summed weights and stored scalar, as
+    # dt2fits already does for freq_mfs.
+    wsum_tot = float(wsum_sum.astype(np.float64).sum())
+    freq_eff = float(freq_sum.sum() / wsum_tot) if wsum_tot > 0 else float(freq_nominal)
     band_attrs = {
         "bandid": meta["bandid"],
         "timeid": meta["timeid"],
-        "freq_out": float(freq_out),
+        "freq_out": freq_eff,
+        "freq_nominal": float(freq_nominal),
         "time_out": meta["time_out"],
         "ra": meta["ra"],
         "dec": meta["dec"],

--- a/src/pfb_imaging/operators/gridder.py
+++ b/src/pfb_imaging/operators/gridder.py
@@ -329,10 +329,10 @@ def grid_partition(
 
     # the piece BEAM is already on the output image grid, placed there in
     # pass 1 (stokes_vis, #281): (corr, ny, nx), tangent point + target offset
-    # included. Pieces of a partition share the field (and the rotation-
-    # averaged beam is time-independent), so the first piece's beam stands in
-    # for the partition; replace with a weighted mean when time-dependent
-    # beams arrive.
+    # included. A partition's pieces are reduced to one BEAM upstream in
+    # core.imager._concat_pieces (wsum_nat-weighted mean, wiki D28); here it is
+    # pure pass-through -- cast to the vis dtype and returned, never used in
+    # the gridding itself.
     # ducc templates every real-valued array on the vis dtype: complex64 vis
     # require float32 wgt/dirty buffers (mixing trips an "incorrect data type"
     # assertion), so image buffers follow the precision of the stored data

--- a/src/pfb_imaging/utils/fits.py
+++ b/src/pfb_imaging/utils/fits.py
@@ -468,8 +468,8 @@ def dt2fits(
 
     timeids = np.unique([int(ds.attrs["timeid"]) for ds in nodes])
     for timeid in timeids:
-        # bands for this time chunk, ordered by frequency
-        # order by bandid, not freq_out: effective frequencies are data-dependent
+        # bands for this time chunk, ordered by bandid, not freq_out: effective
+        # frequencies are data-dependent
         # (issue #296) and severe asymmetric flagging could invert two bands,
         # silently reordering cube planes. bandid is monotonic in frequency by
         # construction (the band_edges grid in core.imager).

--- a/src/pfb_imaging/utils/fits.py
+++ b/src/pfb_imaging/utils/fits.py
@@ -469,7 +469,11 @@ def dt2fits(
     timeids = np.unique([int(ds.attrs["timeid"]) for ds in nodes])
     for timeid in timeids:
         # bands for this time chunk, ordered by frequency
-        dst = sorted((ds for ds in nodes if int(ds.attrs["timeid"]) == timeid), key=lambda d: d.attrs["freq_out"])
+        # order by bandid, not freq_out: effective frequencies are data-dependent
+        # (issue #296) and severe asymmetric flagging could invert two bands,
+        # silently reordering cube planes. bandid is monotonic in frequency by
+        # construction (the band_edges grid in core.imager).
+        dst = sorted((ds for ds in nodes if int(ds.attrs["timeid"]) == timeid), key=lambda d: int(d.attrs["bandid"]))
         ref = dst[0]
         nband = len(dst)
         freqs = np.array([ds.attrs["freq_out"] for ds in dst])

--- a/src/pfb_imaging/utils/stokes2vis_msv4.py
+++ b/src/pfb_imaging/utils/stokes2vis_msv4.py
@@ -83,7 +83,7 @@ def stokes_vis(
     bandid=None,
     timeid=None,
     msid=None,
-    freq_out=None,
+    freq_nominal=None,
     precision="double",
     sigma_column=None,
     weight_column=None,
@@ -118,7 +118,10 @@ def stokes_vis(
         nx_pad, ny_pad, cell_rad: padded uv-grid size and image cell (rad) for the per-piece
             COUNTS grid used to build imaging weights in pass 2.
         baseline_group: partition baseline-group label (single ``"all"`` group for now).
-        freq_out: output frequency for selected data.
+        freq_nominal: nominal band centre (band-edge midpoint) used by the driver to
+            assign channel slices to bands. The piece reports its own effective
+            frequency as freq_out; freq_nominal is the fallback when no weight
+            survives (issue #296, wiki D28).
         precision: "single" or "double" for output data and weights.
         sigma_column: name of column containing sigma values to convert to weights.
         weight_column: name of column containing weights to use instead of sigma.
@@ -437,6 +440,22 @@ def stokes_vis(
     flag = flag.any(axis=-1)
     mask = (~flag).astype(np.uint8)
 
+    # Effective frequency of this piece: the weight-weighted mean over the
+    # channels that survive flagging (issue #296, wiki D28). freq_nominal is
+    # only the band *assignment* grid and is wrong by up to half a channel
+    # whenever nband does not divide nchan. This value is what the beam is
+    # evaluated at below and what the piece reports as freq_out.
+    # These are natural weights because they are the only ones that exist here:
+    # robust imaging weights are not formed until pass 2. See wiki D28 for why
+    # that basis is deliberate rather than an oversight.
+    w_chan = (weight * mask[:, :, None]).sum(axis=(0, 2), dtype=np.float64)
+    wsum_nat = float(w_chan.sum())
+    if wsum_nat > 0:
+        freq_eff = float((w_chan * freq).sum() / wsum_nat)
+    else:
+        # rows survived the mrow filter above but carry zero weight
+        freq_eff = float(freq_nominal)
+
     # ---- primary beam on the output image grid (pass-1 beam, #281) ----
     # The (rotation-averaged) beam is evaluated about the FIELD's own pointing
     # -- where the antennas point regardless of rephasing -- on a small grid,
@@ -509,7 +528,7 @@ def stokes_vis(
                     l=l_beam,
                     m=m_beam,
                     times=t_beam,
-                    freq=np.atleast_1d(freq_out),
+                    freq=np.atleast_1d(freq_eff),
                     time_stepping=1,
                     pixel_stepping=1,
                     var="nstokes",
@@ -536,7 +555,7 @@ def stokes_vis(
             # katbeam evaluates pointwise, so beam0 takes the (m, l) shape
             mm, ll = np.meshgrid(m_beam, l_beam, indexing="ij")
             # katbeam expects freq in MHz
-            fmhz = freq_out / 1e6
+            fmhz = freq_eff / 1e6
             beam_small = np.zeros((ncorr, npix, npix), dtype=np.float64)
             for i, p in enumerate(corr):
                 beam0 = getattr(beamo, p)(ll, mm, fmhz)
@@ -633,7 +652,9 @@ def stokes_vis(
         "spw_name": spw_name,
         "baseline_group": baseline_group,
         "scan_name": scan_name,
-        "freq_out": freq_out,
+        "freq_out": freq_eff,
+        "freq_nominal": float(freq_nominal),
+        "wsum_nat": wsum_nat,
         "freq_min": freq_min,
         "freq_max": freq_max,
         "bandid": bandid,

--- a/tests/test_fits_tree.py
+++ b/tests/test_fits_tree.py
@@ -7,21 +7,29 @@ from astropy.io import fits as afits
 from pfb_imaging.utils.fits import dt2fits
 
 
-def _band_node(timeid, freq_out, val, wsum=10.0, nx=8):
+def _band_node(timeid, freq_out, val, wsum=10.0, nx=8, bandid=0):
     return xr.Dataset(
         {
             "DIRTY": (("corr", "y", "x"), np.full((1, nx, nx), float(val))),
             "WSUM": (("corr",), np.array([float(wsum)])),
         },
         coords={"corr": ["I"]},
-        attrs={"timeid": timeid, "freq_out": freq_out, "time_out": 5.0e9, "ra": 0.1, "dec": -0.2, "cell_rad": 1.0e-6},
+        attrs={
+            "timeid": timeid,
+            "bandid": bandid,
+            "freq_out": freq_out,
+            "time_out": 5.0e9,
+            "ra": 0.1,
+            "dec": -0.2,
+            "cell_rad": 1.0e-6,
+        },
     )
 
 
 def test_dt2fits_mfs(tmp_path):
     store = str(tmp_path / "out.dt")
-    _band_node(0, 1.0e9, 1.0).to_zarr(store, group="band0000_time0000", mode="w")
-    _band_node(0, 1.1e9, 3.0).to_zarr(store, group="band0001_time0000", mode="a")
+    _band_node(0, 1.0e9, 1.0, bandid=0).to_zarr(store, group="band0000_time0000", mode="w")
+    _band_node(0, 1.1e9, 3.0, bandid=1).to_zarr(store, group="band0001_time0000", mode="a")
 
     outname = str(tmp_path / "img")
     dt2fits(store, "DIRTY", outname, norm_wsum=True, do_mfs=True, do_cube=False)
@@ -35,9 +43,9 @@ def test_dt2fits_mfs(tmp_path):
 def test_dt2fits_cube_has_band_axis(tmp_path):
     # 3 bands: set_wcs's reference-channel index (nchan//2+1) needs nchan>2
     store = str(tmp_path / "out2.dt")
-    _band_node(0, 1.0e9, 1.0).to_zarr(store, group="band0000_time0000", mode="w")
-    _band_node(0, 1.1e9, 3.0).to_zarr(store, group="band0001_time0000", mode="a")
-    _band_node(0, 1.2e9, 5.0).to_zarr(store, group="band0002_time0000", mode="a")
+    _band_node(0, 1.0e9, 1.0, bandid=0).to_zarr(store, group="band0000_time0000", mode="w")
+    _band_node(0, 1.1e9, 3.0, bandid=1).to_zarr(store, group="band0001_time0000", mode="a")
+    _band_node(0, 1.2e9, 5.0, bandid=2).to_zarr(store, group="band0002_time0000", mode="a")
 
     outname = str(tmp_path / "img2")
     dt2fits(store, "DIRTY", outname, norm_wsum=True, do_mfs=False, do_cube=True)
@@ -53,6 +61,26 @@ def test_dt2fits_cube_has_band_axis(tmp_path):
 
 def test_dt2fits_no_column_is_noop(tmp_path):
     store = str(tmp_path / "out3.dt")
-    _band_node(0, 1.0e9, 1.0).to_zarr(store, group="band0000_time0000", mode="w")
+    _band_node(0, 1.0e9, 1.0, bandid=0).to_zarr(store, group="band0000_time0000", mode="w")
     # MODEL is not present on the band node -> returns column, writes nothing
     assert dt2fits(store, "MODEL", str(tmp_path / "img3"), do_mfs=True, do_cube=False) == "MODEL"
+
+
+def test_dt2fits_orders_planes_by_bandid(tmp_path):
+    """Effective frequencies are data-dependent and can invert under severe
+    asymmetric flagging; plane order must follow bandid, which is monotonic in
+    frequency by construction (issue #296).
+    """
+    store = str(tmp_path / "out.dt")
+    # band 0 deliberately labelled at a HIGHER frequency than band 1
+    _band_node(0, 1.4e9, 1.0, bandid=0).to_zarr(store, group="band0000_time0000", mode="w")
+    _band_node(0, 1.1e9, 3.0, bandid=1).to_zarr(store, group="band0001_time0000", mode="a")
+
+    outname = str(tmp_path / "img")
+    dt2fits(store, "DIRTY", outname, norm_wsum=True, do_mfs=False, do_cube=True)
+
+    data = np.squeeze(afits.getdata(outname + "_dirty_time0.fits"))
+    assert data.shape == (2, 8, 8)
+    # plane 0 is bandid 0 (value 1.0/10), not the lower-frequency bandid 1
+    np.testing.assert_allclose(data[0].flat[0], 0.1, rtol=1e-5)
+    np.testing.assert_allclose(data[1].flat[0], 0.3, rtol=1e-5)

--- a/tests/test_imager.py
+++ b/tests/test_imager.py
@@ -673,3 +673,51 @@ def test_stokes_vis_beam_follows_effective_freq(ms_name, tmp_path):
     # katbeam narrows with frequency, so the higher-frequency beam encloses
     # less total response over the same fov
     assert hi.BEAM.values.sum() < lo.BEAM.values.sum()
+
+
+def test_imager_effective_freq_uneven_bands(ms_name, tmp_path):
+    """8 channels binned 3/3/2: the band-edge centres miss the true channel
+    groups by 17-50 MHz. freq_out must track the channels actually gridded
+    (issue #296); freq_nominal preserves the assignment grid.
+    """
+    outname = str(tmp_path / "eff_freq")
+    imager_core(
+        [Path(ms_name)],
+        outname,
+        integrations_per_image=15,
+        channels_per_image=3,
+        product="I",
+        field_of_view=1.0,
+        robustness=0.0,
+        fits_mfs=False,
+        fits_cubes=False,
+        overwrite=True,
+        keep_ray_alive=True,
+    )
+
+    dt = xr.open_datatree(outname + "_I.dt", engine="zarr", chunks=None)
+    band_names = sorted(n for n in dt.children if n.startswith("band"))
+    bands = sorted((dt[n].ds for n in band_names), key=lambda d: d.attrs["bandid"])
+    assert len({b.attrs["bandid"] for b in bands}) == 3
+
+    nominal = [b.attrs["freq_nominal"] for b in bands]
+    effective = [b.attrs["freq_out"] for b in bands]
+
+    # band_edges = linspace(0.95, 1.75, 4) GHz -> midpoints
+    assert_allclose(sorted(set(nominal)), [1.0833333e9, 1.35e9, 1.6166667e9], rtol=1e-6)
+
+    # the actual channel groups are 1.0-1.2, 1.3-1.5 and 1.6-1.7 GHz
+    for eff, nom in zip(effective, nominal):
+        lo, hi = {0: (1.0e9, 1.2e9), 1: (1.3e9, 1.5e9), 2: (1.6e9, 1.7e9)}[
+            int(np.argmin(np.abs(np.array([1.0833333e9, 1.35e9, 1.6166667e9]) - nom)))
+        ]
+        assert lo <= eff <= hi, f"effective freq {eff} outside its channel group"
+        assert abs(eff - nom) > 1.0e7
+
+    # each partition carries its own effective frequency, and the band value is
+    # the wsum-weighted mean over them
+    for name in band_names:
+        parts = [dt[name][p].ds for p in dt[name].children]
+        w = np.array([np.asarray(p.attrs["wsum"]).sum() for p in parts])
+        f = np.array([p.attrs["freq_out"] for p in parts])
+        assert_allclose(dt[name].ds.attrs["freq_out"], (w * f).sum() / w.sum(), rtol=1e-10)

--- a/tests/test_imager.py
+++ b/tests/test_imager.py
@@ -335,13 +335,28 @@ def _open_first_vis_node(ms_name):
     raise RuntimeError("no visibility node in test MS")
 
 
-def _run_stokes_vis(ms_name, scratch, radec_new=None, beam_model=None, cell_rad=1e-5):
-    """Drive stokes_vis directly (no Ray) on the test MS's first node."""
+def _run_stokes_vis(ms_name, scratch, radec_new=None, beam_model=None, cell_rad=1e-5, flag_chans=None):
+    """Drive stokes_vis directly (no Ray) on the test MS's first node.
+
+    flag_chans: optional channel slice to flag before conversion, used to shift
+    the piece's effective frequency away from the nominal band centre (#296).
+    """
     from pfb_imaging.utils.stokes2vis_msv4 import stokes_vis
 
     node = _open_first_vis_node(ms_name)
     dc1 = node.ds.attrs["data_groups"]["base"]["correlated_data"]
     freq = node.ds.frequency.values
+    if flag_chans is not None:
+        # FLAG is (time, baseline_id, frequency, polarization). Assign through
+        # the .dataset setter on a copy: rebuilding the node with
+        # xr.DataTree(dataset=...) would drop antenna_xds and the other
+        # children stokes_vis reads.
+        ds_mod = node.to_dataset()
+        flg = ds_mod.FLAG.values.copy()
+        flg[:, :, flag_chans, :] = True
+        ds_mod["FLAG"] = (ds_mod.FLAG.dims, flg)
+        node = node.copy()
+        node.dataset = ds_mod
     uvw = node.ds.UVW.values.reshape(-1, 3)
     uvw = uvw[~np.isnan(uvw).all(axis=-1)]
     max_blength = np.sqrt(uvw[:, 0] ** 2 + uvw[:, 1] ** 2).max()
@@ -353,7 +368,7 @@ def _run_stokes_vis(ms_name, scratch, radec_new=None, beam_model=None, cell_rad=
         bandid=0,
         timeid=0,
         msid=0,
-        freq_out=float(freq.mean()),
+        freq_nominal=float(freq.mean()),
         product="I",
         beam_model=beam_model,
         max_blength=float(max_blength),
@@ -621,3 +636,40 @@ def test_imager_fits_per_partition(sky_truth, ms_name, tmp_path):
     bhit = sorted(glob.glob(str(pdir / "beam_band*_part0000_*.fits")))[0]
     with afits.open(bhit) as hdul:
         assert hdul[0].header["BEAMINCN"]
+
+
+def test_stokes_vis_effective_freq_is_weighted(ms_name, tmp_path):
+    """freq_out is the weight-weighted mean over surviving channels, not the
+    nominal band centre handed in by the driver (issue #296)."""
+    ds = _run_stokes_vis(ms_name, str(tmp_path / "f0.scratch"), flag_chans=slice(4, 8))
+
+    # stored WEIGHT is the natural weight (robust weights arrive in pass 2)
+    w_chan = (ds.WEIGHT.values * ds.MASK.values[None]).sum(axis=(0, 1))
+    expected = (w_chan * ds.FREQ.values).sum() / w_chan.sum()
+    assert_allclose(ds.attrs["freq_out"], expected, rtol=1e-10)
+    assert_allclose(ds.attrs["wsum_nat"], w_chan.sum(), rtol=1e-10)
+
+    # nominal is the unweighted mean of all 8 channels (1.35 GHz); flagging the
+    # top half must pull the effective frequency well below it
+    assert_allclose(ds.attrs["freq_nominal"], 1.35e9, rtol=1e-6)
+    assert ds.attrs["freq_out"] < ds.attrs["freq_nominal"] - 5.0e7
+
+
+def test_stokes_vis_beam_follows_effective_freq(ms_name, tmp_path):
+    """The effective frequency must reach the beam evaluation, not just the
+    attrs. cell is enlarged for the same reason as
+    test_stokes_vis_beam_on_image_grid: at the default 1e-5 rad cell katbeam is
+    flat to ~1e-6 across the fov and any comparison is noise.
+    """
+    cell = 5.0e-4
+    lo = _run_stokes_vis(
+        ms_name, str(tmp_path / "lo.scratch"), beam_model="katbeam", cell_rad=cell, flag_chans=slice(4, 8)
+    )
+    hi = _run_stokes_vis(
+        ms_name, str(tmp_path / "hi.scratch"), beam_model="katbeam", cell_rad=cell, flag_chans=slice(0, 4)
+    )
+    assert lo.attrs["freq_out"] < hi.attrs["freq_out"]
+    assert not np.allclose(lo.BEAM.values, hi.BEAM.values, rtol=1e-3)
+    # katbeam narrows with frequency, so the higher-frequency beam encloses
+    # less total response over the same fov
+    assert hi.BEAM.values.sum() < lo.BEAM.values.sum()

--- a/tests/test_imager_pass2.py
+++ b/tests/test_imager_pass2.py
@@ -1,8 +1,10 @@
 """Pass-2 per-partition gridding (casacore-free, synthetic data)."""
 
 import numpy as np
+import pytest
 import xarray as xr
 
+from pfb_imaging.core.imager import _concat_pieces
 from pfb_imaging.operators.gridder import grid_partition, residual_from_partitions
 from pfb_imaging.utils.weighting import _compute_counts
 
@@ -196,3 +198,48 @@ def test_residual_gradient_beam_applied_twice():
     # bdirty=None keeps the legacy single-return signature
     r_only = residual_from_partitions(dirty, [p1, p2], model, 1.0e-6)
     np.testing.assert_allclose(r_only, r12, rtol=0, atol=0)
+
+
+def _synth_piece(freq_out, wsum_nat, beam_val, nrow=10, nx=4, ny=4, seed=0):
+    """A minimal scratch piece carrying only what _concat_pieces touches."""
+    rng = np.random.default_rng(seed)
+    return xr.Dataset(
+        {
+            "VIS": (("corr", "row", "chan"), rng.standard_normal((1, nrow, 1)) + 0j),
+            "WEIGHT": (("corr", "row", "chan"), np.ones((1, nrow, 1))),
+            "MASK": (("row", "chan"), np.ones((nrow, 1), dtype=np.uint8)),
+            "UVW": (("row", "three"), rng.standard_normal((nrow, 3))),
+            "FREQ": (("chan",), np.array([1.0e9])),
+            "BEAM": (("corr", "y", "x"), np.full((1, ny, nx), float(beam_val))),
+        },
+        coords={"corr": ["I"]},
+        attrs={"freq_out": float(freq_out), "wsum_nat": float(wsum_nat)},
+    )
+
+
+def test_concat_pieces_single_is_identity():
+    p = _synth_piece(1.0e9, 5.0, 0.5)
+    assert _concat_pieces([p]) is p
+
+
+def test_concat_pieces_weighted_beam_and_freq():
+    """Pieces of a partition may differ in beam and effective frequency; both
+    reduce as wsum_nat-weighted means. Taking piece 0's beam (the old
+    behaviour) silently discarded the rest -- issue #296, wiki D28.
+    """
+    a = _synth_piece(1.0e9, 3.0, 1.0, nrow=10, seed=1)
+    b = _synth_piece(1.4e9, 1.0, 5.0, nrow=6, seed=2)
+
+    out = _concat_pieces([a, b])
+
+    assert out.sizes["row"] == 16
+    np.testing.assert_allclose(out.attrs["freq_out"], (3.0 * 1.0e9 + 1.0 * 1.4e9) / 4.0)
+    np.testing.assert_allclose(out.attrs["wsum_nat"], 4.0)
+    np.testing.assert_allclose(out.BEAM.values, (3.0 * 1.0 + 1.0 * 5.0) / 4.0)
+
+
+def test_concat_pieces_rejects_mismatched_freq():
+    a = _synth_piece(1.0e9, 1.0, 1.0)
+    b = _synth_piece(1.0e9, 1.0, 1.0).assign(FREQ=(("chan",), np.array([2.0e9])))
+    with pytest.raises(AssertionError):
+        _concat_pieces([a, b])


### PR DESCRIPTION
Closes #296.

## What

`freq_out` is now the **weight-weighted effective frequency of the channels actually gridded**, reduced at three levels, instead of the band-edge midpoint from a `linspace` over the frequency span.

The band-edge grid was only ever correct when `nband` divided `nchan`, because channels are sliced *by count* and assigned to the nearest midpoint. It keeps its one remaining role — band assignment — renamed `band_centres` / `freq_nominal` so a single name no longer means two things.

## Why this is more than a labelling fix

`stokes_vis` evaluated the **primary beam** at the value passed in as `freq_out`. The beam was being *computed* at the wrong frequency, not merely reported at one. This is the likely explanation for beam-model discrepancies that have been hard to account for.

Flagging makes it worse than the uneven-split arithmetic suggests: a fully flagged channel shifts a band's centre of mass by a whole channel width, which a frequency-uniform grid cannot represent at all.

## The three reductions

| level | where | weights |
|---|---|---|
| piece | `stokes_vis` (pass 1) | natural — evaluates the beam *and* is stored |
| partition | `_concat_pieces` (pass 2) | natural `wsum_nat` |
| band | `_grid_image` (pass 2) | imaging `prod["WSUM"]` |

The mixed basis is deliberate and commented at every site. Level 3 must use the imaging weights because it is the identical reduction `beam_sum` already performs — `BEAM` and `freq_out` must not be weighted by different quantities at the same level. Level 2 runs before gridding where robust weights do not exist; obtaining them would mean holding every piece's `BEAM` resident through gridding (~67 MB per piece at 4096² f4), against `docs/wiki/memory-and-ray.md`, to correct a beam that varies slowly with frequency.

## Latent bug fixed along the way

`_grid_image` took `plist[0]`'s `BEAM` for the whole partition, discarding every other piece. `grid_partition` documented this as a stand-in on the premise that the rotation-averaged beam is time-independent — already false for `BeamWizard`, which is evaluated with the piece's own timestamps. The concat path is not exercised by current data (`timeid` is keyed on scan, so a `(band, time)` node holds one scan) but is deliberate future-proofing for MeerKAT+ baseline groups.

## Measured impact

On `tests/data/test_ascii_1h60.0s.MS` at `--channels-per-image 3` (8 channels of 100 MHz, binned 3/3/2):

| band | nominal | effective | delta |
|---|---|---|---|
| 0 | 1083.333 MHz | 1099.847 MHz | +16.5 MHz |
| 1 | 1350.000 MHz | 1449.868 MHz | +99.9 MHz |
| 2 | 1616.667 MHz | 1649.904 MHz | +33.2 MHz |

Bands 0 and 2 are the uneven-split error alone (1/6 and 1/3 of a channel — the same fractional pattern as the MeerKAT measurements in the issue). Band 1 is nearly a full channel because channel 3 is entirely flagged, so its centre of mass is 1.45 GHz.

**Band frequencies therefore change value** for uneven splits. This is the intended correction, but anyone comparing against a previously produced `.dt` or FITS will see it. No migration is needed: `.scratch` is rebuilt every run and the `.dt` only gains attrs — `deconv` keeps reading `freq_out`, same meaning, better value.

## Also

- Frequency accumulators are f8 regardless of `--precision` (f4 resolves 1e9 Hz only to ~64 Hz — cf. D27, where everything else follows the data dtype).
- `dt2fits` orders cube planes by `bandid` rather than `freq_out`, since data-dependent frequencies could otherwise invert and silently reorder planes.

## Tests

Six new, `540 passed` overall. The one worth reading is `test_stokes_vis_beam_follows_effective_freq`: it flags opposite halves of the band and asserts the stored `BEAM` actually differs, pinning the failure mode where the effective frequency reaches the attrs but never the beam call — every other test would still pass in that case.

## Out of scope (follow-up)

FITS cubes keep a linear `CRVAL3`/`CDELT3` and so cannot represent a non-uniform frequency axis. Per-plane `FREQ%04d` cards, and a `--fits-split-bands` option for WSClean-style per-band files, are tracked in #302 — the latter justified by ecosystem interop rather than by #296.

Rationale and the load-bearing constraints are recorded as **wiki D28**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Script follow-ups (`scripts/`)

Validated against real data: `max_gamma.py` on `subset_withbeam_I.dt` (3 bands, an
*old-format* tree — also a backward-compatibility check) and `compare_wsclean.py` on
`sgra_scan42_700to800MHz.ms`, both the documented single-band comparison and a fresh
4-band run (188 channels ÷ 4 = 47, an even split).

**`compare_wsclean.py` band alignment** compared pfb's `freq_out` against wsclean's `CRVAL3`
at a 1 Hz tolerance. Since `freq_out` is now the flag-weighted effective frequency while
`CRVAL3` is the band centre, that check fired on correct data. It now compares
`freq_nominal` — the like-for-like quantity — and reports `freq_out` separately:

```
band   pfb nominal (Hz)  wsclean freq (Hz)   df   pfb effective (Hz)
   0      712605468.750      712605468.750    +0      712702154.596
   1      737574218.750      737574218.750    +0      737679385.034
   2      762542968.750      762542968.750    +0      762653777.873
   3      787511718.750      787511718.750    +0      787025322.888
```

0 Hz on the even split, as expected, with the effective frequencies 97–111 kHz above
nominal for bands 0–2 and 486 kHz below for band 3 (heavier flagging at the band top).
Per-band and MFS images agree with wsclean at ~1e-6. Band nodes are also now sorted by
`bandid` rather than `freq_out`, matching `dt2fits`.

**`max_gamma.py`** wsum-weights the eigenvector FITS frequency instead of taking a plain
mean over bands (650.184 → 653.287 MHz on the test tree; band wsums span ~33%).

**One pre-existing bug fixed, unrelated to #296.** Under natural weighting every sampled uv
cell is exactly 1.0, so `mad_rms` of the reference is 0, every grid-transform candidate
scored `inf`, and the sort silently selected candidate 0 — the wrong transform, which made
the natural-weighted weight-grid comparison meaningless including its cell-support report.
Scoring now falls back to support disagreement when the values carry no information. On the
4-band run this moves the selection from `flipu=0` (0.878) to `flipu=1` (exactly 0), and the
weight grids from `max|d|/pk = 1.0`, `scale 0.19–0.22` to `max|d| = 0`, `scale 1.0`, with
19125 cells shared and none on either side alone.

