### PR TITLE
restore: interface with the DataTree, three flux scales, reinstate fFcC

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -75,9 +75,11 @@ One MSv4 front-end produces the intermediary products consumed by deconvolution:
 `pfb hci` is the separate high-cadence-imaging front-end. The legacy MSv2 subcommands
 (`init`, `grid`, `kclean`, `sara`, `fluxtractor`) were retired in 0.1.0 (#277); their
 correctness coverage lives in the ground-truth imager tests (`tests/test_imager*.py`,
-`tests/test_deconv.py`). `pfb restore` remains registered as **untested reference code**
-only — its `.dds` inputs can no longer be produced in-repo; its functionality moves into
-`deconv` eventually. `pfb model2comps` was **removed** (#286): its portable WSClean-FITS →
+`tests/test_deconv.py`). `pfb restore` was ported to the `.dt` in #303 and is tested
+(`tests/test_restore.py`, including an end-to-end `imager → deconv → restore` ground
+truth); it emits three explicitly-scaled restored products — apparent, intrinsic and
+mixed (wiki D29) — and no longer uses Ray. Its functionality may still fold into `deconv`
+eventually. `pfb model2comps` was **removed** (#286): its portable WSClean-FITS →
 `.mds` path migrated to `pfbspec model2comps` in
 [pfb-model-spec](https://github.com/landmanbester/pfb-model-spec), and its `.dds`-input path
 (daskms-coupled, no longer producible in-repo) was dropped. The component-model spec library
@@ -135,7 +137,9 @@ falls back to `DIRTY` when it is absent.
 **Image-space arrays are (Y, X)-ordered end to end** — `.dt` dims `("corr", "y", "x")` etc.,
 scratch beam `("corr", "m_beam", "l_beam")`; ducc's x-major world exists only behind zero-copy
 `.T` views at the wgridder call sites (wiki design-decisions D19/D20).
-`MODEL`/`RESIDUAL`/`NOISE` are added later by the `deconv` consumer.
+`MODEL`/`RESIDUAL`/`NOISE` are added later by the `deconv` consumer, and
+`IMAGE`/`BIMAGE`/`KIMAGE` plus `PSFPARSF` by the `restore` consumer (the intrinsic,
+apparent and mixed flux scales — wiki D29).
 
 **Access layer — native DataTree only.** Use `xr.open_datatree(store)`,
 `ds.to_zarr(store, group="band…/part…", mode="a")`, and `dt.children` directly. Do **not** add

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The processing pipeline follows a modular pattern where each step is a separate 
 Additional commands:
 
 - `pfb hci` -- High cadence imaging
-- `pfb restore` -- Restore clean components (reference code; being folded into `deconv`)
+- `pfb restore` -- Restore clean components onto residuals (apparent, intrinsic and mixed products)
 
 The legacy MSv2 pipeline (`init`, `grid`, `kclean`, `sara`, `fluxtractor`) was removed
 in 0.1.0 in favour of `imager`+`deconv`. The `model2comps` converter moved to

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-04T00:00:00Z
-last_verified_commit: 5111b13
+timestamp: 2026-08-06T00:00:00Z
+last_verified_commit: 5a30f2a
 ---
 
 # Design decisions, known debt and recurring gotchas
@@ -804,6 +804,58 @@ update it (and this page's `last_verified_commit`) in the same session.
   5111b13; `tests/test_imager.py::test_stokes_vis_beam_follows_effective_freq`,
   `::test_imager_effective_freq_uneven_bands`,
   `tests/test_imager_pass2.py::test_concat_pieces_weighted_beam_and_freq`.
+
+### D29 — Restore names its flux scale; the MFS clean beam is fitted to the MFS PSF
+
+- **Context:** `restore` was the last `.dds` consumer (#303). Porting it to the `.dt`
+  exposed two latent errors. First, the band `MODEL` is intrinsic flux (the forward solve
+  fits `V ≈ G(B·m)`, D22/D23) while the band `RESIDUAL` is apparent, once-attenuated flux
+  (`operators/gridder.residual_from_partitions`); legacy `restore_image` added them
+  directly, which is only correct where `B ≈ 1`. Second, with one PSF per data partition
+  the restoring beam was undefined, and the MFS beam was taken as the *mean of the
+  per-band fitted Gaussians* — a value with no referent when bands are not homogenised.
+- **Decision:** Restore emits three separately-named products, selected by CLI letter and
+  stored as distinct band variables: `BIMAGE` (`a`/`A`) `= (B̄·m) ⊗ G + r/wsum`, apparent
+  throughout; `IMAGE` (`i`/`I`) `= m ⊗ G + r/(wsum·B̄)`, intrinsic throughout and zeroed
+  below `--pb-min`; and `KIMAGE` (`k`/`K`) `= m ⊗ G + r/wsum`, the legacy mixed product,
+  kept for visualisation and left as the default. The restoring beam is `PSFPARSN` per
+  band — already the fit to the wsum-weighted average of the band's partition PSFs — and
+  `fitcleanbeam(Σ_b PSF_b / Σ_b WSUM_b)` for the MFS.
+- **Rationale:** `Σ_p dirty_p / Σ_p wsum_p` has effective response exactly `B̄`, the stored
+  band `BEAM`, so `BIMAGE / B̄ = IMAGE` is an identity rather than an approximation and
+  neither product misstates its scale. For the MFS beam, `r_mfs` *is* the wsum-weighted
+  sum of the band residuals, whose effective PSF is the wsum-weighted sum of the band
+  PSFs; fitting that sum makes the FITS `BMAJ`/`BMIN` exact with no cross-band
+  homogenisation. Averaging band beams is wrong because it is a mean of fits to
+  *different* PSFs, a quantity nothing in the image is shaped like — and it is
+  **weight-blind**: a band contributing 1% of the weight moves it as much as a band
+  contributing 99%. Measured on two circular PSFs at 6 and 18 px FWHM with weights 100
+  and 1, `clean_beam` returns ≈6.07 (the heavily-weighted band dominates the summed PSF,
+  correctly) while the mean of the per-band fits returns 12.
+  **Do not "demonstrate" this with equally weighted Gaussians.** For those the two agree
+  closely (6/18 equally weighted gives 12.33 vs 12.0), because `fitcleanbeam` is an L2 fit
+  over an `nsigma=10` window, area-dominated at large radius — *not* a half-power width.
+  The half-power width of that sum is ≈9.4, which is what makes the naive argument look
+  compelling and why it was wrong in the original spec. The divergence that matters comes
+  from weighting and from real PSFs with sidelobes.
+- **Consequences:** The MFS restored image is **not** the weighted sum of the per-band
+  restored images (different resolutions), so `dt2fits` cannot produce it and the driver
+  computes it directly — the one place restore does not reuse `dt2fits`. `--drop-bands`
+  must filter the `G_mfs` PSF sum, not merely the image sum, or a dropped band still sets
+  the restoring beam; the same applies to fully flagged bands, which are skipped
+  altogether because `RESIDUAL / WSUM` on a zero wsum puts inf/NaN into the stored products
+  *and* into the MFS accumulators. `--outputs i`/`I` changes meaning: same letter,
+  intrinsic product; the default moved to `kK` so a default run is unchanged. Restore no
+  longer uses Ray (the work is FFT-bound and the driver holds the cubes for the MFS
+  anyway), so `--nworkers` and `--ray-address` are gone. `convolve2gaussres` gained
+  `yx_order` because `gaussian2d`'s position angle is not transpose-invariant and the `.dt`
+  is `(corr, y, x)` (D19/D20). Dropped bands are omitted from cubes rather than zeroed,
+  which can leave a non-uniform FITS frequency axis — restore warns and defers to #302.
+- **Source:** issue #303; `src/pfb_imaging/core/restore.py`;
+  `src/pfb_imaging/utils/restoration.py`; `src/pfb_imaging/utils/misc.py`
+  (`convolve2gaussres`); `src/pfb_imaging/utils/fits.py` (`dt2fits` `drop_bands`,
+  `psfpars_var`); commits 84dd88b, 8501dee, 4b41d26, a4a6b08, 7b66502, d0bdd6b;
+  `tests/test_restore.py`, `tests/test_convolve2gaussres.py`, `tests/test_fits_tree.py`.
 
 ## Known debt
 

--- a/docs/wiki/imager-pipeline.md
+++ b/docs/wiki/imager-pipeline.md
@@ -3,8 +3,8 @@ type: Subsystem Notes
 title: MSv4 DataTree imager pipeline
 description: Why the imager writes a DataTree, the two-pass data flow, the .dt layout, counts/weight-grouping and concat_row semantics, and the operator split that downstream deconvolution relies on.
 tags: [imager, msv4, datatree, weighting, gridding, mosaic]
-timestamp: 2026-08-04T00:00:00Z
-last_verified_commit: 5111b13
+timestamp: 2026-08-06T00:00:00Z
+last_verified_commit: 5a30f2a
 ---
 
 # MSv4 DataTree imager pipeline
@@ -57,6 +57,9 @@ no-op later: just another `part{p}` child with its own `BEAM`.
               # BDIRTY = sum_p B_p * dirty_p: model-free term of the exact deconv
               # gradient (D23) -- not derivable from the summed DIRTY
               # MODEL / RESIDUAL / BRESIDUAL / NOISE added later by the deconv consumer
+              # IMAGE / BIMAGE / KIMAGE (corr, y, x) + PSFPARSF (corr, bpar) and a
+              # psfparsf_mfs attr added by the restore consumer -- the three flux
+              # scales (intrinsic / apparent / mixed) of D29
       part{p:04d}/                    # ONE DATA PARTITION
           attrs:  msid, field_name, spw_name, baseline_group, freq_out,
                   ra, dec, l0, m0, wsum

--- a/src/pfb_imaging/cabs/restore.yml
+++ b/src/pfb_imaging/cabs/restore.yml
@@ -17,13 +17,13 @@ cabs:
           rich_help_panel: Naming
       model-name:
         info:
-          Name of model in dds
+          Name of the model variable in the band nodes of the dt
         default: MODEL
         metadata:
           rich_help_panel: Input
       residual-name:
         info:
-          Name of residual in dds
+          Name of the residual variable in the band nodes of the dt
         default: RESIDUAL
         metadata:
           rich_help_panel: Input
@@ -37,9 +37,12 @@ cabs:
           rich_help_panel: Naming
       outputs:
         info:
-          Output products (m)odel, (r)esidual, (i)mage, (c)lean beam, (d)irty, (f)ft_residuals.
+          Output products.
+          (d)irty, (m)odel, (r)esidual, (k) restored with intrinsic model and apparent residual.
+          (a) restored fully apparent, (i) restored fully intrinsic (primary beam corrected).
+          (c)lean beam image, (f)ft of the residual.
           Use capitals to produce corresponding cubes.
-        default: iI
+        default: kK
         metadata:
           rich_help_panel: Output
       gausspar:
@@ -58,21 +61,14 @@ cabs:
         dtype: Optional[List[int]]
         metadata:
           rich_help_panel: Data Selection
-      ray-address:
+      pb-min:
         info:
-          Address of the ray cluster to connect to.
-          If not provided, will run locally.
-        default: local
+          Primary beam cutoff for the intrinsic restored image.
+          Pixels where the beam falls below this value are set to zero.
+        dtype: float
+        default: 0.1
         metadata:
-          rich_help_panel: Performance
-      nworkers:
-        info:
-          Number of worker processes.
-          Use with distributed scheduler.
-        dtype: int
-        default: 1
-        metadata:
-          rich_help_panel: Performance
+          rich_help_panel: Restoration
       nthreads:
         info:
           Number of threads used to scale vertically (for FFTs and gridding).
@@ -91,10 +87,10 @@ cabs:
     outputs:
       mfs-image:
         dtype: File
-        implicit: '{current.output-filename}_{current.product}_{current.suffix}_image_mfs.fits'
+        implicit: '{current.output-filename}_{current.product}_{current.suffix}_kimage_time0_mfs.fits'
       image:
         dtype: File
-        implicit: '{current.output-filename}_{current.product}_{current.suffix}_image.fits'
+        implicit: '{current.output-filename}_{current.product}_{current.suffix}_kimage_time0.fits'
       log-directory:
         dtype: Directory
         info:

--- a/src/pfb_imaging/cli/restore.py
+++ b/src/pfb_imaging/cli/restore.py
@@ -23,13 +23,13 @@ File = NewType("File", Path)
     dtype="File",
     name="mfs-image",
     info="",
-    implicit="{current.output-filename}_{current.product}_{current.suffix}_image_mfs.fits",
+    implicit="{current.output-filename}_{current.product}_{current.suffix}_kimage_time0_mfs.fits",
 )
 @stimela_output(
     dtype="File",
     name="image",
     info="",
-    implicit="{current.output-filename}_{current.product}_{current.suffix}_image.fits",
+    implicit="{current.output-filename}_{current.product}_{current.suffix}_kimage_time0.fits",
 )
 @stimela_output(
     dtype="Directory",
@@ -74,14 +74,14 @@ def restore(
     model_name: Annotated[
         str,
         typer.Option(
-            help="Name of model in dds",
+            help="Name of the model variable in the band nodes of the dt",
             rich_help_panel="Input",
         ),
     ] = "MODEL",
     residual_name: Annotated[
         str,
         typer.Option(
-            help="Name of residual in dds",
+            help="Name of the residual variable in the band nodes of the dt",
             rich_help_panel="Input",
         ),
     ] = "RESIDUAL",
@@ -97,11 +97,14 @@ def restore(
     outputs: Annotated[
         str,
         typer.Option(
-            help="Output products (m)odel, (r)esidual, (i)mage, (c)lean beam, (d)irty, (f)ft_residuals. "
+            help="Output products. "
+            "(d)irty, (m)odel, (r)esidual, (k) restored with intrinsic model and apparent residual. "
+            "(a) restored fully apparent, (i) restored fully intrinsic (primary beam corrected). "
+            "(c)lean beam image, (f)ft of the residual. "
             "Use capitals to produce corresponding cubes.",
             rich_help_panel="Output",
         ),
-    ] = "iI",
+    ] = "kK",
     gausspar: Annotated[
         tuple[float, float, float] | None,
         typer.Option(
@@ -121,20 +124,14 @@ def restore(
             rich_help_panel="Data Selection",
         ),
     ] = None,
-    ray_address: Annotated[
-        str,
+    pb_min: Annotated[
+        float,
         typer.Option(
-            help="Address of the ray cluster to connect to. If not provided, will run locally.",
-            rich_help_panel="Performance",
+            help="Primary beam cutoff for the intrinsic restored image. "
+            "Pixels where the beam falls below this value are set to zero.",
+            rich_help_panel="Restoration",
         ),
-    ] = "local",
-    nworkers: Annotated[
-        int,
-        typer.Option(
-            help="Number of worker processes. Use with distributed scheduler.",
-            rich_help_panel="Performance",
-        ),
-    ] = 1,
+    ] = 0.1,
     nthreads: Annotated[
         int | None,
         typer.Option(
@@ -220,8 +217,7 @@ def restore(
                     outputs=outputs,
                     gausspar=gausspar,
                     drop_bands=drop_bands,
-                    ray_address=ray_address,
-                    nworkers=nworkers,
+                    pb_min=pb_min,
                     nthreads=nthreads,
                     product=product,
                     log_directory=log_directory,
@@ -241,8 +237,7 @@ def restore(
                 outputs=outputs,
                 gausspar=gausspar,
                 drop_bands=drop_bands,
-                ray_address=ray_address,
-                nworkers=nworkers,
+                pb_min=pb_min,
                 nthreads=nthreads,
                 product=product,
                 log_directory=log_directory,
@@ -271,8 +266,7 @@ def restore(
             outputs=outputs,
             gausspar=gausspar,
             drop_bands=drop_bands,
-            ray_address=ray_address,
-            nworkers=nworkers,
+            pb_min=pb_min,
             nthreads=nthreads,
             product=product,
             log_directory=log_directory,

--- a/src/pfb_imaging/core/restore.py
+++ b/src/pfb_imaging/core/restore.py
@@ -18,12 +18,15 @@ from ducc0.misc import resize_thread_pool
 
 from pfb_imaging import set_envs
 from pfb_imaging.utils import logging as pfb_logging
+from pfb_imaging.utils.fits import dt2fits
 from pfb_imaging.utils.naming import set_output_names
 from pfb_imaging.utils.restoration import (
     PRODUCT_VARS,
+    beams_table,
     clean_beam,
     lowest_resolution,
     restore_products,
+    write_fits,
 )
 
 log = pfb_logging.get_logger("RESTORE")
@@ -243,6 +246,84 @@ def restore(
         b_mfs /= wsum_tot[:, None, None]
 
         psfpars_by_time[timeid] = gaussparf_mfs
+
+        freqs = np.array([dt[n].ds.attrs["freq_out"] for n in keep])
+        freq_mfs = float(np.sum(freqs[:, None] * wsums) / wsum_tot.sum())
+        meta = {
+            "cell_deg": cell_deg,
+            "nx": nx,
+            "ny": ny,
+            "radec": (ref.attrs["ra"], ref.attrs["dec"]),
+            "freq": freq_mfs,
+            "time_out": ref.attrs["time_out"],
+            "l0": float(ref.attrs.get("l0", 0.0)),
+            "m0": float(ref.attrs.get("m0", 0.0)),
+        }
+        drop_card = {"DROPBAND": ",".join(str(b) for b in sorted(dropped))} if dropped else {}
+        corr = ref.corr.values
+
+        # MFS restored images. Not obtainable from dt2fits: the per-band restored
+        # images sit at different resolutions, so their weighted sum is not the
+        # MFS restored image. r_mfs is already at G_mfs by construction.
+        mfs_products = tuple(k for k in products if k in outputs)
+        if mfs_products:
+            out_mfs = restore_products(
+                m_mfs,
+                r_mfs,
+                b_mfs,
+                gaussparf_mfs,
+                gausspari=gausspari_mfs,
+                products=mfs_products,
+                pb_min=pb_min,
+                nthreads=nthreads,
+            )
+            hdu = beams_table(gaussparf_mfs[None], corr, cell_deg)
+            for key, arr in out_mfs.items():
+                var = PRODUCT_VARS[key]
+                extra = {**drop_card, "WSUM": float(wsum_tot[0])}
+                if key == "i":
+                    extra["PBMIN"] = (float(pb_min), "beam floor below which the image is zeroed")
+                write_fits(
+                    arr,
+                    f"{fits_oname}_{var.lower()}_time{timeid}_mfs.fits",
+                    meta,
+                    gausspar=gaussparf_mfs[0],
+                    beams_hdu=hdu,
+                    extra_hdr=extra,
+                )
+
         log.info(f"time {timeid}: restored {nband} bands")
+
+    # cubes for every product, plus the MFS images of the stored variables,
+    # which are ordinary wsum reductions dt2fits can do itself. Runs once, after
+    # the per-time loop: dt2fits opens the store and loops over every timeid.
+    columns = []
+    if "d" in outputs.lower():
+        columns.append(("DIRTY", "d", True, None))
+    if "m" in outputs.lower():
+        columns.append((model_name, "m", False, None))
+    if "r" in outputs.lower():
+        columns.append((residual_name, "r", True, None))
+    for key in products:
+        columns.append((PRODUCT_VARS[key], key, False, "PSFPARSF"))
+
+    for column, key, norm_wsum, psfvar in columns:
+        do_mfs = key in outputs and psfvar is None  # restored MFS already written
+        do_cube = key.upper() in outputs
+        if not (do_mfs or do_cube):
+            continue
+        dt2fits(
+            dt_name,
+            column,
+            fits_oname,
+            norm_wsum=norm_wsum,
+            nthreads=nthreads,
+            do_mfs=do_mfs,
+            do_cube=do_cube,
+            psfpars_mfs=psfpars_by_time,
+            drop_bands=sorted(dropped) or None,
+            psfpars_var=psfvar or "PSFPARSN",
+        )
+        log.info(f"Done writing {column}")
 
     log.info(f"All done after {time.time() - time_start:.1f}s")

--- a/src/pfb_imaging/core/restore.py
+++ b/src/pfb_imaging/core/restore.py
@@ -14,11 +14,13 @@ import time
 import numpy as np
 import psutil
 import xarray as xr
+from ducc0.fft import c2c
 from ducc0.misc import resize_thread_pool
 
 from pfb_imaging import set_envs
 from pfb_imaging.utils import logging as pfb_logging
 from pfb_imaging.utils.fits import dt2fits
+from pfb_imaging.utils.misc import gaussian2d
 from pfb_imaging.utils.naming import set_output_names
 from pfb_imaging.utils.restoration import (
     PRODUCT_VARS,
@@ -290,6 +292,75 @@ def restore(
                     gausspar=gaussparf_mfs[0],
                     beams_hdu=hdu,
                     extra_hdr=extra,
+                )
+
+        # c/C: the restoring Gaussian itself. Derived from the beam parameters
+        # alone, so it is rendered rather than stored in the tree.
+        if "c" in outputs.lower():
+            xg = -(nx // 2) + np.arange(nx)
+            yg = -(ny // 2) + np.arange(ny)
+            xxg, yyg = np.meshgrid(xg, yg, indexing="ij")
+            if "c" in outputs:
+                # gaussian2d is x-major; transpose onto the (y, x) raster (D19)
+                cpsf = gaussian2d(xxg, yyg, gaussparf_mfs[0], normalise=False).T[None]
+                write_fits(
+                    cpsf,
+                    f"{fits_oname}_cpsf_time{timeid}_mfs.fits",
+                    meta,
+                    unit="",
+                    gausspar=gaussparf_mfs[0],
+                    extra_hdr=drop_card,
+                )
+            if "C" in outputs:
+                cube = np.stack([gaussian2d(xxg, yyg, gaussparf[b, 0], normalise=False).T[None] for b in range(nband)])
+                write_fits(
+                    cube,
+                    f"{fits_oname}_cpsf_time{timeid}.fits",
+                    {**meta, "freq": freqs},
+                    unit="",
+                    gausspar=gaussparf_mfs[0],
+                    gausspars=gaussparf[:, 0],
+                    beams_hdu=beams_table(gaussparf, corr, cell_deg),
+                    extra_hdr=drop_card,
+                )
+
+        # f/F: magnitude and phase of the FFT of the residual. A uv-plane
+        # diagnostic, so the image WCS in the header is nominal.
+        if "f" in outputs.lower():
+            fft_hdr = {**drop_card, "FFTDOM": ("uv", "image-plane WCS is nominal for this product")}
+            if "f" in outputs:
+                rhat = np.fft.fftshift(c2c(r_mfs, axes=(1, 2), forward=True, nthreads=nthreads, inorm=0), axes=(1, 2))
+                write_fits(
+                    np.abs(rhat),
+                    f"{fits_oname}_abs_fft_residual_time{timeid}_mfs.fits",
+                    meta,
+                    unit="",
+                    extra_hdr=fft_hdr,
+                )
+                write_fits(
+                    np.angle(rhat),
+                    f"{fits_oname}_phase_fft_residual_time{timeid}_mfs.fits",
+                    meta,
+                    unit="rad",
+                    extra_hdr=fft_hdr,
+                )
+            if "F" in outputs:
+                rcube = np.stack([dt[n].ds[residual_name].values / wsums[b][:, None, None] for b, n in enumerate(keep)])
+                rhat = np.fft.fftshift(c2c(rcube, axes=(2, 3), forward=True, nthreads=nthreads, inorm=0), axes=(2, 3))
+                cube_meta = {**meta, "freq": freqs}
+                write_fits(
+                    np.abs(rhat),
+                    f"{fits_oname}_abs_fft_residual_time{timeid}.fits",
+                    cube_meta,
+                    unit="",
+                    extra_hdr=fft_hdr,
+                )
+                write_fits(
+                    np.angle(rhat),
+                    f"{fits_oname}_phase_fft_residual_time{timeid}.fits",
+                    cube_meta,
+                    unit="rad",
+                    extra_hdr=fft_hdr,
                 )
 
         log.info(f"time {timeid}: restored {nband} bands")

--- a/src/pfb_imaging/core/restore.py
+++ b/src/pfb_imaging/core/restore.py
@@ -300,9 +300,13 @@ def restore(
             xg = -(nx // 2) + np.arange(nx)
             yg = -(ny // 2) + np.arange(ny)
             xxg, yyg = np.meshgrid(xg, yg, indexing="ij")
+            # one plane per correlation, matching the (ncorr, ny, nx) / (nband,
+            # ncorr, ny, nx) shapes save_fits maps onto the STOKES/FREQ axes.
+            # The BMAJ/BMIN/BPA *cards* stay corr 0 -- FITS has one beam per
+            # plane and dt2fits already uses Stokes I there.
+            # gaussian2d is x-major; transpose onto the (y, x) raster (D19)
             if "c" in outputs:
-                # gaussian2d is x-major; transpose onto the (y, x) raster (D19)
-                cpsf = gaussian2d(xxg, yyg, gaussparf_mfs[0], normalise=False).T[None]
+                cpsf = np.stack([gaussian2d(xxg, yyg, gaussparf_mfs[c], normalise=False).T for c in range(ncorr)])
                 write_fits(
                     cpsf,
                     f"{fits_oname}_cpsf_time{timeid}_mfs.fits",
@@ -312,7 +316,12 @@ def restore(
                     extra_hdr=drop_card,
                 )
             if "C" in outputs:
-                cube = np.stack([gaussian2d(xxg, yyg, gaussparf[b, 0], normalise=False).T[None] for b in range(nband)])
+                cube = np.stack(
+                    [
+                        np.stack([gaussian2d(xxg, yyg, gaussparf[b, c], normalise=False).T for c in range(ncorr)])
+                        for b in range(nband)
+                    ]
+                )
                 write_fits(
                     cube,
                     f"{fits_oname}_cpsf_time{timeid}.fits",

--- a/src/pfb_imaging/core/restore.py
+++ b/src/pfb_imaging/core/restore.py
@@ -1,24 +1,30 @@
-"""Restore clean components onto residuals (legacy .dds consumer).
+"""Restore clean components onto residuals in the imager DataTree.
 
-NOTE: kept as reference code only -- its .dds inputs can no longer be
-produced in-repo since init+grid were retired (#277); the functionality
-moves into `deconv` eventually. No test coverage: do not extend without
-tests.
+Consumes the ``.dt`` written by ``pfb imager`` and extended by ``pfb deconv``.
+The band ``MODEL`` is intrinsic flux while the band ``RESIDUAL`` is apparent
+(wiki D22/D23), so three restored products are offered rather than one: see
+``utils/restoration.PRODUCT_VARS``.
+
+No Ray: the work is FFT-bound with threaded ducc, and the driver needs the
+image cubes resident anyway to form the MFS products.
 """
 
 import time
 
 import numpy as np
 import psutil
-import ray
-from daskms.fsspec_store import DaskMSStore
+import xarray as xr
 from ducc0.misc import resize_thread_pool
 
-from pfb_imaging import init_ray, set_envs, setup_ray_worker
+from pfb_imaging import set_envs
 from pfb_imaging.utils import logging as pfb_logging
-from pfb_imaging.utils.fits import rdds2fits
-from pfb_imaging.utils.naming import get_opts, set_output_names, xds_from_url
-from pfb_imaging.utils.restoration import rrestore_image
+from pfb_imaging.utils.naming import set_output_names
+from pfb_imaging.utils.restoration import (
+    PRODUCT_VARS,
+    clean_beam,
+    lowest_resolution,
+    restore_products,
+)
 
 log = pfb_logging.get_logger("RESTORE")
 
@@ -28,22 +34,40 @@ def restore(
     model_name: str = "MODEL",
     residual_name: str = "RESIDUAL",
     suffix: str = "main",
-    outputs: str = "mMrRiI",
+    outputs: str = "kK",
     gausspar: tuple[float, float, float] | None = None,
     drop_bands: list[int] | None = None,
-    nworkers: int = 1,
+    pb_min: float = 0.1,
     nthreads: int | None = None,
     log_directory: str | None = None,
     product: str = "I",
     fits_output_folder: str | None = None,
-    ray_address: str = "local",
-    keep_ray_alive: bool = False,
 ):
+    """Restore clean components onto residuals and render FITS.
+
+    Args:
+        output_filename: basename; the tree read is ``<output>_<PRODUCT>.dt``.
+        model_name: band variable holding the model image.
+        residual_name: band variable holding the residual image.
+        suffix: namespaces the FITS outputs only, never the tree path.
+        outputs: product letters, lowercase for MFS and uppercase for cubes.
+        gausspar: restoring resolution ``(emaj, emin, pa)`` in degrees, degrees
+            and degrees. ``(0, 0, 0)`` selects the lowest-resolution band. None
+            restores each band at its native resolution.
+        drop_bands: band ids excluded from cubes and from every MFS reduction.
+        pb_min: beam floor below which the intrinsic image is zeroed.
+        nthreads: FFT threads; half the logical CPUs by default.
+        log_directory: log destination.
+        product: Stokes product, used to build the tree and FITS names.
+        fits_output_folder: FITS destination.
+
+    Raises:
+        ValueError: the tree has no band nodes, was written without ``--psf``,
+            lacks the named model or residual variable, or has no band left
+            once dropped and fully flagged bands are excluded.
     """
-    Create fits image cubes from data products (eg. restored images).
-    """
-    # for logging options
     opts_dict = locals().copy()
+    time_start = time.time()
 
     output_filename, fits_output_folder, log_directory, oname = set_output_names(
         output_filename,
@@ -55,243 +79,170 @@ def restore(
     opts_dict["fits_output_folder"] = fits_output_folder
     opts_dict["log_directory"] = log_directory
 
-    nthreads_total = psutil.cpu_count(logical=True)
-    ncpu = psutil.cpu_count(logical=False)
     if nthreads is None:
-        nthreads = nthreads_total // 2
-        ncpu = ncpu // 2
+        nthreads = psutil.cpu_count(logical=True) // 2
+    ncpu = int(np.minimum(nthreads, psutil.cpu_count(logical=False)))
     opts_dict["nthreads"] = nthreads
-    log.info(f"Using {nworkers} workers with {nthreads} threads per worker")
-
     resize_thread_pool(nthreads)
     set_envs(nthreads, ncpu, log=log)
 
     timestamp = time.strftime("%Y%m%d-%H%M%S")
-    logname = f"{log_directory}/restore_{timestamp}.log"
-    pfb_logging.log_to_file(logname)
+    pfb_logging.log_to_file(f"{log_directory}/restore_{timestamp}.log")
     log.log_options_dict(opts_dict, title="RESTORE options")
 
-    # these are passed through to child Ray processes
-    renv = {"env_vars": {}}
-    if nworkers == 1:
-        renv["env_vars"]["RAY_DEBUG_POST_MORTEM"] = "1"
-
-    init_ray(
-        nworkers,
-        ray_address=ray_address,
-        runtime_env={
-            "env_vars": renv["env_vars"],
-            "worker_process_setup_hook": setup_ray_worker,
-        },
-        log=log,
-    )
-
-    ti = time.time()
-
-    # Inlined _restore() function logic
+    # unlike the legacy .dds (where `suffix` came from), imager() never appends
+    # a suffix to the tree name -- it namespaces the FITS outputs only
     basename = output_filename
-    if fits_output_folder is not None:
-        fits_oname = fits_output_folder + "/" + basename.split("/")[-1]
-    else:
-        fits_oname = basename
+    fits_oname = f"{fits_output_folder}/{oname}_{suffix}"
+    dt_name = f"{basename}.dt"
 
-    dds_name = f"{basename}_{suffix}.dds"
-    dds, dds_list = xds_from_url(dds_name)
-    dds_store = DaskMSStore(dds_name)
-    if "://" in dds_store.url:
-        protocol = dds_store.url.split("://")[0]
-    else:
-        protocol = "file"
+    dt = xr.open_datatree(dt_name, engine="zarr", chunks=None)
+    band_nodes = [n for n in dt.children if n.startswith("band")]
+    if not band_nodes:
+        log.error_and_raise(f"No band nodes found in {dt_name}", ValueError)
 
-    # get MFS PSF PARS
-    try:
-        psfpars_mfs = get_opts(dds_store.url, protocol, name="psfparsn_mfs.pkl")
-    except Exception:
-        log.error_and_raise("Could not load MFS PSF pamaters. Run grid worker with psf=true to remake.", RuntimeError)
+    dropped = set(drop_bands or ())
+    products = tuple(k for k in ("a", "i", "k") if k in outputs.lower())
+    timeids = sorted({int(dt[n].ds.attrs["timeid"]) for n in band_nodes})
+    log.info(f"Number of output times = {len(timeids)}")
 
-    if drop_bands is not None:
-        ddso = []
-        ddso_list = []
-        for ds, dsl in zip(dds, dds_list):
-            b = int(ds.bandid)
-            if b not in drop_bands:
-                ddso.append(ds)
-                ddso_list.append(dsl)
-        dds = ddso
-        dds_list = ddso_list
+    psfpars_by_time = {}
 
-    timeids = np.unique(np.array([int(ds.timeid) for ds in dds]))
-    freqs = [ds.freq_out for ds in dds]
-    freqs = np.unique(freqs)
-    nband = freqs.size
-    ntime = timeids.size
-    ncorr = dds[0].corr.size
-    cell_deg = dds[0].cell_rad * 180 / np.pi
-    log.info(f"Number of output times = {ntime}")
-    log.info(f"Number of output bands = {nband}")
     for timeid in timeids:
-        # collect datasets for this timeid
-        dst = [ds for ds in dds if int(ds.timeid) == timeid]
-        # we don't want a reference to the ds lying around so pass list of ds_list to child processes instead
-        dst_list = [dsl for ds, dsl in zip(dds, dds_list) if int(ds.timeid) == timeid]
-        # need this loop before scatter to extract lowest resolution
-        if not np.array(gausspar).any():  # if gausspar is None or all elements are zero (allow float comparison)
-            emaj = 0.0
-            emin = 0.0
-            pas = []
-            for ds in dst:
-                gausspars = ds.PSFPARSN.values
-                emaj = np.maximum(emaj, gausspars[:, 0].max())
-                emin = np.maximum(emin, gausspars[:, 1].max())
-                pas.append(np.mean(gausspars[:, 2]))
-            pa = np.mean(np.array(pas))
+        nodes = sorted(
+            (n for n in band_nodes if int(dt[n].ds.attrs["timeid"]) == timeid),
+            key=lambda n: int(dt[n].ds.attrs["bandid"]),
+        )
+        keep = [n for n in nodes if int(dt[n].ds.attrs["bandid"]) not in dropped]
+        if dropped:
+            log.info(f"time {timeid}: dropping bands {sorted(dropped)} from cubes and all MFS reductions")
+
+        for n in keep:
+            bds = dt[n].ds
+            if "PSF" not in bds or "PSFPARSN" not in bds:
+                log.error_and_raise(
+                    f"{dt_name}/{n} has no PSF (imager run with --no-psf?) -- re-run pfb imager with --psf to restore",
+                    ValueError,
+                )
+            for name in (model_name, residual_name):
+                if name not in bds:
+                    log.error_and_raise(
+                        f"{dt_name}/{n} has no {name}; run pfb deconv first, or name an "
+                        "existing variable with --model-name/--residual-name",
+                        ValueError,
+                    )
+
+        # A fully flagged band carries WSUM == 0 (core/imager.py emits these --
+        # freq_eff falls back to freq_nominal when wsum_tot == 0). Dividing the
+        # residual by it yields inf/NaN, which would land in the stored products
+        # AND in the MFS accumulators, poisoning every other band's MFS image.
+        # Skip them exactly as --drop-bands does.
+        dead = [n for n in keep if not float(dt[n].ds.WSUM.values.sum()) > 0]
+        if dead:
             log.info(
-                f"Using lowest resolution of ({emaj * cell_deg:.3e} deg, "
-                f"{emin * cell_deg:.3e} deg, {pa * 180 / np.pi:.3e} deg) for restored images"
+                f"time {timeid}: skipping fully flagged bands "
+                f"{[int(dt[n].ds.attrs['bandid']) for n in dead]} (WSUM == 0)"
             )
-            # these are in pixel units
-            # restore needs corr axis
-            gaussparf = np.tile([emaj, emin, pa], (ncorr, 1))
+            keep = [n for n in keep if n not in set(dead)]
+        if not keep:
+            log.error_and_raise(
+                f"No bands left at timeid {timeid} after --drop-bands and fully flagged bands were excluded",
+                ValueError,
+            )
+
+        ref = dt[keep[0]].ds
+        nband = len(keep)
+        ncorr, ny, nx = ref[model_name].shape
+        cell_deg = np.rad2deg(ref.attrs["cell_rad"])
+        otype = ref[residual_name].dtype
+        wsums = np.stack([dt[n].ds.WSUM.values for n in keep])  # (nband, ncorr)
+        wsum_tot = wsums.sum(axis=0)
+        psfparsn = np.stack([dt[n].ds.PSFPARSN.values for n in keep])  # (nband, ncorr, 3)
+
+        # accumulate the MFS PSF one band at a time: stacking every band's PSF
+        # would hold 4x the image cube (PSFs are 2nx by 2ny)
+        psf_sum = np.zeros(dt[keep[0]].ds.PSF.shape, dtype=np.float64)
+        for n in keep:
+            psf_sum += dt[n].ds.PSF.values
+        gausspar_mfs_native = clean_beam(psf_sum, wsum_tot)
+        del psf_sum
+
+        # resolve the restoring resolutions. gausspari is None wherever the
+        # target already is the residual's own resolution, which skips the
+        # residual reconvolution entirely.
+        if gausspar is not None and np.any(np.asarray(gausspar, dtype=float)):
+            target = np.tile([gausspar[0] / cell_deg, gausspar[1] / cell_deg, np.deg2rad(gausspar[2])], (ncorr, 1))
+            log.info(
+                f"Using specified resolution of ({gausspar[0]:.3e} deg, {gausspar[1]:.3e} deg, {gausspar[2]:.3e} deg)"
+            )
+            gaussparf = np.tile(target, (nband, 1, 1))
+            gaussparf_mfs = target
+            gausspari_band, gausspari_mfs = psfparsn, gausspar_mfs_native
         elif gausspar is not None:
-            # these are passed in in degrees
-            emaj = gausspar[0]
-            emin = gausspar[1]
-            pa = gausspar[2]
-            log.info(f"Using specified resolution of ({emaj:.3e} deg, {emin:.3e} deg, {pa:.3e} deg)")
-            # convert to pixel units
-            emaj /= cell_deg
-            emin /= cell_deg
-            # convert degrees to radians
-            pa *= np.pi / 180
-            # restore needs corr axis
-            gaussparf = np.tile([emaj, emin, pa], (ncorr, 1))
-
-        # create restored images
-        tasksi = []
-        for ds, ds_name in zip(dst, dst_list):
-            if gausspar is None:
-                gaussparf = ds.PSFPARSN.values
-            task = rrestore_image.remote(ds_name, model_name, residual_name, gaussparf, nthreads=nthreads)
-            tasksi.append(task)
-
-    # the loop over timeid happens inside dds2fits
-    tasks = []
-    if "d" in outputs.lower():
-        task = rdds2fits.remote(
-            dds_list,
-            "DIRTY",
-            f"{fits_oname}_{suffix}",
-            norm_wsum=True,
-            nthreads=nthreads,
-            do_mfs="d" in outputs,
-            do_cube="D" in outputs,
-            psfpars_mfs=psfpars_mfs,
+            target = lowest_resolution(psfparsn)
+            log.info(
+                f"Using lowest resolution of ({target[0, 0] * cell_deg:.3e} deg, "
+                f"{target[0, 1] * cell_deg:.3e} deg, {np.rad2deg(target[0, 2]):.3e} deg)"
+            )
+            gaussparf = np.tile(target, (nband, 1, 1))
+            gaussparf_mfs = target
+            gausspari_band, gausspari_mfs = psfparsn, gausspar_mfs_native
+        else:
+            gaussparf = psfparsn
+            gaussparf_mfs = gausspar_mfs_native
+            gausspari_band, gausspari_mfs = None, None
+        log.info(
+            f"MFS restoring beam: ({gaussparf_mfs[0, 0] * cell_deg:.3e} deg, "
+            f"{gaussparf_mfs[0, 1] * cell_deg:.3e} deg, {np.rad2deg(gaussparf_mfs[0, 2]):.3e} deg)"
         )
-        tasks.append(task)
 
-    if "m" in outputs.lower():
-        task = rdds2fits.remote(
-            dds_list,
-            model_name,
-            f"{fits_oname}_{suffix}",
-            norm_wsum=False,
-            nthreads=nthreads,
-            do_mfs="m" in outputs,
-            do_cube="M" in outputs,
-            psfpars_mfs=psfpars_mfs,
-        )
-        tasks.append(task)
+        # per-band restore, accumulating the wsum-weighted MFS reductions as we
+        # go so only one band's arrays are resident at a time
+        m_mfs = np.zeros((ncorr, ny, nx), dtype=np.float64)
+        r_mfs = np.zeros((ncorr, ny, nx), dtype=np.float64)
+        b_mfs = np.zeros((ncorr, ny, nx), dtype=np.float64)
+        for b, n in enumerate(keep):
+            bds = dt[n].ds
+            model = bds[model_name].values
+            residual = bds[residual_name].values / wsums[b][:, None, None]
+            beam = bds.BEAM.values
+            w = wsums[b][:, None, None]
+            m_mfs += w * model
+            r_mfs += w * residual
+            b_mfs += w * beam
 
-    if "r" in outputs.lower():
-        task = rdds2fits.remote(
-            dds_list,
-            residual_name,
-            f"{fits_oname}_{suffix}",
-            norm_wsum=True,
-            nthreads=nthreads,
-            do_mfs="r" in outputs,
-            do_cube="R" in outputs,
-            psfpars_mfs=psfpars_mfs,
-        )
-        tasks.append(task)
+            data_vars = {"PSFPARSF": (("corr", "bpar"), gaussparf[b].astype(otype))}
+            if products:
+                out = restore_products(
+                    model,
+                    residual,
+                    beam,
+                    gaussparf[b],
+                    gausspari=None if gausspari_band is None else gausspari_band[b],
+                    products=products,
+                    pb_min=pb_min,
+                    nthreads=nthreads,
+                )
+                for key, arr in out.items():
+                    # convolve2gaussres returns a non-contiguous view under
+                    # yx_order=True; zarr wants a contiguous buffer
+                    data_vars[PRODUCT_VARS[key]] = (("corr", "y", "x"), np.ascontiguousarray(arr, dtype=otype))
+            # to_zarr(mode="a") replaces a group's attrs wholesale, so start
+            # from the band's own attrs (core/deconv.py:409-424)
+            xr.Dataset(
+                data_vars,
+                attrs={
+                    **dict(bds.attrs),
+                    "psfparsf_mfs": [float(v) for v in gaussparf_mfs[0]],
+                    "pb_min": float(pb_min),
+                },
+            ).to_zarr(dt_name, group=n, mode="a")
 
-    # we need to wait for tasksi before rendering restored to fits
-    tasksc = ray.get(tasksi)
+        m_mfs /= wsum_tot[:, None, None]
+        r_mfs /= wsum_tot[:, None, None]
+        b_mfs /= wsum_tot[:, None, None]
 
-    if "i" in outputs.lower():
-        # recompute the mean PSF parameters
-        psfparsf = {}
-        for psfpar, bandid, timeid in tasksc:
-            psfparsf.setdefault(timeid, np.zeros((nband, ncorr, 3)))
-            psfparsf[timeid][int(bandid)] = psfpar
-        psfpars_mfs = {timeid: psfparsf[timeid].mean(axis=0) for timeid in psfparsf}
-        task = rdds2fits.remote(
-            dds_list,
-            "IMAGE",
-            f"{fits_oname}_{suffix}",
-            norm_wsum=False,
-            nthreads=nthreads,
-            do_mfs="i" in outputs,
-            do_cube="I" in outputs,
-            psfpars_mfs=psfpars_mfs,
-            psfparsf=psfparsf,
-            force_unit="Jy/beam",
-        )
-        tasks.append(task)
+        psfpars_by_time[timeid] = gaussparf_mfs
+        log.info(f"time {timeid}: restored {nband} bands")
 
-    # TODO(LB) - we may want to add these outputs back in, at least the useful ones
-    # if 'f' in outputs:
-    #     rhat_mfs = c2c(residual_mfs, forward=True,
-    #                    nthreads=nthreads, inorm=0)
-    #     rhat_mfs = np.fft.fftshift(rhat_mfs)
-    #     save_fits(np.abs(rhat_mfs),
-    #               f'{fits_oname}_{suffix}.abs_fft_residual_mfs.fits',
-    #               hdr_mfs,
-    #               overwrite=overwrite)
-    #     save_fits(np.angle(rhat_mfs),
-    #               f'{fits_oname}_{suffix}.phase_fft_residual_mfs.fits',
-    #               hdr_mfs,
-    #               overwrite=overwrite)
-
-    # if 'F' in outputs:
-    #     rhat = c2c(residual, axes=(1,2), forward=True,
-    #                nthreads=nthreads, inorm=0)
-    #     rhat = np.fft.fftshift(rhat, axes=(1,2))
-    #     save_fits(np.abs(rhat),
-    #               f'{fits_oname}_{suffix}.abs_fft_residual.fits',
-    #               hdr,
-    #               overwrite=overwrite)
-    #     save_fits(np.angle(rhat),
-    #               f'{fits_oname}_{suffix}.phase_fft_residual.fits',
-    #               hdr,
-    #               overwrite=overwrite)
-
-    # if 'c' in outputs:
-    #     if gausspar is None:
-    #         raise ValueError("Clean beam in output but no PSF in dds")
-    #     cpsf_mfs = gaussian2d(xx, yy, gausspar[0], normalise=False)
-    #     save_fits(cpsf_mfs,
-    #               f'{fits_oname}_{suffix}.cpsf_mfs.fits',
-    #               hdr_mfs,
-    #               overwrite=overwrite)
-
-    # if 'C' in outputs:
-    #     if gausspars is None:
-    #         raise ValueError("Clean beam in output but no PSF in dds")
-    #     cpsf = np.zeros(residual.shape, dtype=output_type)
-    #     for v in range(nband):
-    #         gpar = gausspars[v]
-    #         if not np.isnan(gpar).any():
-    #             cpsf[v] = gaussian2d(xx, yy, gpar, normalise=False)
-    #     save_fits(cpsf,
-    #               f'{fits_oname}_{suffix}.cpsf.fits',
-    #               hdr,
-    #               overwrite=overwrite)
-
-    # wait for all tasks to finish before returning
-    ray.get(tasks)
-
-    log.info(f"All done after {time.time() - ti}s")
-
-    if not keep_ray_alive:
-        ray.shutdown()
+    log.info(f"All done after {time.time() - time_start:.1f}s")

--- a/src/pfb_imaging/utils/fits.py
+++ b/src/pfb_imaging/utils/fits.py
@@ -432,6 +432,8 @@ def dt2fits(
     psfpars_mfs=None,
     force_unit=None,
     extra_hdr=None,
+    drop_bands=None,
+    psfpars_var="PSFPARSN",
 ):
     """Render a band-node variable from the imager ``.dt`` DataTree to FITS.
 
@@ -451,6 +453,13 @@ def dt2fits(
         force_unit: override the BUNIT header.
         extra_hdr: optional dict of extra FITS header cards stamped into every
             written header.
+        drop_bands: optional list of ``bandid`` values to exclude from the cube
+            and from every MFS reduction (image sum, wsum, ``freq_mfs``). Bands
+            are omitted, not zeroed, so a non-edge drop leaves a non-uniform
+            FITS frequency axis -- see issue #302.
+        psfpars_var: band variable supplying the cube BEAMS table and
+            ``BMAJ{i}`` cards. ``"PSFPARSF"`` publishes a restored image's final
+            resolution instead of the native ``"PSFPARSN"``.
 
     Returns:
         The rendered ``column`` name.
@@ -474,6 +483,11 @@ def dt2fits(
         # silently reordering cube planes. bandid is monotonic in frequency by
         # construction (the band_edges grid in core.imager).
         dst = sorted((ds for ds in nodes if int(ds.attrs["timeid"]) == timeid), key=lambda d: int(d.attrs["bandid"]))
+        if drop_bands:
+            dst = [ds for ds in dst if int(ds.attrs["bandid"]) not in set(drop_bands)]
+            if not dst:
+                continue
+        drop_card = {"DROPBAND": ",".join(str(b) for b in sorted(drop_bands))} if drop_bands else {}
         ref = dst[0]
         nband = len(dst)
         freqs = np.array([ds.attrs["freq_out"] for ds in dst])
@@ -517,6 +531,8 @@ def dt2fits(
             if extra_hdr:
                 for k, v in extra_hdr.items():
                     hdr[k] = v
+            for k, v in drop_card.items():
+                hdr[k] = v
             hdr["WSUM"] = float(wsum[0])
             if norm_wsum:
                 cube_mfs = np.sum(cube, axis=0) / wsum[:, None, None]
@@ -535,8 +551,8 @@ def dt2fits(
         if do_cube:
             cube_beams = None
             psfparsf_timeid = None
-            if all("PSFPARSN" in ds for ds in dst):
-                pp = np.stack([ds.PSFPARSN.values for ds in dst], axis=0)  # (band, corr, 3)
+            if all(psfpars_var in ds for ds in dst):
+                pp = np.stack([ds[psfpars_var].values for ds in dst], axis=0)  # (band, corr, 3)
                 da = xr.DataArray(
                     pp,
                     dims=("band", "corr", "bpar"),
@@ -562,6 +578,8 @@ def dt2fits(
             if extra_hdr:
                 for k, v in extra_hdr.items():
                     hdr[k] = v
+            for k, v in drop_card.items():
+                hdr[k] = v
             for i in range(nband):
                 hdr[f"WSUM{i + 1}"] = float(wsums[i, 0])
             cube_out = cube / wsums[:, :, None, None] if norm_wsum else cube

--- a/src/pfb_imaging/utils/misc.py
+++ b/src/pfb_imaging/utils/misc.py
@@ -176,28 +176,39 @@ def get_padding_info(nx, ny, pfrac):
     return padding, unpad_x, unpad_y
 
 
-def convolve2gaussres(image, xx, yy, gaussparf, nthreads=1, gausspari=None, pfrac=0.5, norm_kernel=False):
+def convolve2gaussres(
+    image, xx, yy, gaussparf, nthreads=1, gausspari=None, pfrac=0.5, norm_kernel=False, yx_order=False
+):
     """
     Convolves the image to a specified resolution.
 
     Parameters
     ----------
-    Image       - (nband, nx, ny) array to convolve
+    image       - (nplane, nx, ny) array to convolve, or (nplane, ny, nx)
+                  with yx_order=True.
     xx/yy       - coordinates on the grid in the same units as gaussparf.
-    gaussparf   - tuple containing Gaussian parameters of desired resolution
-                  (emaj, emin, pa).
-    gausspari   - initial resolution . By default it is assumed that the image
-                  is a clean component image with no associated resolution.
-                  If beampari is specified, it must be a tuple containing
-                  gausspars for each imaging band in the same format.
+                  ALWAYS in the wgridder (X, Y) convention -- built from nx
+                  then ny -- regardless of yx_order.
+    gaussparf   - (3,) Gaussian parameters (emaj, emin, pa) shared by every
+                  plane, or (nplane, 3) per plane.
+    gausspari   - initial resolution, same shapes as gaussparf. By default the
+                  image is assumed to be a clean component image with no
+                  associated resolution.
     nthreads    - number of threads to use for the FFT's.
     pfrac       - padding used for the FFT based convolution.
                   Will pad by pfrac/2 on both sides of image
     norm_kernel - Normalise the Gaussian kernel to have volume 1.
+    yx_order    - set True for cube/FITS (Y, X)-ordered input (see
+                  docs/wiki/image-and-beam-orientation.md). The convolution is
+                  defined in wgridder (X, Y) order; this adapts via a zero-copy
+                  view and transposes the result back, so gaussian2d's position
+                  angle keeps its meaning.
     """
+    if yx_order:
+        image = image.transpose(0, 2, 1)
     nband, nx, ny = image.shape
-    if gausspari is not None and len(gausspari) != nband:
-        raise ValueError("gausspari must be on length nband")
+    if gausspari is not None and np.ndim(gausspari) > 1 and np.shape(gausspari)[0] != nband:
+        raise ValueError("gausspari must be of length nband")
     padding, unpad_x, unpad_y = get_padding_info(nx, ny, pfrac)
     ax = (1, 2)  # axes over which to perform fft
     lastsize = ny + np.sum(padding[-1])
@@ -206,13 +217,13 @@ def convolve2gaussres(image, xx, yy, gaussparf, nthreads=1, gausspari=None, pfra
     image = np.pad(image, padding, mode="constant")
     imhat = r2c(ifftshift(image, axes=ax), axes=ax, forward=True, nthreads=nthreads, inorm=0)
 
-    if len(gaussparf) == 3:  # single final resolution
+    if np.ndim(gaussparf) == 1:  # single final resolution shared by all planes
         gausskern = gaussian2d(xx, yy, gaussparf, normalise=norm_kernel)
         gausskern = np.pad(gausskern, padding[1:], mode="constant")
         gausskernhat = r2c(ifftshift(gausskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0)
         gausskernhat = np.broadcast_to(gausskernhat[None], imhat.shape)
     else:
-        assert len(gaussparf) == nband
+        assert np.shape(gaussparf)[0] == nband
         gausskernhat = np.zeros_like(imhat)
         for b in range(nband):
             gausskern = gaussian2d(xx, yy, gaussparf[b], normalise=norm_kernel)
@@ -230,8 +241,10 @@ def convolve2gaussres(image, xx, yy, gaussparf, nthreads=1, gausspari=None, pfra
     if gausspari is None:
         imhat *= gausskernhat
     else:
+        gausspari = np.asarray(gausspari)
         for b in range(nband):
-            thiskern = gaussian2d(xx, yy, gausspari[b], normalise=norm_kernel)
+            gpi = gausspari if gausspari.ndim == 1 else gausspari[b]
+            thiskern = gaussian2d(xx, yy, gpi, normalise=norm_kernel)
             thiskern = np.pad(thiskern, padding[1:], mode="constant")
             thiskernhat = r2c(ifftshift(thiskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0)
 
@@ -244,6 +257,9 @@ def convolve2gaussres(image, xx, yy, gaussparf, nthreads=1, gausspari=None, pfra
     image = fftshift(c2r(imhat, axes=ax, forward=False, lastsize=lastsize, inorm=2, nthreads=nthreads), axes=ax)[
         :, unpad_x, unpad_y
     ]
+
+    if yx_order:
+        image = image.transpose(0, 2, 1)
 
     return image
 

--- a/src/pfb_imaging/utils/misc.py
+++ b/src/pfb_imaging/utils/misc.py
@@ -179,30 +179,41 @@ def get_padding_info(nx, ny, pfrac):
 def convolve2gaussres(
     image, xx, yy, gaussparf, nthreads=1, gausspari=None, pfrac=0.5, norm_kernel=False, yx_order=False
 ):
-    """
-    Convolves the image to a specified resolution.
+    """Convolves the image to a specified resolution.
 
-    Parameters
-    ----------
-    image       - (nplane, nx, ny) array to convolve, or (nplane, ny, nx)
-                  with yx_order=True.
-    xx/yy       - coordinates on the grid in the same units as gaussparf.
-                  ALWAYS in the wgridder (X, Y) convention -- built from nx
-                  then ny -- regardless of yx_order.
-    gaussparf   - (3,) Gaussian parameters (emaj, emin, pa) shared by every
-                  plane, or (nplane, 3) per plane.
-    gausspari   - initial resolution, same shapes as gaussparf. By default the
-                  image is assumed to be a clean component image with no
-                  associated resolution.
-    nthreads    - number of threads to use for the FFT's.
-    pfrac       - padding used for the FFT based convolution.
-                  Will pad by pfrac/2 on both sides of image
-    norm_kernel - Normalise the Gaussian kernel to have volume 1.
-    yx_order    - set True for cube/FITS (Y, X)-ordered input (see
-                  docs/wiki/image-and-beam-orientation.md). The convolution is
-                  defined in wgridder (X, Y) order; this adapts via a zero-copy
-                  view and transposes the result back, so gaussian2d's position
-                  angle keeps its meaning.
+    Args:
+        image: (nplane, nx, ny) array to convolve, or (nplane, ny, nx) with
+            yx_order=True.
+        xx: Grid coordinates in the same units as gaussparf. ALWAYS in the
+            wgridder (X, Y) convention -- built from nx then ny -- regardless
+            of yx_order.
+        yy: Grid coordinates in the same units as gaussparf. ALWAYS in the
+            wgridder (X, Y) convention -- built from nx then ny -- regardless
+            of yx_order.
+        gaussparf: (3,) Gaussian parameters (emaj, emin, pa) shared by every
+            plane, or (nplane, 3) per plane.
+        nthreads: Number of threads to use for the FFT's.
+        gausspari: Initial resolution, same shapes as gaussparf. By default
+            the image is assumed to be a clean component image with no
+            associated resolution.
+        pfrac: Padding used for the FFT based convolution. Will pad by
+            pfrac/2 on both sides of image.
+        norm_kernel: Normalise the Gaussian kernel to have volume 1.
+        yx_order: Set True for cube/FITS (Y, X)-ordered input (see
+            docs/wiki/image-and-beam-orientation.md). The convolution is
+            defined in wgridder (X, Y) order; this adapts via a zero-copy
+            view and transposes the result back, so gaussian2d's position
+            angle keeps its meaning.
+
+    Returns:
+        The convolved image, same shape and axis order as the input image
+        (nplane, nx, ny), or (nplane, ny, nx) with yx_order=True.
+
+    Raises:
+        ValueError: If gausspari is per-plane (ndim > 1) and its length does
+            not match the number of planes in image.
+        AssertionError: If gaussparf is per-plane (ndim > 1) and its length
+            does not match the number of planes in image.
     """
     if yx_order:
         image = image.transpose(0, 2, 1)

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -1,7 +1,15 @@
 """Restoration helpers for the imager DataTree.
 
-Pure array functions: no tree I/O, no Ray, no FITS. ``core/restore.py`` owns
-reading the ``.dt``, writing products back and rendering FITS.
+Two groups, both free of tree I/O and of Ray -- ``core/restore.py`` owns reading
+the ``.dt`` and writing products back into it:
+
+* **Pure array functions** -- :func:`clean_beam`, :func:`lowest_resolution` and
+  :func:`restore_products` -- which take and return numpy arrays.
+* **FITS rendering helpers** -- :func:`beams_table` and :func:`write_fits` --
+  for the products the driver computes itself and so cannot source from a
+  stored band variable via :func:`~pfb_imaging.utils.fits.dt2fits`. Principally
+  the MFS restored images: the per-band restored images sit at different
+  resolutions, so their weighted sum is not the MFS restored image.
 
 Flux-scale conventions (wiki D22/D23): the band ``MODEL`` is intrinsic flux and
 the band ``RESIDUAL`` is apparent (once-attenuated) flux, so a restored image

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -9,7 +9,9 @@ must say which scale it is on. Three are offered, keyed by their CLI letter.
 """
 
 import numpy as np
+import xarray as xr
 
+from pfb_imaging.utils.fits import create_beams_table, save_fits, set_wcs
 from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam
 
 # CLI letter -> DataTree variable name. The B prefix follows the tree's
@@ -105,5 +107,73 @@ def restore_products(model, residual, beam, gaussparf, gausspari=None, products=
             rint = np.where(beam > pb_min, rconv / beam, 0.0)
         out["i"] = np.where(beam > pb_min, mconv + rint, 0.0)
     if "a" in products:
+        # (B*m) (x) G, NOT B*(m (x) G) -- convolution does not commute with
+        # multiplication by a spatially varying beam, so mconv cannot be reused
         out["a"] = convolve2gaussres(beam * model, xx, yy, gaussparf, **kw) + rconv
     return out
+
+
+def beams_table(gausspars, corr, cell_deg):
+    """Build a BEAMS BinTableHDU from resolutions in pixel units.
+
+    Args:
+        gausspars: ``(nband, ncorr, 3)`` in pixels, pixels, radians.
+        corr: correlation labels, length ``ncorr``.
+        cell_deg: cell size in degrees, converting the axes to degrees.
+
+    Returns:
+        An astropy ``BinTableHDU`` named BEAMS.
+    """
+    gausspars = np.asarray(gausspars, dtype=float)
+    da = xr.DataArray(
+        gausspars,
+        dims=("band", "corr", "bpar"),
+        coords={
+            "band": np.arange(gausspars.shape[0]),
+            "corr": list(corr),
+            "bpar": ["BMAJ", "BMIN", "BPA"],
+        },
+    )
+    return create_beams_table(da, cell2deg=cell_deg)
+
+
+def write_fits(
+    data, name, meta, unit="Jy/beam", gausspar=None, gausspars=None, beams_hdu=None, extra_hdr=None, otype=np.float32
+):
+    """Render a (Y, X)-ordered array to FITS with the ``.dt``'s WCS conventions.
+
+    Used for the products the driver computes itself, which :func:`dt2fits`
+    cannot source from a stored band variable -- principally the MFS restored
+    images, which are not weighted sums of the per-band restored images.
+
+    Args:
+        data: ``(ncorr, ny, nx)`` or ``(nband, ncorr, ny, nx)``, (Y, X)-ordered.
+        name: output path.
+        meta: dict with ``cell_deg``, ``nx``, ``ny``, ``radec``, ``freq``,
+            ``time_out``, ``l0`` and ``m0``. ``freq`` is scalar for an MFS image
+            and an array for a cube.
+        unit: BUNIT value.
+        gausspar: ``(3,)`` MFS beam in pixel units for the BMAJ/BMIN/BPA cards.
+        gausspars: ``(nband, 3)`` per-plane beams in pixel units.
+        beams_hdu: optional BEAMS table from :func:`beams_table`.
+        extra_hdr: extra header cards.
+        otype: output dtype.
+    """
+    hdr = set_wcs(
+        meta["cell_deg"],
+        meta["cell_deg"],
+        meta["nx"],
+        meta["ny"],
+        meta["radec"],
+        meta["freq"],
+        unit=unit,
+        ms_time=meta["time_out"],
+        time_is_unix=True,  # the .dt carries unix seconds (wiki D13)
+        gausspar=gausspar,
+        gausspars=gausspars,
+        l0=meta["l0"],
+        m0=meta["m0"],
+    )
+    for key, value in (extra_hdr or {}).items():
+        hdr[key] = value
+    save_fits(data, name, hdr, overwrite=True, dtype=otype, beams_hdu=beams_hdu, yx_order=True)

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -1,94 +1,109 @@
+"""Restoration helpers for the imager DataTree.
+
+Pure array functions: no tree I/O, no Ray, no FITS. ``core/restore.py`` owns
+reading the ``.dt``, writing products back and rendering FITS.
+
+Flux-scale conventions (wiki D22/D23): the band ``MODEL`` is intrinsic flux and
+the band ``RESIDUAL`` is apparent (once-attenuated) flux, so a restored image
+must say which scale it is on. Three are offered, keyed by their CLI letter.
+"""
+
 import numpy as np
-import ray
 
-from pfb_imaging.utils.misc import convolve2gaussres
-from pfb_imaging.utils.naming import xds_from_list
+from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam
 
-
-@ray.remote
-def rrestore_image(*args, **kwargs):
-    return restore_image(*args, **kwargs)
+# CLI letter -> DataTree variable name. The B prefix follows the tree's
+# convention for beam-attenuated quantities (BDIRTY, BRESIDUAL).
+PRODUCT_VARS = {"a": "BIMAGE", "i": "IMAGE", "k": "KIMAGE"}
 
 
-def restore_image(
-    ds_name,
-    model_name,
-    residual_name,
-    gaussparf,  # final desired resolution
-    nthreads=1,
-):
-    """
-    Writes restored image to dds.
-    Final resolution is specified by gaussparf.
-    The intrinsic resolution is stored in PSFPARSN in the dds.
-    The dataset will contain a new variable PSFPARSF with the final resolution in pixel units,
-    and the restored image will be in a variable called IMAGE.
-    Only the restored image's resolution will be updated.
+def clean_beam(psf, wsum):
+    """Fit the restoring Gaussian to a wsum-normalised PSF.
 
     Args:
-        ds_name: str or list of str
-            Name(s) of dataset(s) to read from and write to.
-        model_name: str
-            Name of variable in dataset containing model image.
-        residual_name: str
-            Name of variable in dataset containing residual image.
-        gaussparf: (ncorr, 3) array of floats
-            Desired final resolution (emaj, emin, pa) in units (pixels, pixels, radians).
-        nthreads: int
-            Number of threads to use for convolution.
+        psf: ``(ncorr, ny_psf, nx_psf)`` un-normalised PSF, as stored on a band
+            node. Pass the sum over bands to obtain the MFS restoring beam.
+        wsum: ``(ncorr,)`` matching weight sum. Pass the sum over the same bands.
 
     Returns:
-        gaussparf: (ncorr, 3) array of floats
-            Final resolution in pixel units.
-        bandid: int
-            Band ID of dataset.
-        timeid: int
-            Time ID of dataset.
+        ``(ncorr, 3)`` array of ``(emaj, emin, pa)`` in pixels, pixels, radians.
+        Rows are NaN where ``wsum`` is zero.
     """
-    # convolve residual
-    if not isinstance(ds_name, list):
-        ds_name = [ds_name]
-    drop_all_but = [model_name, residual_name, "PSFPARSN", "WSUM"]
-    dds = xds_from_list(ds_name, nthreads=nthreads, drop_all_but=drop_all_but)
-    if len(dds) > 1:
-        raise RuntimeError("Some thing went wrong. Done per band so should return a single dataset")
-    ds = dds[0]
-    if not isinstance(gaussparf, np.ndarray):
-        gaussparf = np.array(gaussparf)
-        if len(gaussparf.shape) == 1:
-            gaussparf = np.tile(gaussparf, (ds.corr.size, 1))
-        assert gaussparf.shape == (ds.corr.size, 3), "gaussparf should have shape (ncorr, 3)"
-    if model_name not in ds:
-        raise ValueError(f"Could not find {model_name} in dds")
-    if residual_name not in ds:
-        raise ValueError(f"Could not find {residual_name} in dds")
-    wsum = ds.WSUM.values
-    model = ds.get(model_name).values
-    _, nx, ny = model.shape
-    l_coord = -(nx // 2) + np.arange(nx)
-    m_coord = -(ny // 2) + np.arange(ny)
-    xx, yy = np.meshgrid(l_coord, m_coord, indexing="ij")
-    residual = ds.get(residual_name).values / wsum[:, None, None]
+    psf = np.asarray(psf)
+    wsum = np.asarray(wsum)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        norm = np.where(wsum[:, None, None] > 0, psf / wsum[:, None, None], 0.0)
+    return np.array(fitcleanbeam(norm, yx_order=True))
 
-    # units are (pixel, pixel, radians)
-    gausspari = ds.PSFPARSN.values
 
-    if np.allclose(gaussparf, gausspari):  # passed in in pixel units
-        # no convolution required
+def lowest_resolution(gausspars):
+    """Reduce per-band resolutions to the lowest-resolution one.
+
+    Args:
+        gausspars: ``(nband, ncorr, 3)`` in pixels, pixels, radians. NaN rows
+            (fully flagged bands) are skipped.
+
+    Returns:
+        ``(ncorr, 3)``: the largest major and minor axes over bands and the mean
+        position angle.
+    """
+    gausspars = np.asarray(gausspars, dtype=float)
+    out = np.empty(gausspars.shape[1:], dtype=float)
+    out[:, 0] = np.nanmax(gausspars[:, :, 0], axis=0)
+    out[:, 1] = np.nanmax(gausspars[:, :, 1], axis=0)
+    out[:, 2] = np.nanmean(gausspars[:, :, 2], axis=0)
+    return out
+
+
+def restore_products(model, residual, beam, gaussparf, gausspari=None, products=("k",), pb_min=0.1, nthreads=1):
+    """Build the restored images for one image grid.
+
+    Args:
+        model: ``(ncorr, ny, nx)`` intrinsic model, Jy/pixel, not wsum-scaled.
+        residual: ``(ncorr, ny, nx)`` apparent residual already normalised to
+            Jy/beam (the stored ``RESIDUAL`` divided by the matching ``WSUM``).
+        beam: ``(ncorr, ny, nx)`` effective response ``B/n`` (band node ``BEAM``).
+        gaussparf: ``(ncorr, 3)`` target resolution in pixels, pixels, radians.
+        gausspari: ``(ncorr, 3)`` intrinsic resolution of ``residual``, or None
+            to skip the residual reconvolution. None is correct whenever
+            ``gaussparf`` is the residual's own resolution.
+        products: iterable over ``"a"`` (apparent), ``"i"`` (intrinsic) and
+            ``"k"`` (intrinsic model plus apparent residual).
+        pb_min: beam floor below which the intrinsic image is zeroed, matching
+            the cutoff convention in ``utils/spi.py``.
+        nthreads: threads for the convolution FFTs.
+
+    Returns:
+        dict mapping each requested key to an ``(ncorr, ny, nx)`` array.
+    """
+    model = np.asarray(model)
+    residual = np.asarray(residual)
+    beam = np.asarray(beam)
+    gaussparf = np.asarray(gaussparf, dtype=float)
+    _, ny, nx = model.shape
+    # grids stay x-major; convolve2gaussres(yx_order=True) transposes the
+    # (corr, y, x) images onto them and back (wiki D19/D20)
+    x = -(nx // 2) + np.arange(nx)
+    y = -(ny // 2) + np.arange(ny)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+    kw = {"nthreads": nthreads, "pfrac": 0.2, "norm_kernel": False, "yx_order": True}
+
+    if gausspari is None or np.allclose(gaussparf, np.asarray(gausspari, dtype=float)):
         rconv = residual
     else:
-        # convolve with ratio of Gaussians
-        rconv = convolve2gaussres(
-            residual, xx, yy, gaussparf, nthreads=nthreads, gausspari=gausspari, pfrac=0.2, norm_kernel=False
-        )
-    # convolve with gaussparf to get final resolution
-    # TODO - this assumes the model's intrinsic resolution is zero, which is not really true
-    mconv = convolve2gaussres(model, xx, yy, gaussparf, nthreads=nthreads, pfrac=0.2, norm_kernel=False)
+        rconv = convolve2gaussres(residual, xx, yy, gaussparf, gausspari=np.asarray(gausspari, dtype=float), **kw)
 
-    mconv += rconv
-
-    ds = ds.assign({"IMAGE": (("corr", "x", "y"), mconv), "PSFPARSF": (("corr", "bpar"), gaussparf)})
-    # only write updates
-    ds = ds[["IMAGE", "PSFPARSF"]]
-    ds.to_zarr(ds_name[0], mode="a")
-    return gaussparf, ds.bandid, ds.timeid
+    out = {}
+    if "i" in products or "k" in products:
+        # the model is treated as having zero intrinsic resolution, which is
+        # the standard clean-component assumption
+        mconv = convolve2gaussres(model, xx, yy, gaussparf, **kw)
+    if "k" in products:
+        out["k"] = mconv + rconv
+    if "i" in products:
+        with np.errstate(invalid="ignore", divide="ignore"):
+            rint = np.where(beam > pb_min, rconv / beam, 0.0)
+        out["i"] = np.where(beam > pb_min, mconv + rint, 0.0)
+    if "a" in products:
+        out["a"] = convolve2gaussres(beam * model, xx, yy, gaussparf, **kw) + rconv
+    return out

--- a/tests/test_convolve2gaussres.py
+++ b/tests/test_convolve2gaussres.py
@@ -309,3 +309,25 @@ def test_convolve2gaussres_single_triple_still_shared():
 
     np.testing.assert_allclose(out[0], out[1], rtol=0, atol=1e-12)
     np.testing.assert_allclose(out[0], out[2], rtol=0, atol=1e-12)
+
+
+def test_convolve2gaussres_gausspari_shared_triple_matches_per_plane():
+    """A shared (3,) gausspari must give the same result as passing the
+    equivalent (nplane, 3) per-plane array with identical rows -- this is
+    the `gpi = gausspari if gausspari.ndim == 1 else gausspari[b]` branch.
+    """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
+    n = 48
+    img = np.zeros((3, n, n))
+    img[:, n // 2 + 3, n // 2 - 2] = 1.0
+    coord = -(n // 2) + np.arange(n)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    gaussparf = np.array([6.0, 3.0, 0.3])
+    gausspari_shared = np.array([2.0, 2.0, 0.0])
+    gausspari_per_plane = np.tile(gausspari_shared, (3, 1))
+
+    shared = convolve2gaussres(img, xx, yy, gaussparf, nthreads=1, pfrac=0.2, gausspari=gausspari_shared)
+    per_plane = convolve2gaussres(img, xx, yy, gaussparf, nthreads=1, pfrac=0.2, gausspari=gausspari_per_plane)
+
+    np.testing.assert_allclose(shared, per_plane, rtol=0, atol=1e-12)

--- a/tests/test_convolve2gaussres.py
+++ b/tests/test_convolve2gaussres.py
@@ -230,3 +230,82 @@ def test_fitcleanbeam(nx, ny, gpars):
     # if 0 and pi are equivalent
     padiff = np.abs(gpars[2] - gpars_fit[2])
     assert np.sin(padiff) < 1e-4
+
+
+def test_convolve2gaussres_yx_order_matches_manual_transpose():
+    """yx_order=True must equal transposing to x-major, convolving, and
+    transposing back. gaussian2d's PA is not transpose-invariant, so the
+    .dt's (corr, y, x) arrays (wiki D19/D20) cannot be fed in directly.
+    """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
+    nx, ny = 64, 48
+    img_xy = np.zeros((1, nx, ny))
+    img_xy[0, nx // 2 + 5, ny // 2 - 3] = 1.0
+    x = -(nx // 2) + np.arange(nx)
+    y = -(ny // 2) + np.arange(ny)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+    gpar = np.array([[6.0, 3.0, 0.7]])
+
+    ref = convolve2gaussres(img_xy, xx, yy, gpar, nthreads=1, pfrac=0.2)
+    got = convolve2gaussres(img_xy.transpose(0, 2, 1), xx, yy, gpar, nthreads=1, pfrac=0.2, yx_order=True)
+
+    assert got.shape == (1, ny, nx)
+    np.testing.assert_allclose(got, ref.transpose(0, 2, 1), rtol=0, atol=1e-10)
+
+
+def test_convolve2gaussres_yx_order_is_not_a_noop():
+    """On a square image the missing transpose does not raise, it silently
+    mirrors the position angle. Guard that the flag actually does something.
+    """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
+    n = 64
+    img = np.zeros((1, n, n))
+    img[0, n // 2 + 5, n // 2 - 3] = 1.0
+    coord = -(n // 2) + np.arange(n)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    gpar = np.array([[8.0, 3.0, 0.6]])  # elongated, PA off the axes
+
+    naive = convolve2gaussres(img, xx, yy, gpar, nthreads=1, pfrac=0.2)
+    yx = convolve2gaussres(img, xx, yy, gpar, nthreads=1, pfrac=0.2, yx_order=True)
+
+    assert not np.allclose(naive, yx)
+
+
+def test_convolve2gaussres_per_plane_gausspar_for_three_planes():
+    """A (3, 3) gaussparf is three per-plane triples, not one triple.
+    The old `len(gaussparf) == 3` test took the single-resolution branch for
+    any 3-plane input -- reachable via restore with 3 correlations.
+    """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
+    n = 48
+    img = np.zeros((3, n, n))
+    img[:, n // 2, n // 2] = 1.0
+    coord = -(n // 2) + np.arange(n)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    gpars = np.array([[4.0, 4.0, 0.0], [8.0, 8.0, 0.0], [12.0, 12.0, 0.0]])
+
+    out = convolve2gaussres(img, xx, yy, gpars, nthreads=1, pfrac=0.2)
+
+    # peak-normalised kernels: total flux scales with emaj*emin, so wider
+    # planes must integrate to more. Equal sums would mean one shared kernel.
+    sums = [float(out[i].sum()) for i in range(3)]
+    assert sums[0] < sums[1] < sums[2]
+
+
+def test_convolve2gaussres_single_triple_still_shared():
+    """A 1-D gaussparf stays the single-shared-resolution branch."""
+    from pfb_imaging.utils.misc import convolve2gaussres
+
+    n = 48
+    img = np.zeros((3, n, n))
+    img[:, n // 2, n // 2] = 1.0
+    coord = -(n // 2) + np.arange(n)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+
+    out = convolve2gaussres(img, xx, yy, np.array([6.0, 3.0, 0.3]), nthreads=1, pfrac=0.2)
+
+    np.testing.assert_allclose(out[0], out[1], rtol=0, atol=1e-12)
+    np.testing.assert_allclose(out[0], out[2], rtol=0, atol=1e-12)

--- a/tests/test_fits_tree.py
+++ b/tests/test_fits_tree.py
@@ -84,3 +84,80 @@ def test_dt2fits_orders_planes_by_bandid(tmp_path):
     # plane 0 is bandid 0 (value 1.0/10), not the lower-frequency bandid 1
     np.testing.assert_allclose(data[0].flat[0], 0.1, rtol=1e-5)
     np.testing.assert_allclose(data[1].flat[0], 0.3, rtol=1e-5)
+
+
+def _band_node_with_psfpars(timeid, freq_out, val, psfparsn, psfparsf, wsum=10.0, nx=8, bandid=0):
+    ds = _band_node(timeid, freq_out, val, wsum=wsum, nx=nx, bandid=bandid)
+    return ds.assign(
+        {
+            "PSFPARSN": (("corr", "bpar"), np.asarray(psfparsn, dtype=float)[None]),
+            "PSFPARSF": (("corr", "bpar"), np.asarray(psfparsf, dtype=float)[None]),
+        }
+    ).assign_coords({"bpar": ["BMAJ", "BMIN", "BPA"]})
+
+
+def test_dt2fits_drop_bands_excludes_from_cube_and_mfs(tmp_path):
+    """A dropped band leaves the cube entirely and contributes to no MFS
+    reduction -- image sum, wsum or freq. Zero planes are deliberately NOT
+    used; the resulting non-uniform frequency axis is issue #302's problem.
+    """
+    store = str(tmp_path / "drop.dt")
+    _band_node(0, 1.0e9, 1.0, bandid=0).to_zarr(store, group="band0000_time0000", mode="w")
+    _band_node(0, 1.1e9, 3.0, bandid=1).to_zarr(store, group="band0001_time0000", mode="a")
+    _band_node(0, 1.2e9, 5.0, bandid=2).to_zarr(store, group="band0002_time0000", mode="a")
+
+    outname = str(tmp_path / "img")
+    dt2fits(store, "DIRTY", outname, norm_wsum=True, do_mfs=True, do_cube=True, drop_bands=[1])
+
+    cube = afits.getdata(outname + "_dirty_time0.fits")
+    assert cube.shape == (1, 2, 8, 8)
+    np.testing.assert_allclose(cube[0, 0].flat[0], 1.0 / 10.0, rtol=1e-5)
+    np.testing.assert_allclose(cube[0, 1].flat[0], 5.0 / 10.0, rtol=1e-5)
+
+    mfs = np.squeeze(afits.getdata(outname + "_dirty_time0_mfs.fits"))
+    np.testing.assert_allclose(mfs.flat[0], (1.0 + 5.0) / 20.0, rtol=1e-5)
+
+    hdr = afits.getheader(outname + "_dirty_time0_mfs.fits")
+    assert hdr["DROPBAND"] == "1"
+    assert hdr["WSUM"] == 20.0
+
+
+def test_dt2fits_psfpars_var_selects_the_named_variable(tmp_path):
+    """The cube BEAMS table and BMAJ{i} cards come from psfpars_var, so
+    restore can publish the final resolution (PSFPARSF) rather than the
+    native one (PSFPARSN).
+    """
+    store = str(tmp_path / "pp.dt")
+    _band_node_with_psfpars(0, 1.0e9, 1.0, [2.0, 1.0, 0.0], [6.0, 5.0, 0.0], bandid=0).to_zarr(
+        store, group="band0000_time0000", mode="w"
+    )
+    _band_node_with_psfpars(0, 1.1e9, 3.0, [3.0, 1.5, 0.0], [6.0, 5.0, 0.0], bandid=1).to_zarr(
+        store, group="band0001_time0000", mode="a"
+    )
+
+    outname = str(tmp_path / "pp")
+    dt2fits(store, "DIRTY", outname, do_mfs=False, do_cube=True, psfpars_var="PSFPARSF")
+
+    hdr = afits.getheader(outname + "_dirty_time0.fits")
+    cell_deg = np.rad2deg(1.0e-6)
+    np.testing.assert_allclose(hdr["BMAJ1"], 6.0 * cell_deg, rtol=1e-5)
+    np.testing.assert_allclose(hdr["BMAJ2"], 6.0 * cell_deg, rtol=1e-5)
+
+
+def test_dt2fits_psfpars_var_defaults_to_native(tmp_path):
+    """Default behaviour is unchanged: PSFPARSN drives the beam cards."""
+    store = str(tmp_path / "ppn.dt")
+    _band_node_with_psfpars(0, 1.0e9, 1.0, [2.0, 1.0, 0.0], [6.0, 5.0, 0.0], bandid=0).to_zarr(
+        store, group="band0000_time0000", mode="w"
+    )
+    _band_node_with_psfpars(0, 1.1e9, 3.0, [3.0, 1.5, 0.0], [6.0, 5.0, 0.0], bandid=1).to_zarr(
+        store, group="band0001_time0000", mode="a"
+    )
+
+    outname = str(tmp_path / "ppn")
+    dt2fits(store, "DIRTY", outname, do_mfs=False, do_cube=True)
+
+    hdr = afits.getheader(outname + "_dirty_time0.fits")
+    cell_deg = np.rad2deg(1.0e-6)
+    np.testing.assert_allclose(hdr["BMAJ1"], 2.0 * cell_deg, rtol=1e-5)
+    np.testing.assert_allclose(hdr["BMAJ2"], 3.0 * cell_deg, rtol=1e-5)

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -476,3 +476,56 @@ def test_restore_zero_wsum_band_does_not_poison_mfs(tmp_path):
     assert np.isfinite(mfs).all()
     cube = afits.getdata(str(tmp_path / "fits" / "rt_I_main_kimage_time0.fits"))
     assert cube.shape[1] == 1  # only the live band
+
+
+# ---------------------------------------------------------------------------
+# clean-beam and FFT-residual products (Task 6)
+# ---------------------------------------------------------------------------
+
+
+def test_restore_clean_beam_images(tmp_path):
+    """c/C render the restoring Gaussian itself, peak 1 at the image centre."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kKcC")
+
+    mfs = np.squeeze(afits.getdata(str(tmp_path / "fits" / "rt_I_main_cpsf_time0_mfs.fits")))
+    assert mfs.shape == (64, 64)
+    np.testing.assert_allclose(mfs.max(), 1.0, rtol=1e-5)
+    assert np.unravel_index(int(np.argmax(mfs)), mfs.shape) == (32, 32)
+
+    cube = afits.getdata(str(tmp_path / "fits" / "rt_I_main_cpsf_time0.fits"))
+    assert cube.shape == (1, 2, 64, 64)
+    # band 1 has the wider native beam, so its Gaussian integrates to more
+    assert cube[0, 1].sum() > cube[0, 0].sum()
+
+
+def test_restore_fft_residual_products(tmp_path):
+    """f/F write magnitude and phase of the FFT of the residual."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kKfF")
+
+    for stem in ("abs_fft_residual", "phase_fft_residual"):
+        for tail in ("_time0_mfs.fits", "_time0.fits"):
+            assert (tmp_path / "fits" / f"rt_I_main_{stem}{tail}").exists(), stem + tail
+
+    # a flat residual transforms to a single central spike
+    mag = np.squeeze(afits.getdata(str(tmp_path / "fits" / "rt_I_main_abs_fft_residual_time0_mfs.fits")))
+    assert np.unravel_index(int(np.argmax(mag)), mag.shape) == (32, 32)
+    assert mag.max() > 100.0 * np.median(mag)
+
+    phase = np.squeeze(afits.getdata(str(tmp_path / "fits" / "rt_I_main_phase_fft_residual_time0_mfs.fits")))
+    assert np.all(np.abs(phase) <= np.pi + 1e-5)
+
+
+def test_restore_clean_beam_not_written_when_not_requested(tmp_path):
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kK")
+
+    assert not (tmp_path / "fits" / "rt_I_main_cpsf_time0_mfs.fits").exists()
+    assert not (tmp_path / "fits" / "rt_I_main_abs_fft_residual_time0_mfs.fits").exists()

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -81,6 +81,34 @@ def test_restore_products_preserves_position_angle(pa_deg):
     np.testing.assert_allclose(pa, np.deg2rad(pa_deg), atol=np.deg2rad(3.0))
 
 
+def test_restore_apparent_applies_the_beam_before_convolving():
+    """``a`` is ``(B*m) (x) G``, not ``B*(m (x) G)``.
+
+    Convolution does not commute with multiplication by a spatially varying
+    beam, so the two differ. Every other product test uses a constant beam,
+    under which they coincide -- this is the only guard against a future
+    "simplification" to ``beam * mconv + rconv``.
+    """
+    from pfb_imaging.utils.restoration import restore_products
+
+    nx = ny = 64
+    model = np.zeros((1, ny, nx))
+    model[0, ny // 2, nx // 2] = 1.0
+    residual = np.zeros((1, ny, nx))
+    # a beam that varies strongly across the restoring kernel's footprint
+    ramp = np.linspace(0.2, 1.0, nx)[None, None, :]
+    beam = np.broadcast_to(ramp, (1, ny, nx)).copy()
+    gpar = np.array([[8.0, 8.0, 0.0]])
+
+    out = restore_products(model, residual, beam, gpar, products=("a", "k"), pb_min=0.0)
+
+    shortcut = beam * out["k"]  # the wrong-but-plausible B*(m (x) G)
+    assert not np.allclose(out["a"], shortcut, rtol=1e-3, atol=1e-8)
+    # the correct form attenuates by the beam at the source, then spreads
+    peak = float(beam[0, ny // 2, nx // 2])
+    np.testing.assert_allclose(out["a"].max(), peak * out["k"].max(), rtol=0.05)
+
+
 def test_clean_beam_is_weighted_and_not_the_mean_of_per_band_fits():
     """G_mfs is the fit to the wsum-weighted average PSF, so a band carrying
     almost no weight barely moves it. The mean of the per-band fitted

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -9,6 +9,7 @@ integration test runs ``imager -> deconv -> restore`` against the
 
 import numpy as np
 import pytest
+import xarray as xr
 
 
 def test_restore_products_algebra():
@@ -122,3 +123,206 @@ def test_lowest_resolution_takes_max_axes_and_mean_pa():
 
     gp = np.array([[[6.0, 3.0, 0.2]], [[4.0, 5.0, 0.6]]])
     np.testing.assert_allclose(lowest_resolution(gp), np.array([[6.0, 5.0, 0.4]]))
+
+
+# ---------------------------------------------------------------------------
+# driver tests (Task 4): synthetic .dt, no MS or imager needed
+# ---------------------------------------------------------------------------
+
+
+def _write_restore_dt(
+    store,
+    nband=2,
+    nx=64,
+    ny=64,
+    beam_vals=(1.0, 0.5),
+    gpars=((6.0, 4.0, 0.3), (10.0, 6.0, 0.3)),
+    wsums=(10.0, 30.0),
+    model_flux=2.0,
+    with_psf=True,
+    with_model=True,
+):
+    """Synthetic single-time .dt carrying exactly the band variables restore reads.
+
+    PSF is stored un-normalised (shape x wsum) so PSF/WSUM is a peak-1 Gaussian
+    and fitcleanbeam recovers ``gpars[b]``, matching what core/imager.py writes.
+    RESIDUAL is likewise stored un-normalised.
+    """
+    from pfb_imaging.utils.misc import gaussian2d
+
+    nx_psf, ny_psf = 2 * nx, 2 * ny
+    xp = -(nx_psf // 2) + np.arange(nx_psf)
+    yp = -(ny_psf // 2) + np.arange(ny_psf)
+    xxp, yyp = np.meshgrid(xp, yp, indexing="ij")
+
+    for b in range(nband):
+        model = np.zeros((1, ny, nx))
+        model[0, ny // 2, nx // 2] = model_flux
+        data_vars = {
+            "DIRTY": (("corr", "y", "x"), np.zeros((1, ny, nx))),
+            "RESIDUAL": (("corr", "y", "x"), np.full((1, ny, nx), 0.01) * wsums[b]),
+            "BEAM": (("corr", "y", "x"), np.full((1, ny, nx), beam_vals[b])),
+            "WSUM": (("corr",), np.array([wsums[b]])),
+        }
+        if with_model:
+            data_vars["MODEL"] = (("corr", "y", "x"), model)
+        coords = {"corr": ["I"]}
+        if with_psf:
+            psf = gaussian2d(xxp, yyp, gpars[b], normalise=False).T[None]
+            data_vars["PSF"] = (("corr", "y_psf", "x_psf"), psf * wsums[b])
+            data_vars["PSFPARSN"] = (("corr", "bpar"), np.array([list(gpars[b])]))
+            coords["bpar"] = ["BMAJ", "BMIN", "BPA"]
+        xr.Dataset(
+            data_vars,
+            coords=coords,
+            attrs={
+                "bandid": b,
+                "timeid": 0,
+                "freq_out": 1.0e9 + b * 1.0e8,
+                "freq_nominal": 1.0e9 + b * 1.0e8,
+                "time_out": 1.7e9,
+                "ra": 0.0,
+                "dec": 0.0,
+                "l0": 0.0,
+                "m0": 0.0,
+                "cell_rad": 1.0e-6,
+                "niters": 1,
+            },
+        ).to_zarr(store, group=f"band{b:04d}_time0000", mode="a")
+
+
+def _run_restore(tmp_path, name="rt", **kwargs):
+    """Call the driver with the fixed plumbing arguments these tests share."""
+    from pfb_imaging.core.restore import restore as restore_core
+
+    restore_core(
+        str(tmp_path / name),
+        fits_output_folder=str(tmp_path / "fits"),
+        log_directory=str(tmp_path / "logs"),
+        nthreads=1,
+        **kwargs,
+    )
+
+
+def test_restore_writes_products_and_psfparsf(tmp_path):
+    """All three products land in the band nodes at native resolution, and
+    BIMAGE / BEAM == IMAGE -- the mosaic relation.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="aik")
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    for b in range(2):
+        ds = dt[f"band{b:04d}_time0000"].ds
+        for v in ("IMAGE", "BIMAGE", "KIMAGE", "PSFPARSF"):
+            assert v in ds, f"{v} missing from band {b}"
+        # no --gausspar: the final resolution is the native one
+        np.testing.assert_allclose(ds.PSFPARSF.values, ds.PSFPARSN.values, rtol=1e-6)
+        np.testing.assert_allclose(ds.BIMAGE.values / ds.BEAM.values, ds.IMAGE.values, rtol=1e-5, atol=1e-10)
+
+
+def test_restore_preserves_band_attrs(tmp_path):
+    """to_zarr(mode='a') replaces a group's attrs wholesale, so the driver must
+    re-stamp them (core/deconv.py:409-424). Losing bandid breaks every later read.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kK")
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    ds = dt["band0001_time0000"].ds
+    assert ds.attrs["bandid"] == 1
+    assert ds.attrs["timeid"] == 0
+    np.testing.assert_allclose(ds.attrs["freq_out"], 1.1e9)
+    np.testing.assert_allclose(ds.attrs["cell_rad"], 1.0e-6)
+    assert len(ds.attrs["psfparsf_mfs"]) == 3
+
+
+def test_restore_only_computes_requested_products(tmp_path):
+    """--outputs gates the compute and the storage, not just the FITS."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kK")
+
+    ds = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds
+    assert "KIMAGE" in ds
+    assert "IMAGE" not in ds
+    assert "BIMAGE" not in ds
+
+
+def test_restore_gausspar_homogenises_to_specified_resolution(tmp_path):
+    """--gausspar is in degrees; PSFPARSF must come back in pixel units."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+    cell_deg = np.rad2deg(1.0e-6)
+
+    _run_restore(tmp_path, outputs="kK", gausspar=(12.0 * cell_deg, 8.0 * cell_deg, 45.0))
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    for b in range(2):
+        pf = dt[f"band{b:04d}_time0000"].ds.PSFPARSF.values[0]
+        np.testing.assert_allclose(pf[0], 12.0, rtol=1e-4)
+        np.testing.assert_allclose(pf[1], 8.0, rtol=1e-4)
+        np.testing.assert_allclose(pf[2], np.deg2rad(45.0), rtol=1e-6)
+
+
+def test_restore_zero_gausspar_selects_lowest_resolution(tmp_path):
+    """--gausspar 0 0 0 homogenises to the lowest-resolution band."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kK", gausspar=(0.0, 0.0, 0.0))
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    for b in range(2):
+        pf = dt[f"band{b:04d}_time0000"].ds.PSFPARSF.values[0]
+        np.testing.assert_allclose(pf[0], 10.0, rtol=1e-6)  # max emaj over bands
+        np.testing.assert_allclose(pf[1], 6.0, rtol=1e-6)  # max emin over bands
+        np.testing.assert_allclose(pf[2], 0.3, rtol=1e-6)  # mean pa
+
+
+def test_restore_skips_zero_wsum_bands(tmp_path):
+    """A fully flagged band (WSUM == 0) must be skipped, not divided by.
+
+    Without the guard, `RESIDUAL / WSUM` yields inf/NaN which lands in the
+    stored products AND in the MFS accumulators, poisoning every other band's
+    MFS image. core/imager.py already emits such bands (freq_eff falls back to
+    freq_nominal when wsum_tot == 0).
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, wsums=(10.0, 0.0))
+
+    _run_restore(tmp_path, outputs="kK")
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    # the live band is restored and finite
+    live = dt["band0000_time0000"].ds
+    assert "KIMAGE" in live
+    assert np.isfinite(live.KIMAGE.values).all()
+    # the dead band is skipped entirely rather than written with NaNs
+    assert "KIMAGE" not in dt["band0001_time0000"].ds
+    # the live band's attrs still record the MFS beam, so the dead band did not
+    # poison the reduction (the MFS *image* is asserted finite in Task 5)
+    assert np.isfinite(np.asarray(live.attrs["psfparsf_mfs"], dtype=float)).all()
+
+
+def test_restore_errors_without_psf(tmp_path):
+    """A --no-psf imager tree cannot define a restoring beam."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, with_psf=False)
+
+    with pytest.raises(ValueError, match="--psf"):
+        _run_restore(tmp_path, outputs="kK")
+
+
+def test_restore_errors_without_model(tmp_path):
+    """Nothing to restore before pfb deconv has run."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, with_model=False)
+
+    with pytest.raises(ValueError, match="MODEL"):
+        _run_restore(tmp_path, outputs="kK")

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -529,3 +529,104 @@ def test_restore_clean_beam_not_written_when_not_requested(tmp_path):
 
     assert not (tmp_path / "fits" / "rt_I_main_cpsf_time0_mfs.fits").exists()
     assert not (tmp_path / "fits" / "rt_I_main_abs_fft_residual_time0_mfs.fits").exists()
+
+
+# ---------------------------------------------------------------------------
+# end-to-end integration (Task 8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(600)
+def test_restore_groundtruth(sky_truth, ms_name, tmp_path):
+    """imager -> deconv -> restore recovers the injected source fluxes.
+
+    Mirrors test_deconv_groundtruth's setup (single band, nthreads=1, so the
+    nband==1 Hessian/Psi pools stay on their in-process path within the session
+    cluster's num_cpus). Restore is asserted at the FITS level because that is
+    the product users consume.
+    """
+    from pathlib import Path
+
+    from pfb_imaging.core.deconv import deconv as deconv_core
+    from pfb_imaging.core.imager import imager as imager_core
+    from pfb_imaging.core.restore import restore as restore_core
+
+    outname = str(tmp_path / "gtrestore")
+    imager_core(
+        [Path(ms_name)],
+        outname,
+        channels_per_image=-1,
+        integrations_per_image=-1,
+        product="I",
+        nx=sky_truth.nx,
+        ny=sky_truth.ny,
+        cell_size=sky_truth.cell_size,
+        robustness=0.0,
+        fits_mfs=False,
+        fits_cubes=False,
+        overwrite=True,
+        keep_ray_alive=True,
+    )
+    deconv_core(
+        outname,
+        minor_cycle="sara",
+        opt_backend="primal-dual",
+        niter=5,
+        gamma=1.0,
+        eta=0.001,
+        rmsfactor=1.0,
+        init_factor=1.0,
+        l1_reweight_from=100,
+        bases=["self", "db1"],
+        nlevels=2,
+        positivity=1,
+        pd_tol=1e-6,
+        pd_maxit=5000,
+        cg_tol=1e-6,
+        cg_maxit=3000,
+        pm_tol=1e-4,
+        pm_maxit=200,
+        nthreads=1,
+        do_wgridding=True,
+        epsilon=1e-7,
+        fits_mfs=False,
+        fits_cubes=False,
+        verbosity=0,
+    )
+    restore_core(
+        outname,
+        outputs="aik",
+        nthreads=1,
+        fits_output_folder=str(tmp_path / "fits"),
+        log_directory=str(tmp_path / "logs"),
+    )
+
+    stem = str(tmp_path / "fits" / "gtrestore_I_main")
+    with afits.open(stem + "_kimage_time0_mfs.fits") as hdul:
+        img = np.squeeze(hdul[0].data).astype(np.float64)
+        hdr = hdul[0].header
+
+    # the header beam is the fit to the MFS PSF, in degrees
+    assert hdr["BMAJ"] > 0.0
+    assert hdr["BMAJ"] >= hdr["BMIN"]
+
+    # a restored point source integrates to its flux times the beam area in
+    # pixels; normalise by that to compare against the injected flux
+    cell_deg = np.rad2deg(sky_truth.cell_rad)
+    beam_area = np.pi * (hdr["BMAJ"] / cell_deg) * (hdr["BMIN"] / cell_deg) / (4.0 * np.log(2.0))
+    half = 6
+    for s in range(sky_truth.lpix.size):
+        ixm = sky_truth.nx // 2 - int(sky_truth.lpix[s])
+        iym = sky_truth.ny // 2 + int(sky_truth.mpix[s])
+        # FITS data is (y, x) so the model raster's (x, y) indices swap
+        box = img[iym - half : iym + half + 1, ixm - half : ixm + half + 1]
+        got = float(box.sum()) / beam_area
+        want = float(sky_truth.ref_flux[s])
+        assert abs(got - want) < 0.3 * want, f"source {s}: restored flux {got} vs {want}"
+
+    # all three products exist and the tree carries the restored variables
+    for var in ("bimage", "image", "kimage"):
+        assert (tmp_path / "fits" / f"gtrestore_I_main_{var}_time0_mfs.fits").exists()
+    dt = xr.open_datatree(outname + "_I.dt", engine="zarr", chunks=None)
+    node = next(n for n in dt.children if n.startswith("band"))
+    assert {"IMAGE", "BIMAGE", "KIMAGE", "PSFPARSF"} <= set(dt[node].ds.data_vars)

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -10,6 +10,7 @@ integration test runs ``imager -> deconv -> restore`` against the
 import numpy as np
 import pytest
 import xarray as xr
+from astropy.io import fits as afits
 
 
 def test_restore_products_algebra():
@@ -326,3 +327,124 @@ def test_restore_errors_without_model(tmp_path):
 
     with pytest.raises(ValueError, match="MODEL"):
         _run_restore(tmp_path, outputs="kK")
+
+
+# ---------------------------------------------------------------------------
+# FITS dispatch (Task 5)
+# ---------------------------------------------------------------------------
+
+
+def test_restore_writes_mfs_and_cube_fits(tmp_path):
+    """Every requested letter produces its file, with the case controlling
+    whether it is the MFS image or the cube.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="aAiIkKrR")
+
+    base = tmp_path / "fits" / "rt_I_main"
+    for var in ("bimage", "image", "kimage", "residual"):
+        assert (tmp_path / "fits" / f"rt_I_main_{var}_time0_mfs.fits").exists(), var
+        assert (tmp_path / "fits" / f"rt_I_main_{var}_time0.fits").exists(), var
+    cube = afits.getdata(str(base) + "_kimage_time0.fits")
+    assert cube.shape[1] == 2  # FREQ axis carries both bands
+    mfs = afits.getdata(str(base) + "_kimage_time0_mfs.fits")
+    assert mfs.shape[1] == 1  # MFS collapses the FREQ axis
+
+
+def test_restore_mfs_beam_is_fit_to_the_mfs_psf(tmp_path):
+    """BMAJ on the MFS image comes from the summed PSF, not from averaging the
+    per-band beams -- the correction issue #303 exists for.
+    """
+    from pfb_imaging.utils.restoration import clean_beam
+
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, gpars=((6.0, 6.0, 0.0), (18.0, 18.0, 0.0)))
+
+    _run_restore(tmp_path, outputs="kK")
+
+    hdr = afits.getheader(str(tmp_path / "fits" / "rt_I_main_kimage_time0_mfs.fits"))
+    cell_deg = np.rad2deg(1.0e-6)
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    psf_sum = sum(dt[f"band{b:04d}_time0000"].ds.PSF.values for b in range(2))
+    wsum = sum(dt[f"band{b:04d}_time0000"].ds.WSUM.values for b in range(2))
+    want = clean_beam(psf_sum, wsum)[0]
+
+    np.testing.assert_allclose(hdr["BMAJ"], want[0] * cell_deg, rtol=1e-4)
+
+
+def test_restore_cube_beams_come_from_psfparsf(tmp_path):
+    """Cube BMAJ{i} cards carry the final resolution, not the native one."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+    cell_deg = np.rad2deg(1.0e-6)
+
+    _run_restore(tmp_path, outputs="kK", gausspar=(20.0 * cell_deg, 20.0 * cell_deg, 0.0))
+
+    hdr = afits.getheader(str(tmp_path / "fits" / "rt_I_main_kimage_time0.fits"))
+    np.testing.assert_allclose(hdr["BMAJ1"], 20.0 * cell_deg, rtol=1e-4)
+    np.testing.assert_allclose(hdr["BMAJ2"], 20.0 * cell_deg, rtol=1e-4)
+
+
+def test_restore_mfs_residual_floor_is_the_weighted_mean(tmp_path):
+    """MFS restored = r_mfs + m_mfs (x) G_mfs, both wsum-weighted over kept
+    bands. Away from the source the restored image is just r_mfs, which for a
+    flat 0.01 residual in both bands must be flat 0.01.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, beam_vals=(1.0, 1.0))
+
+    _run_restore(tmp_path, outputs="kK")
+
+    got = np.squeeze(afits.getdata(str(tmp_path / "fits" / "rt_I_main_kimage_time0_mfs.fits")))
+    assert abs(float(got[0, 0]) - 0.01) < 1e-5
+    # the source is still there at the centre
+    assert float(got[32, 32]) > 0.01
+
+
+def test_restore_intrinsic_mfs_is_apparent_over_beam(tmp_path):
+    """The mosaic relation must survive the MFS reduction too: with a uniform
+    beam, IMAGE == BIMAGE / beam pixel for pixel.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, beam_vals=(0.5, 0.5))
+
+    _run_restore(tmp_path, outputs="ai")
+
+    app = np.squeeze(afits.getdata(str(tmp_path / "fits" / "rt_I_main_bimage_time0_mfs.fits")))
+    intr = np.squeeze(afits.getdata(str(tmp_path / "fits" / "rt_I_main_image_time0_mfs.fits")))
+    np.testing.assert_allclose(app / 0.5, intr, rtol=1e-4, atol=1e-8)
+    hdr = afits.getheader(str(tmp_path / "fits" / "rt_I_main_image_time0_mfs.fits"))
+    assert hdr["PBMIN"] == 0.1
+
+
+def test_restore_drop_bands_excludes_from_mfs_beam(tmp_path):
+    """A dropped band must leave the G_mfs PSF fit, not just the image sum."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, gpars=((6.0, 6.0, 0.0), (18.0, 18.0, 0.0)))
+    cell_deg = np.rad2deg(1.0e-6)
+
+    _run_restore(tmp_path, outputs="kK", drop_bands=[1])
+
+    hdr = afits.getheader(str(tmp_path / "fits" / "rt_I_main_kimage_time0_mfs.fits"))
+    # band 1 (the 18 px beam) is gone, so G_mfs is band 0's 6 px beam
+    np.testing.assert_allclose(hdr["BMAJ"], 6.0 * cell_deg, rtol=0.05)
+    cube = afits.getdata(str(tmp_path / "fits" / "rt_I_main_kimage_time0.fits"))
+    assert cube.shape[1] == 1  # dropped, not zeroed
+
+
+def test_restore_zero_wsum_band_does_not_poison_mfs(tmp_path):
+    """The Task 4 guard, asserted at the FITS level: a fully flagged band must
+    leave the MFS image finite.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, wsums=(10.0, 0.0))
+
+    _run_restore(tmp_path, outputs="kK")
+
+    mfs = afits.getdata(str(tmp_path / "fits" / "rt_I_main_kimage_time0_mfs.fits"))
+    assert np.isfinite(mfs).all()
+    cube = afits.getdata(str(tmp_path / "fits" / "rt_I_main_kimage_time0.fits"))
+    assert cube.shape[1] == 1  # only the live band

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,0 +1,124 @@
+"""Tests for ``pfb restore`` on the imager ``.dt`` DataTree (issue #303).
+
+Unit tests exercise the pure array functions in ``utils/restoration.py``.
+Driver tests build a synthetic ``.dt`` in-process (``_write_restore_dt``, no
+MS or imager needed), in the style of ``tests/test_fits_tree.py``. One
+integration test runs ``imager -> deconv -> restore`` against the
+``sky_truth`` fixture.
+"""
+
+import numpy as np
+import pytest
+
+
+def test_restore_products_algebra():
+    """The three products differ only in where the beam is applied.
+
+    With a spatially constant beam the closed forms collapse to scalar
+    relations, so the test pins the definitions rather than the numerics of
+    the convolution.
+    """
+    from pfb_imaging.utils.restoration import restore_products
+
+    nx = ny = 64
+    rng = np.random.default_rng(0)
+    model = np.zeros((1, ny, nx))
+    model[0, ny // 2, nx // 2] = 2.0
+    residual = rng.standard_normal((1, ny, nx)) * 0.01
+    beam = np.full((1, ny, nx), 0.5)
+    gpar = np.array([[4.0, 4.0, 0.0]])
+
+    out = restore_products(model, residual, beam, gpar, products=("a", "i", "k"), pb_min=0.1)
+
+    mconv = out["k"] - residual  # m (x) G, recovered from the mixed product
+    np.testing.assert_allclose(out["i"], mconv + residual / 0.5, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(out["a"], 0.5 * mconv + residual, rtol=0, atol=1e-10)
+    # the relation the mosaic case depends on
+    np.testing.assert_allclose(out["a"] / 0.5, out["i"], rtol=0, atol=1e-10)
+
+
+def test_restore_products_pb_min_zeroes_low_beam():
+    """The intrinsic image is zeroed below pb_min, following utils/spi.py:31."""
+    from pfb_imaging.utils.restoration import restore_products
+
+    nx = ny = 32
+    model = np.zeros((1, ny, nx))
+    model[0, ny // 2, nx // 2] = 1.0
+    residual = np.full((1, ny, nx), 0.1)
+    beam = np.ones((1, ny, nx))
+    beam[0, :, : nx // 2] = 0.05  # below the floor
+    gpar = np.array([[3.0, 3.0, 0.0]])
+
+    out = restore_products(model, residual, beam, gpar, products=("i",), pb_min=0.1)
+
+    assert np.all(out["i"][0, :, : nx // 2] == 0.0)
+    assert np.any(out["i"][0, :, nx // 2 :] != 0.0)
+
+
+@pytest.mark.parametrize("pa_deg", [20.0, 70.0])
+def test_restore_products_preserves_position_angle(pa_deg):
+    """Restoring a delta with an elliptical beam reproduces that beam on the
+    (y, x) raster. Dropping convolve2gaussres(yx_order=True) mirrors the PA
+    and this fails (wiki D19/D20).
+    """
+    from pfb_imaging.utils.misc import fitcleanbeam
+    from pfb_imaging.utils.restoration import restore_products
+
+    nx = ny = 128
+    gpar = np.array([[10.0, 4.0, np.deg2rad(pa_deg)]])
+    model = np.zeros((1, ny, nx))
+    model[0, ny // 2, nx // 2] = 1.0
+    residual = np.zeros((1, ny, nx))
+    beam = np.ones((1, ny, nx))
+
+    out = restore_products(model, residual, beam, gpar, products=("k",))
+
+    emaj, emin, pa = fitcleanbeam(out["k"] / out["k"].max(), yx_order=True)[0]
+    np.testing.assert_allclose(emaj, 10.0, rtol=0.05)
+    np.testing.assert_allclose(emin, 4.0, rtol=0.05)
+    np.testing.assert_allclose(pa, np.deg2rad(pa_deg), atol=np.deg2rad(3.0))
+
+
+def test_clean_beam_is_weighted_and_not_the_mean_of_per_band_fits():
+    """G_mfs is the fit to the wsum-weighted average PSF, so a band carrying
+    almost no weight barely moves it. The mean of the per-band fitted
+    Gaussians -- the legacy MFS beam -- is weight-blind and lands far away.
+    """
+    from pfb_imaging.utils.misc import gaussian2d
+    from pfb_imaging.utils.restoration import clean_beam
+
+    n = 128
+    coord = -(n // 2) + np.arange(n)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    shapes = [(6.0, 6.0, 0.0), (18.0, 18.0, 0.0)]
+    wsums = np.array([[100.0], [1.0]])
+    # stored PSFs are un-normalised (shape * wsum), as core/imager.py writes them
+    psfs = np.stack([w[0] * gaussian2d(xx, yy, g, normalise=False).T[None] for g, w in zip(shapes, wsums)])
+
+    per_band = np.stack([clean_beam(p, w) for p, w in zip(psfs, wsums)])
+    mfs = clean_beam(psfs.sum(axis=0), wsums.sum(axis=0))
+
+    np.testing.assert_allclose(per_band[0, 0, 0], 6.0, rtol=0.05)
+    np.testing.assert_allclose(per_band[1, 0, 0], 18.0, rtol=0.05)
+    # the heavily-weighted narrow band dominates the summed PSF
+    assert mfs[0, 0] < 8.0
+    # ... and that is nowhere near the weight-blind mean of the two fits (12.0)
+    assert abs(mfs[0, 0] - per_band[:, 0, 0].mean()) > 3.0
+
+
+def test_clean_beam_zero_wsum_is_nan_not_a_crash():
+    """A fully flagged band has wsum 0; the fit must degrade to NaN so the
+    caller's nanmax/nanmean skip it rather than dividing by zero.
+    """
+    from pfb_imaging.utils.restoration import clean_beam
+
+    psf = np.zeros((1, 32, 32))
+    out = clean_beam(psf, np.array([0.0]))
+    assert np.isnan(out).all()
+
+
+def test_lowest_resolution_takes_max_axes_and_mean_pa():
+    from pfb_imaging.utils.restoration import lowest_resolution
+
+    gp = np.array([[[6.0, 3.0, 0.2]], [[4.0, 5.0, 0.6]]])
+    np.testing.assert_allclose(lowest_resolution(gp), np.array([[6.0, 5.0, 0.4]]))

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -170,12 +170,18 @@ def _write_restore_dt(
     model_flux=2.0,
     with_psf=True,
     with_model=True,
+    ncorr=1,
 ):
     """Synthetic single-time .dt carrying exactly the band variables restore reads.
 
     PSF is stored un-normalised (shape x wsum) so PSF/WSUM is a peak-1 Gaussian
     and fitcleanbeam recovers ``gpars[b]``, matching what core/imager.py writes.
     RESIDUAL is likewise stored un-normalised.
+
+    ``ncorr > 1`` gives every correlation a *distinct* beam width (scaled by
+    ``1 + c``) so a product that silently collapses to correlation 0 is
+    detectable. Note deconv currently refuses multi-correlation trees, so this
+    path is reachable only by pointing restore at an existing variable.
     """
     from pfb_imaging.utils.misc import gaussian2d
 
@@ -184,22 +190,26 @@ def _write_restore_dt(
     yp = -(ny_psf // 2) + np.arange(ny_psf)
     xxp, yyp = np.meshgrid(xp, yp, indexing="ij")
 
+    def _gpar(b, c):
+        emaj, emin, pa = gpars[b]
+        return (emaj * (1 + c), emin * (1 + c), pa)
+
     for b in range(nband):
-        model = np.zeros((1, ny, nx))
-        model[0, ny // 2, nx // 2] = model_flux
+        model = np.zeros((ncorr, ny, nx))
+        model[:, ny // 2, nx // 2] = model_flux
         data_vars = {
-            "DIRTY": (("corr", "y", "x"), np.zeros((1, ny, nx))),
-            "RESIDUAL": (("corr", "y", "x"), np.full((1, ny, nx), 0.01) * wsums[b]),
-            "BEAM": (("corr", "y", "x"), np.full((1, ny, nx), beam_vals[b])),
-            "WSUM": (("corr",), np.array([wsums[b]])),
+            "DIRTY": (("corr", "y", "x"), np.zeros((ncorr, ny, nx))),
+            "RESIDUAL": (("corr", "y", "x"), np.full((ncorr, ny, nx), 0.01) * wsums[b]),
+            "BEAM": (("corr", "y", "x"), np.full((ncorr, ny, nx), beam_vals[b])),
+            "WSUM": (("corr",), np.full(ncorr, wsums[b])),
         }
         if with_model:
             data_vars["MODEL"] = (("corr", "y", "x"), model)
-        coords = {"corr": ["I"]}
+        coords = {"corr": ["I", "Q", "U", "V"][:ncorr]}
         if with_psf:
-            psf = gaussian2d(xxp, yyp, gpars[b], normalise=False).T[None]
+            psf = np.stack([gaussian2d(xxp, yyp, _gpar(b, c), normalise=False).T for c in range(ncorr)])
             data_vars["PSF"] = (("corr", "y_psf", "x_psf"), psf * wsums[b])
-            data_vars["PSFPARSN"] = (("corr", "bpar"), np.array([list(gpars[b])]))
+            data_vars["PSFPARSN"] = (("corr", "bpar"), np.array([list(_gpar(b, c)) for c in range(ncorr)]))
             coords["bpar"] = ["BMAJ", "BMIN", "BPA"]
         xr.Dataset(
             data_vars,
@@ -630,3 +640,31 @@ def test_restore_groundtruth(sky_truth, ms_name, tmp_path):
     dt = xr.open_datatree(outname + "_I.dt", engine="zarr", chunks=None)
     node = next(n for n in dt.children if n.startswith("band"))
     assert {"IMAGE", "BIMAGE", "KIMAGE", "PSFPARSF"} <= set(dt[node].ds.data_vars)
+
+
+def test_restore_multi_corr_products_keep_every_correlation(tmp_path):
+    """Nothing may silently collapse to correlation 0.
+
+    save_fits maps (ncorr, ny, nx) onto STOKES for an MFS image and
+    (nband, ncorr, ny, nx) onto STOKES/FREQ for a cube. The clean-beam images
+    previously hard-coded correlation 0 and a singleton corr axis, so a
+    2-correlation tree lost half its planes.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store, ncorr=2)
+
+    _run_restore(tmp_path, outputs="kKcC")
+
+    d = tmp_path / "fits"
+    # restored MFS image and cube
+    assert afits.getdata(str(d / "rt_I_main_kimage_time0_mfs.fits")).shape == (2, 1, 64, 64)
+    assert afits.getdata(str(d / "rt_I_main_kimage_time0.fits")).shape == (2, 2, 64, 64)
+    # clean-beam MFS image and cube
+    cpsf_mfs = afits.getdata(str(d / "rt_I_main_cpsf_time0_mfs.fits"))
+    assert cpsf_mfs.shape == (2, 1, 64, 64)
+    cpsf_cube = afits.getdata(str(d / "rt_I_main_cpsf_time0.fits"))
+    assert cpsf_cube.shape == (2, 2, 64, 64)
+    # the fixture gives correlation 1 a beam twice as wide, so its Gaussian
+    # integrates to ~4x more -- identical planes would mean a collapse to corr 0
+    assert cpsf_mfs[1, 0].sum() > 2.0 * cpsf_mfs[0, 0].sum()
+    assert cpsf_cube[1, 0].sum() > 2.0 * cpsf_cube[0, 0].sum()


### PR DESCRIPTION
Closes #303.

Ports `pfb restore` — the last `.dds` consumer — to the `.dt` DataTree, and answers the clean-beam question the issue raises.

## The clean beam

No imager change was needed: `core/imager.py` already writes per-band `PSFPARSN = fitcleanbeam(psf_sum / wsum_sum)`, the Gaussian fitted to the wsum-weighted average of every partition PSF in the band — exactly what the issue proposes. Restore reads it for cube planes, and applies the same reduction across bands for the MFS beam: `fitcleanbeam(Σ_b PSF_b / Σ_b WSUM_b)`.

This matters because `r_mfs = Σ_b r_b / Σ_b wsum_b` *literally has* that effective PSF, so the FITS `BMAJ`/`BMIN` are exact with no cross-band homogenisation. The previous MFS beam — the mean of the per-band fitted Gaussians — is a mean of fits to *different* PSFs, and is **weight-blind**: a band carrying 1% of the weight moves it as much as one carrying 99%.

A consequence worth knowing: the MFS restored image is **not** the weighted sum of the per-band restored images (they sit at different resolutions), so `dt2fits` cannot produce it and the driver computes it directly.

## Three flux scales (beyond the issue, but load-bearing for mosaics)

The band `MODEL` is intrinsic flux — the forward solve fits `V ≈ G(B·m)`, so the beam is on the degrid side (D22/D23) — while `RESIDUAL` is apparent, once-attenuated flux. Legacy `restore_image` added them directly. At a single field centre `B ≈ 1` and nobody noticed; across the multi-field mosaic that motivates this issue they are on different scales.

So restore now emits three separately-named products rather than one:

| Letter | Variable | Definition | Flux scale |
|---|---|---|---|
| `a`/`A` | `BIMAGE` | `(B̄·m) ⊗ G + r/wsum` | apparent throughout |
| `i`/`I` | `IMAGE` | `m ⊗ G + r/(wsum·B̄)`, zeroed below `--pb-min` | intrinsic throughout |
| `k`/`K` | `KIMAGE` | `m ⊗ G + r/wsum` | mixed (legacy), for visualisation |

`B̄` is the band node's stored `BEAM`, which is exactly the effective response of `Σ_p dirty_p / Σ_p wsum_p` — so `BIMAGE / B̄ = IMAGE` is an identity, not an approximation.

## Also in scope

- **`fFcC` reinstated** on `.dt` data (clean-beam image; magnitude and phase of the residual FFT). Both are derived or non-sky products, so they render straight to FITS rather than being stored.
- **Dispatch tidied**: one spec table replaces four copy-pasted `rdds2fits` blocks.
- **Ray removed** from restore — the work is FFT-bound with threaded ducc and the driver holds the cubes for the MFS anyway. `--nworkers` and `--ray-address` are gone.
- **Fully flagged bands (`WSUM == 0`) are skipped.** `RESIDUAL / WSUM` on a zero wsum put inf/NaN into the stored products *and* the MFS accumulators, poisoning every other band's MFS image. `core/imager.py` already emits such bands.
- **`convolve2gaussres` gained `yx_order`** (mirroring `fitcleanbeam`), because `gaussian2d`'s position angle is not transpose-invariant and the `.dt` is `(corr, y, x)` (D19/D20). Also fixes a latent bug there: `len(gaussparf) == 3` misread a 3-correlation per-plane array as a single shared triple.
- **`dt2fits` gained `drop_bands` and `psfpars_var`.** `drop_bands` excludes a band from the cube *and* every MFS reduction — including the `G_mfs` PSF fit, or a dropped band still sets the restoring beam.
- **Stale cab outputs fixed**: the `stimela_output` implicit paths omitted the `_time{t}` infix that `dds2fits`/`dt2fits` have always emitted, so they never resolved.

## Behaviour changes

- `--outputs` defaults to `kK` — the legacy product under a new letter, so a **default run is unchanged**.
- `--outputs i`/`I` **changes meaning**: same letter, now the intrinsic (primary-beam-corrected) image. A recipe naming it explicitly gets different output with no error.
- `--drop-bands` omits bands from cubes rather than zeroing them, which can leave a non-uniform FITS frequency axis. Restore warns and defers to #302.

## Testing

New `tests/test_restore.py` (27 tests): product algebra for all three scales, the `BIMAGE / B̄ == IMAGE` identity, a position-angle guard that fails if the `yx_order` transpose is dropped, the weighted-vs-mean-of-fits MFS beam, `--gausspar` homogenisation and lowest-resolution paths, `--drop-bands`, zero-wsum handling, header/BEAMS assertions, and error paths. Plus an end-to-end `imager → deconv → restore` ground truth against the `sky_truth` fixture asserting restored flux recovery at the FITS level.

`tests/test_convolve2gaussres.py` and `tests/test_fits_tree.py` extended for the new parameters.

Full suite: **575 passed**. `restore` is no longer untested reference code — `README.md` and `.claude/rules/architecture.md` updated accordingly.

Rationale recorded as wiki **D29**, including the trap that cost this branch a test: the argument for fitting the summed PSF must not be demonstrated with equally weighted Gaussians, because `fitcleanbeam` is an area-dominated L2 fit rather than a half-power width, so equal weights make the two definitions nearly coincide (12.33 vs 12.0). The divergence comes from weighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)