### PR TITLE
test: split fast and slow tests so the dev loop runs in 93s

### DIFF
--- a/.claude/rules/testing-and-ci.md
+++ b/.claude/rules/testing-and-ci.md
@@ -28,16 +28,46 @@ explicitly.
 ### arcae / python-casacore coexistence
 
 As of **arcae 0.5.2** (ratt-ru/arcae#211, #212) arcae and python-casacore coexist in one
-process. Run the whole suite as a single command:
+process, so there is one pytest session — no special placement for new tests, and no
+casacore-related import restrictions (the historical casacore-free discipline was retired —
+wiki design-decisions D14).
+
+### Fast by default, slow in CI
+
+`pyproject.toml`'s `addopts` carries `-m "not slow"`, so the bare command is the fast loop:
 
 ```bash
-uv run pytest -v tests/
+uv run pytest tests/          # fast loop: 557 tests, ~93 s
+uv run pytest -m slow tests/  # only the deselected 19, ~326 s
+uv run pytest -m "" tests/    # everything, ~386 s (what CI runs)
 ```
 
-`tests/test_imager.py` (arcae / `pfb imager`) and the casacore-based tests therefore run
-together in one pytest session, sharing the session Ray fixture. New tests need no special
-placement, and modules impose no casacore-related import restrictions (the historical
-casacore-free discipline was retired — wiki design-decisions D14).
+A command-line `-m` overrides the one in `addopts` (pytest keeps a single value, last wins).
+Both `ci.yml` and `publish.yml` therefore pass `-m ""` — a release must be gated on the whole
+suite. `ci.yml` also runs `pytest -m slow --collect-only` as a guard, so a broken override
+cannot silently drop the slow set everywhere at once (pytest exits 5 when a selection collects
+nothing).
+
+**Marking rule: a test is `slow` when its _cheapest_ parametrisation costs ≥2 s.** The
+"cheapest" qualifier is load-bearing. Several functions look expensive but are only carrying a
+one-off warm-up — JIT, beam-model load, Ray spin-up — attributed to whichever param ran first
+(`test_beam`: 4.40 s then 11 × 0.00 s; `test_psi`: 4.15 s then 23 × ~0.01 s). That cost is
+sticky to the *run*, not the test: marking such a function evicts its tests without removing
+the time, which simply reattaches to whatever runs next. Confirmed in practice — deselecting
+`test_hci_channels_per_bin_invariance_no_beam` pushed the hci warm-up onto
+`test_hci_produces_expected_output_structure`, which went from cheap to 10.19 s. Do not chase
+those; it is whack-a-mole.
+
+`addopts` also carries `--durations=10` so a genuinely newly-slow test surfaces in the fast
+loop's own output instead of quietly rotting there.
+
+**Do not make `conftest.manage_ray` opt-in to save its ~4.5 s.** No test calls Ray directly;
+that autouse fixture pre-seeds `ray.init` with a specific `runtime_env`
+(`worker_process_setup_hook`, and the `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` workaround `conftest.py`
+documents as a hang-cause), which the source-level `ray.init(ignore_reinit_error=True)` in
+`src/pfb_imaging/__init__.py` then attaches to. Opt-in means a test that needs Ray but forgets
+to request the fixture silently gets a differently-configured cluster, or hangs. The same
+reasoning rules out `pytest-xdist`: each worker would stand up its own Ray cluster.
 
 ## 2. Commit Messages
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,22 @@ jobs:
         if: env.SKIP_CHECKS != 'true'
         run: uv run pfb --help
 
+      # pyproject's addopts deselect `slow` so the local dev loop stays fast.
+      # CI is the only place the end-to-end pipeline tests run, so guard against
+      # that override silently collecting nothing.
+      - name: Check slow tests are collectable
+        if: env.SKIP_CHECKS != 'true'
+        run: |
+          # pytest exits 5 when a selection collects nothing. Checking the exit
+          # code rather than parsing output keeps this independent of the
+          # collection format, which addopts' --verbose alters.
+          if ! uv run --frozen pytest -m slow --collect-only tests/ > /dev/null; then
+            echo "::error::No slow tests collected - the 'slow' marker or the -m override is broken."
+            exit 1
+          fi
+
+      # -m "" overrides the `-m "not slow"` in pyproject's addopts, so CI runs
+      # the whole suite (fast + slow).
       - name: Run tests
         if: env.SKIP_CHECKS != 'true'
-        run: uv run --frozen pytest -v tests/
+        run: uv run --frozen pytest -v -m "" tests/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,7 +131,9 @@ jobs:
           export OPENBLAS_NUM_THREADS=1
           export NUMEXPR_NUM_THREADS=1
 
-          uv run --frozen pytest -v tests/
+          # -m "" overrides the `-m "not slow"` in pyproject's addopts: a release
+          # must be gated on the whole suite, not just the fast dev loop.
+          uv run --frozen pytest -v -m "" tests/
 
   # Only publish if quality checks and tests pass
   publish:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,13 @@ telemetry in the progress lines). Before touching pass 1/2 or debugging footprin
 uv run ruff format . && uv run ruff check . --fix
 ```
 
+**Tests are fast by default.** `pyproject.toml`'s `addopts` carries `-m "not slow"`, so
+`uv run pytest tests/` runs 557 tests in ~93 s. The 19 end-to-end pipeline tests
+(`*_groundtruth`, the imager/deconv/restore/hci drivers) are deselected and left to CI, which
+overrides with `-m ""`. Use `-m ""` locally before finishing a branch. A test earns the `slow`
+marker when its *cheapest* parametrisation costs ≥2 s — see `.claude/rules/testing-and-ci.md` §1
+for why "cheapest" matters and why chasing warm-up spikes is whack-a-mole.
+
 ## Working Effectively (notes for agents)
 
 Lessons from real debugging sessions in this repo — follow them; they are cheaper than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,12 +97,24 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "--verbose",
+    # Fast by default: the end-to-end pipeline tests are deselected so the
+    # development loop stays ~80s instead of ~400s. CI overrides with `-m ""`
+    # (a command-line -m wins over this one). Run everything locally the same
+    # way; `-m slow` runs only the deselected set.
+    "-m",
+    "not slow",
+    # Drift guard: surfaces a newly-slow test in the fast loop's own output
+    # instead of letting it quietly rot there.
+    "--durations=10",
 ]
 timeout = 300
 timeout_method = "thread"
 markers = [
-    "unit: Unit tests",
-    "integration: Integration tests",
+    # Applied when a test's *cheapest* parametrisation costs >=2s. The
+    # "cheapest" qualifier matters: several functions carry a one-off warm-up
+    # (JIT, beam-model load, Ray spin-up) on whichever param runs first, which
+    # is sticky to the run rather than the test -- marking those would evict
+    # tests without removing the cost.
     "slow: Tests that take more time to run",
 ]
 

--- a/tests/test_deconv.py
+++ b/tests/test_deconv.py
@@ -18,6 +18,7 @@ import pytest
 import xarray as xr
 
 
+@pytest.mark.slow
 def test_deconv_groundtruth(sky_truth, ms_name, tmp_path):
     """deconv on the noiseless predicted sky recovers the injected fluxes.
 
@@ -198,6 +199,7 @@ def _make_part(uvw, nrow, nchan, nx, ny, ny_psf, xo2, freq, nparts):
 
 
 @pytest.mark.timeout(120)
+@pytest.mark.slow
 def test_deconv_two_band_smoke(tmp_path):
     """Multi-band driver smoke test: regression guard for the nband>1 Ray deadlock.
 
@@ -281,6 +283,7 @@ def test_deconv_two_band_smoke(tmp_path):
 
 
 @pytest.mark.timeout(120)
+@pytest.mark.slow
 def test_band_workers_load_matches_driver_side(tmp_path):
     """Worker-side load_bands reproduces driver-side reads exactly.
 
@@ -354,6 +357,7 @@ def test_band_workers_load_matches_driver_side(tmp_path):
 
 
 @pytest.mark.timeout(120)
+@pytest.mark.slow
 def test_deconv_unequal_partition_counts(tmp_path):
     """Bands legitimately carry different partition counts (a fully flagged
     field chunk writes no scratch piece, so its band node has fewer part####

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -194,6 +194,7 @@ def test_make_fits_header_does_not_mutate_input():
     assert base == snapshot
 
 
+@pytest.mark.slow
 def test_hci_channels_per_bin_invariance_no_beam(ms_name, tmp_path):
     """channels_per_bin must not change hci output when no beam model is supplied.
 
@@ -321,6 +322,7 @@ def test_hci_rejects_existing_output_without_overwrite(ms_name, tmp_path):
     assert (Path(out) / "marker").exists()
 
 
+@pytest.mark.slow
 def test_hci_inject_transients(ms_name, ms_meta, tmp_path):
     """Injected transient lands at the expected pixel with the expected dynamic spectrum.
 

--- a/tests/test_hessian_approx.py
+++ b/tests/test_hessian_approx.py
@@ -185,6 +185,7 @@ def test_wgridder_conventions(center_offset):
     np.testing.assert_allclose(vis.imag, vis_explicit.imag, atol=1e-4)
 
 
+@pytest.mark.slow
 def test_inject_transient_fringe_wterm():
     """The transient-injection fringe in utils/stokes2im.stokes_image must be the
     wgridder forward model, so injected sources land at their true position.

--- a/tests/test_imager.py
+++ b/tests/test_imager.py
@@ -19,6 +19,7 @@ from numpy.testing import assert_allclose
 from pfb_imaging.core.imager import imager as imager_core
 
 
+@pytest.mark.slow
 def test_imager_writes_dt_tree(ms_name, tmp_path):
     """imager() runs both passes and writes a unified .dt DataTree plus FITS."""
     outname = str(tmp_path / "test_imager")
@@ -87,6 +88,7 @@ def test_imager_writes_dt_tree(ms_name, tmp_path):
     assert_allclose(bimg, num / den, rtol=1e-5, atol=1e-7)
 
 
+@pytest.mark.slow
 def test_scratch_retained_by_default(ms_name, tmp_path):
     """The pass-1 .scratch store is kept by default for re-gridding without re-read."""
     from daskms.fsspec_store import DaskMSStore  # casacore-free fsspec store
@@ -107,6 +109,7 @@ def test_scratch_retained_by_default(ms_name, tmp_path):
     assert DaskMSStore(outname + "_I.dt").exists()
 
 
+@pytest.mark.slow
 def test_imager_concat_row_collapses_time(ms_name, tmp_path):
     """concat_row=True collapses the time axis into one band node and agrees
     with concat_row=False on the MFS dirty.
@@ -192,6 +195,7 @@ def _peak_yx(da_2d):
     raise AssertionError(f"unexpected image dims {da_2d.dims}")
 
 
+@pytest.mark.slow
 def test_imager_groundtruth(sky_truth, ms_name, tmp_path):
     """Injected sources land at their (RA, Dec) through the FITS WCS, at the
     right flux; the .dt arrays agree via their dims names.
@@ -411,6 +415,7 @@ def test_stokes_vis_rephases_to_new_centre(sky_truth, ms_name, tmp_path):
     assert not np.allclose(new.UVW.values, ref.UVW.values)
 
 
+@pytest.mark.slow
 def test_imager_rephase_roundtrip(sky_truth, ms_name, tmp_path):
     """Rephasing to an offset phase_dir with target back at the original field
     centre reproduces the unrephased image -- compared projection-aware.
@@ -588,6 +593,7 @@ def test_imager_no_psf_quicklook(ms_name, tmp_path):
         deconv(outname, log_directory=str(tmp_path), nthreads=1)
 
 
+@pytest.mark.slow
 def test_imager_fits_per_partition(sky_truth, ms_name, tmp_path):
     """Per-partition sanity FITS: one file per computed variable per partition,
     with a WCS that puts the injected sources where they belong."""
@@ -675,6 +681,7 @@ def test_stokes_vis_beam_follows_effective_freq(ms_name, tmp_path):
     assert hi.BEAM.values.sum() < lo.BEAM.values.sum()
 
 
+@pytest.mark.slow
 def test_imager_effective_freq_uneven_bands(ms_name, tmp_path):
     """8 channels binned 3/3/2: the band-edge centres miss the true channel
     groups by 17-50 MHz. freq_out must track the channels actually gridded

--- a/tests/test_imager_pol.py
+++ b/tests/test_imager_pol.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import dask
 import dask.array as da
 import numpy as np
+import pytest
 import xarray as xr
 from daskms import xds_to_table
 from ducc0.wgridder.experimental import dirty2vis
@@ -21,6 +22,7 @@ from pfb_imaging.core.imager import imager as imager_core
 from pfb_imaging.operators.gridder import wgridder_conventions
 
 
+@pytest.mark.slow
 def test_imager_polproducts(ms_name, ms_meta, image_geometry, tmp_path):
     """A polarised point source is recovered in each Stokes product."""
     np.random.seed(420)

--- a/tests/test_pfb_solver.py
+++ b/tests/test_pfb_solver.py
@@ -316,6 +316,7 @@ def test_make_sara_sets_dictionary_nu():
     assert solver.reg.nu == len(bases)
 
 
+@pytest.mark.slow
 def test_make_sara_colocates_band_state():
     """Hess and Psi share one BandWorkerPool: one worker process per band.
 

--- a/tests/test_preconditioner_consistency.py
+++ b/tests/test_preconditioner_consistency.py
@@ -262,6 +262,7 @@ def _resid_peak(store):
 
 
 @pytest.mark.timeout(600)
+@pytest.mark.slow
 def test_deconv_unregularised_residual_keeps_descending(sky_truth, ms_name, tmp_path):
     """End-to-end: with rmsfactor=0 and positivity off the major cycle is the
     preconditioned Richardson above. On noiseless predicted vis (a

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -547,6 +547,7 @@ def test_restore_clean_beam_not_written_when_not_requested(tmp_path):
 
 
 @pytest.mark.timeout(600)
+@pytest.mark.slow
 def test_restore_groundtruth(sky_truth, ms_name, tmp_path):
     """imager -> deconv -> restore recovers the injected source fluxes.
 

--- a/tests/test_weight_data_cache.py
+++ b/tests/test_weight_data_cache.py
@@ -11,6 +11,8 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 SNIPPET = """
 import os
 os.environ["NUMBA_CACHE_DIR"] = {cache_dir!r}
@@ -51,6 +53,7 @@ def _nbc_count(cache_dir):
     return sum(1 for _, _, files in os.walk(cache_dir) for f in files if f.endswith(".nbc"))
 
 
+@pytest.mark.slow
 def test_weight_data_cross_process_cache(tmp_path):
     cache_dir = str(tmp_path / "numba_cache")
 


### PR DESCRIPTION
Splits the suite so normal development iterates fast and CI keeps catching regressions in the expensive end-to-end tests.

## Result

Measured on this branch, 576 tests, warm caches:

| command | result | wall |
|---|---|---|
| `uv run pytest tests/` | 557 passed, 19 deselected | **93s** (was 397s) |
| `uv run pytest -m slow tests/` | 19 passed, 557 deselected | 326s |
| `uv run pytest -m "" tests/` (CI) | **576 passed** | 386s |

The full-suite count matches the pre-change baseline exactly, so no coverage is lost.

## How

`pyproject.toml`'s `addopts` gains `-m "not slow"`, so the bare command is the fast loop. A command-line `-m` overrides it (pytest keeps a single value, last wins), which is how CI runs everything.

The 19 deselected tests are the end-to-end pipeline drivers — `test_deconv_groundtruth` (66.7s), `test_restore_groundtruth` (63.7s), `test_deconv_unregularised_residual_keeps_descending` (61.4s), and the imager/hci/deconv drivers. The top 3 alone were 48% of total runtime.

## The marking rule, and why it has a qualifier

**A test is `slow` when its _cheapest_ parametrisation costs ≥2s.**

"Cheapest" is load-bearing. Several functions look expensive but only carry a one-off warm-up — JIT, beam-model load, Ray spin-up — attributed to whichever param happened to run first:

| function | params | breakdown |
|---|---|---|
| `test_beam` | 12 | 4.40s, then 11 × 0.00s |
| `test_psi` | 24 | 4.15s, then 23 × ~0.01s |
| `test_imager_precision_is_uniform` | 2 | 5.19s, then 0.05s |

That cost is sticky to the *run*, not the test. Marking those would evict 38 tests without removing the time.

This was confirmed after the split rather than merely predicted: deselecting `test_hci_channels_per_bin_invariance_no_beam` pushed the hci warm-up onto `test_hci_produces_expected_output_structure`, which went from cheap to **10.19s**. Chasing it is whack-a-mole, so the rule and its evidence are documented in `.claude/rules/testing-and-ci.md` instead of being left to be rediscovered.

## Two things worth reviewer attention

- **`publish.yml` also needed the override.** It gates PyPI publishing on pytest. Without `-m ""`, a release would have shipped with the end-to-end tests silently deselected.
- **`ci.yml` guards the override** with `pytest -m slow --collect-only`, relying on pytest's exit 5 ("no tests collected"). An earlier output-parsing version returned 0 and would have failed CI on every run — `addopts` carries `--verbose`, so `-q` nets to the tree format, not flat ids.

## Deliberately not done

Making `conftest.manage_ray` opt-in (~4.5s) and `pytest-xdist`. No test calls Ray directly; that autouse fixture pre-seeds `ray.init` with a specific `runtime_env` (including the `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` workaround `conftest.py` documents as a hang-cause), which the source-level `ray.init(ignore_reinit_error=True)` then attaches to. Opt-in means a test that forgets to request it silently gets a differently-configured cluster, or hangs — 6% of runtime against a silent-hang failure mode. Same reasoning rules out xdist: each worker would stand up its own Ray cluster. Both are documented in the rules file.

`CONTAINER_IMAGE` is left at `dev-0.1.0`: this is test-infrastructure only, no CLI or cab surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)