### PR TITLE
Frequency-correlated preconditioner, closed-form convolution ratio, Loewner restoring beam

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -139,7 +139,9 @@ scratch beam `("corr", "m_beam", "l_beam")`; ducc's x-major world exists only be
 `.T` views at the wgridder call sites (wiki design-decisions D19/D20).
 `MODEL`/`RESIDUAL`/`NOISE` are added later by the `deconv` consumer, and
 `IMAGE`/`BIMAGE`/`KIMAGE` plus `PSFPARSF` by the `restore` consumer (the intrinsic,
-apparent and mixed flux scales — wiki D29).
+apparent and mixed flux scales — wiki D29), and optionally `CRESIDUAL` (`--outputs s`/`S`),
+the residual convolved to the restoring resolution — apparent, pre-beam-division, and the
+only record of what the resolution change did to the residual (wiki D33).
 
 **Access layer — native DataTree only.** Use `xr.open_datatree(store)`,
 `ds.to_zarr(store, group="band…/part…", mode="a")`, and `dt.children` directly. Do **not** add

--- a/.claude/rules/testing-and-ci.md
+++ b/.claude/rules/testing-and-ci.md
@@ -37,9 +37,9 @@ wiki design-decisions D14).
 `pyproject.toml`'s `addopts` carries `-m "not slow"`, so the bare command is the fast loop:
 
 ```bash
-uv run pytest tests/          # fast loop: 557 tests, ~93 s
-uv run pytest -m slow tests/  # only the deselected 19, ~326 s
-uv run pytest -m "" tests/    # everything, ~386 s (what CI runs)
+uv run pytest tests/          # fast loop: 593 tests, ~125 s
+uv run pytest -m slow tests/  # only the deselected 22, ~400 s
+uv run pytest -m "" tests/    # everything, ~528 s (what CI runs)
 ```
 
 A command-line `-m` overrides the one in `addopts` (pytest keeps a single value, last wins).

--- a/.claude/rules/testing-and-ci.md
+++ b/.claude/rules/testing-and-ci.md
@@ -38,8 +38,8 @@ wiki design-decisions D14).
 
 ```bash
 uv run pytest tests/          # fast loop: 593 tests, ~125 s
-uv run pytest -m slow tests/  # only the deselected 22, ~400 s
-uv run pytest -m "" tests/    # everything, ~528 s (what CI runs)
+uv run pytest -m slow tests/  # only the deselected 23, ~440 s
+uv run pytest -m "" tests/    # everything, ~570 s (what CI runs)
 ```
 
 A command-line `-m` overrides the one in `addopts` (pytest keeps a single value, last wins).

--- a/.claude/rules/testing-and-ci.md
+++ b/.claude/rules/testing-and-ci.md
@@ -37,7 +37,7 @@ wiki design-decisions D14).
 `pyproject.toml`'s `addopts` carries `-m "not slow"`, so the bare command is the fast loop:
 
 ```bash
-uv run pytest tests/          # fast loop: 595 tests, ~127 s
+uv run pytest tests/          # fast loop: 616 tests, ~122 s
 uv run pytest -m slow tests/  # only the deselected 27, ~450 s
 uv run pytest -m "" tests/    # everything, ~570 s (what CI runs)
 ```

--- a/.claude/rules/testing-and-ci.md
+++ b/.claude/rules/testing-and-ci.md
@@ -37,8 +37,8 @@ wiki design-decisions D14).
 `pyproject.toml`'s `addopts` carries `-m "not slow"`, so the bare command is the fast loop:
 
 ```bash
-uv run pytest tests/          # fast loop: 593 tests, ~125 s
-uv run pytest -m slow tests/  # only the deselected 23, ~440 s
+uv run pytest tests/          # fast loop: 595 tests, ~127 s
+uv run pytest -m slow tests/  # only the deselected 27, ~450 s
 uv run pytest -m "" tests/    # everything, ~570 s (what CI runs)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,17 @@ rediscovery:
   stats `R GB` column shows ~0); only compare wall times at matching cache state.
 * **One mechanism per commit,** with the measured before/after in the commit message. It keeps
   cluster-run bisection possible when a change must be re-litigated.
+* **`gh issue view` and `gh pr edit` are broken on this machine — use `gh api` instead.** The
+  system `gh` is Ubuntu's 2.46.0, which asks GraphQL for the Projects-classic `projectCards`
+  field; the API has hard-errored on that since the May 2024 sunset, so both commands die with
+  `GraphQL: Projects (classic) is being deprecated … (repository.pullRequest.projectCards)`.
+  Upstream feature-detects v1 projects from **2.71.0** (`issue view`) and **2.73.0** (`pr edit`),
+  but the machine deliberately stays on the distro package, so treat this as permanent. It is
+  the client, not the repo — it reproduces against `cli/cli`. Reach for REST:
+  `gh api repos/ratt-ru/pfb-imaging/issues/<n> --jq '{title,state,body}'` to read an issue, and
+  `gh api -X PATCH repos/ratt-ru/pfb-imaging/pulls/<n> --input body.json` (a `{"body": …}` file,
+  so markdown survives shell quoting) to edit a PR. `gh pr view`/`list`/`checks`/`create`/`merge`
+  and every `gh api` call are unaffected, as is CI — both workflow uses are already `gh api`.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ uv run ruff format . && uv run ruff check . --fix
 ```
 
 **Tests are fast by default.** `pyproject.toml`'s `addopts` carries `-m "not slow"`, so
-`uv run pytest tests/` runs 595 tests in ~127 s. The 27 deselected tests are the end-to-end
+`uv run pytest tests/` runs 616 tests in ~122 s. The 27 deselected tests are the end-to-end
 pipeline ones (`*_groundtruth`, the imager/deconv/restore/hci drivers) plus a few whose cost is
 Ray actor startup or a dense operator build (the `_build_hess` preset-wiring pair, the
 frequency-prior fixed-point guard and the frequency-prior spectrum guards). They are left to CI, which overrides with `-m ""`. Use

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,9 @@ uv run ruff format . && uv run ruff check . --fix
 `uv run pytest tests/` runs 593 tests in ~125 s. The 23 deselected tests are the end-to-end
 pipeline ones (`*_groundtruth`, the imager/deconv/restore/hci drivers) plus a few whose cost is
 Ray actor startup or a dense operator build (the `_build_hess` preset-wiring pair, the
-frequency-prior fixed-point guard). They are left to CI, which overrides with `-m ""`. Use `-m ""` locally before finishing a branch. A test earns the `slow`
-marker when its *cheapest* parametrisation costs ≥2 s — see `.claude/rules/testing-and-ci.md` §1
+frequency-prior fixed-point guard). They are left to CI, which overrides with `-m ""`. Use
+`-m ""` locally before finishing a branch — not per-task during development. A test earns the
+`slow` marker when its *cheapest* parametrisation costs ≥2 s — see `.claude/rules/testing-and-ci.md` §1
 for why "cheapest" matters and why chasing warm-up spikes is whack-a-mole.
 
 ## Working Effectively (notes for agents)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,10 @@ uv run ruff format . && uv run ruff check . --fix
 ```
 
 **Tests are fast by default.** `pyproject.toml`'s `addopts` carries `-m "not slow"`, so
-`uv run pytest tests/` runs 557 tests in ~93 s. The 19 end-to-end pipeline tests
-(`*_groundtruth`, the imager/deconv/restore/hci drivers) are deselected and left to CI, which
-overrides with `-m ""`. Use `-m ""` locally before finishing a branch. A test earns the `slow`
+`uv run pytest tests/` runs 593 tests in ~125 s. The 22 deselected tests are the end-to-end
+pipeline ones (`*_groundtruth`, the imager/deconv/restore/hci drivers) plus a few whose cost is
+Ray actor startup or a dense operator build (the `_build_hess` preset-wiring pair, the
+frequency-prior fixed-point guard). They are left to CI, which overrides with `-m ""`. Use `-m ""` locally before finishing a branch. A test earns the `slow`
 marker when its *cheapest* parametrisation costs ≥2 s — see `.claude/rules/testing-and-ci.md` §1
 for why "cheapest" matters and why chasing warm-up spikes is whack-a-mole.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,10 @@ uv run ruff format . && uv run ruff check . --fix
 ```
 
 **Tests are fast by default.** `pyproject.toml`'s `addopts` carries `-m "not slow"`, so
-`uv run pytest tests/` runs 593 tests in ~125 s. The 23 deselected tests are the end-to-end
+`uv run pytest tests/` runs 595 tests in ~127 s. The 27 deselected tests are the end-to-end
 pipeline ones (`*_groundtruth`, the imager/deconv/restore/hci drivers) plus a few whose cost is
 Ray actor startup or a dense operator build (the `_build_hess` preset-wiring pair, the
-frequency-prior fixed-point guard). They are left to CI, which overrides with `-m ""`. Use
+frequency-prior fixed-point guard and the frequency-prior spectrum guards). They are left to CI, which overrides with `-m ""`. Use
 `-m ""` locally before finishing a branch — not per-task during development. A test earns the
 `slow` marker when its *cheapest* parametrisation costs ≥2 s — see `.claude/rules/testing-and-ci.md` §1
 for why "cheapest" matters and why chasing warm-up spikes is whack-a-mole.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ uv run ruff format . && uv run ruff check . --fix
 ```
 
 **Tests are fast by default.** `pyproject.toml`'s `addopts` carries `-m "not slow"`, so
-`uv run pytest tests/` runs 593 tests in ~125 s. The 22 deselected tests are the end-to-end
+`uv run pytest tests/` runs 593 tests in ~125 s. The 23 deselected tests are the end-to-end
 pipeline ones (`*_groundtruth`, the imager/deconv/restore/hci drivers) plus a few whose cost is
 Ray actor startup or a dense operator build (the `_build_hess` preset-wiring pair, the
 frequency-prior fixed-point guard). They are left to CI, which overrides with `-m ""`. Use `-m ""` locally before finishing a branch. A test earns the `slow`

--- a/docs/wiki/deconv-primer.md
+++ b/docs/wiki/deconv-primer.md
@@ -3,8 +3,8 @@ type: Domain Primer
 title: Deconvolution primer — the PFB framework, math to code
 description: Maps the preconditioned forward-backward algorithm, the SARA prior and their numerical conventions onto the pfb deconv code, including the constants that break convergence when wrong.
 tags: [deconvolution, sara, primal-dual, forward-backward, protocols, conventions]
-timestamp: 2026-07-31T00:00:00Z
-last_verified_commit: e348d68
+timestamp: 2026-08-07T13:53:02Z
+last_verified_commit: 78de0cf
 ---
 
 # Deconvolution primer — the PFB framework, math to code
@@ -25,7 +25,9 @@ cycle (`core/deconv.py`):
    beam-attenuated gradient residual the driver passes (D23). `forward()` consumes
    this cache, NOT its own argument — calling `forward()` without `first()` raises.
 2. **forward** — `update ≈ H⁻¹ bresidual` by per-band conjugate gradients
-   (`opt/pcg.PCG` → in-worker CG on `HessianTree`). The rhs is the
+   (`opt/pcg.PCG` → in-worker CG on `HessianTree`). **Band-parallel only when no
+   frequency prior is set**: `--gp-length-scale` couples the bands through `M`, and
+   `HessTreeRay.cg` then runs a cube-level CG on the driver instead (D30). The rhs is the
    **beam-attenuated gradient** `BRESIDUAL/wsum = Σ_p B_p·r_p / wsum` — the
    Hessian applies the beam on both sides, so the data-term gradient carries an
    outer per-partition beam (legacy sara's `residual *= beam`; D23). The

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -936,7 +936,8 @@ update it (and this page's `last_verified_commit`) in the same session.
   `src/pfb_imaging/core/deconv.py` (`_M_OPTS`, `_m_signature`, `_cached_hess_norm`);
   `src/pfb_imaging/cli/deconv.py`; `tests/test_freq_precision.py`,
   `tests/test_hess_tree_ray.py`, `tests/test_deconv_hess_norm_cache.py`,
-  `tests/test_pfb_solver.py`, `tests/test_preconditioner_consistency.py`.
+  `tests/test_pfb_solver.py`, `tests/test_preconditioner_consistency.py`,
+  `tests/test_deconv.py::test_deconv_driver_runs_with_the_frequency_prior`.
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-07T13:53:02Z
-last_verified_commit: 78de0cf
+timestamp: 2026-08-12T14:10:00Z
+last_verified_commit: a07eb8a
 ---
 
 # Design decisions, known debt and recurring gotchas
@@ -904,14 +904,36 @@ update it (and this page's `last_verified_commit`) in the same session.
   - **The forward CG moves from band-parallel in-worker to cube-level on the driver**
     (`HessTreeRay.cg` branches on the prior). The FFT work is unchanged and still happens
     in the workers; only `cg_maxit` round trips are added, against the `pd_maxit` the
-    backward step already pays per major cycle.
+    backward step already pays per major cycle. **Measured cost is not negligible:** on
+    `subset_withbeam_I.dt` (3 bands, 750², 3 partitions/band) a `max_gamma` power
+    iteration — one exact sweep plus one CG solve — went **28 s → 115 s (4.1×)**. The
+    exact sweep is common to both, so the whole difference is the CG round trips.
   - `λmax(D^½C⁻¹ₙD^½) = λmax(D)` **exactly**, so `λmax(M)`, `hess_norm` and the
     primal-dual step sizes are unchanged. Pinned by
     `test_prior_stats_report_the_spectrum_and_its_contribution_to_m`.
   - `λmin(M)` drops by up to `gp_cap`, eroding the stable `γ`. The erosion is bounded by
     the `η` fraction of `v'Mv` along the maximising direction — D26 measured 21% for the
-    binding mode, giving `14.7 → 18.2` (24%) at `gp_cap=10`, not 10×. **Measure with
+    binding mode, predicting `14.7 → 18.2` (24%) at `gp_cap=10`, not 10×.
+    **Measured** on `subset_withbeam_I.dt` at `--eta 1e-3 --gp-length-scale 0.5
+    --gp-cap 10` (precision spectrum `[0.107, 1.000]`, i.e. the cap fully saturated):
+    `λmax(M⁻¹H_exact)` **14.48 → 17.15 (+18.5%)**, so `γ` must shrink 15.6%
+    (`0.124 → 0.105`). The bound held and was slightly pessimistic. `λmax(M)` was
+    **unchanged (1.654 → 1.667, +0.8%, within the power-method tolerance)** — the
+    empirical confirmation of the `prec.max()` normalisation. **Measure with
     `scripts/max_gamma.py` before raising the cap.**
+  - **The erosion lands in a mode the solver does not travel in, and the step it does
+    take gets longer.** The maximising eigenvector stayed pinned at the field edge but
+    moved to a much rougher spatial mode (high-frequency power fraction 0.49 → 0.83,
+    `η`'s share of `v'Mv` there 21.1% → 12.7%), while the Rayleigh quotients along the
+    stored `UPDATE` and `DIRTY` — the practically binding directions — were unchanged
+    (0.798 → 0.800, 0.819 → 0.820). Solving `u = M⁻¹·BRESIDUAL` both ways on the same rhs:
+    the update rotates **28.8°**, its norm grows **1.62×**, and per band the gain is
+    1.54 / 1.57 / **1.74** ascending in frequency — largest at the top of the band, which
+    is exactly the symptom #307 reported. Net of the 15.6% `γ` cut that is **≈1.37×
+    effective step overall and ≈1.47× in the top band.** The update's power moves into
+    the smoothest frequency eigenmode (41% → 59%) and out of the roughest (25% → 9%), so
+    genuinely rough spectra are approached *more slowly*; by D22 that is a rate effect,
+    never a bias.
   - The driver-side remainder is **negative** semi-definite (`C⁻¹ₙ`'s eigenvalues are in
     `(0, 1]`); the total operator is still symmetric positive definite, so CG applies, but
     nothing may assume that term alone is PSD.
@@ -937,7 +959,9 @@ update it (and this page's `last_verified_commit`) in the same session.
   `src/pfb_imaging/cli/deconv.py`; `tests/test_freq_precision.py`,
   `tests/test_hess_tree_ray.py`, `tests/test_deconv_hess_norm_cache.py`,
   `tests/test_pfb_solver.py`, `tests/test_preconditioner_consistency.py`,
-  `tests/test_deconv.py::test_deconv_driver_runs_with_the_frequency_prior`.
+  `tests/test_deconv.py::test_deconv_driver_runs_with_the_frequency_prior`;
+  `scripts/max_gamma.py --gp-length-scale/--gp-cap` (the measurements above, on
+  `subset_withbeam_I.dt`, `--eta 1e-3`, 11 vs 9 power iterations to `--tol 5e-3`).
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-12T17:05:00Z
-last_verified_commit: a07eb8a
+timestamp: 2026-08-15T12:00:00Z
+last_verified_commit: eb1bc6d
 ---
 
 # Design decisions, known debt and recurring gotchas
@@ -1021,6 +1021,52 @@ update it (and this page's `last_verified_commit`) in the same session.
   `scripts/profile_freq_correlated_hessian.py` (the cost decomposition above);
   `src/pfb_imaging/operators/gauss.py` (`eta_freq_mul`), `tests/test_eta_freq_mul.py`.
 
+### D31 — Resolution changes use the closed-form Gaussian transform ratio, never a sampled division
+
+- **Context:** `convolve2gaussres` took an image from resolution `gausspari` to `gaussparf`
+  by FFT-ing both sampled `gaussian2d` kernels and dividing (`convkernhat[msk] =
+  gausskernhat[msk] / thiskernhat[msk]`, masked only by `> 0.0`). Issue #312 found this
+  displacing sources: a delta at (170, 260) restored to (146, 260), with −0.81 of peak in
+  ringing. It reaches users through `restore_products` whenever a restoring resolution is
+  asked for — `pfb restore --gausspar` and the lowest-resolution mode.
+- **Decision:** the ratio of two Gaussian transforms is itself a Gaussian, so write it
+  down: `Kf(k)/Ki(k) = sqrt(|Σf|/|Σi|)·exp(−2π²·kᵀ(Σf−Σi)k)`, evaluated directly on the
+  padded rfft grid (`gauss_cov`, `gauss_ratio_hat`). `gaussian2d`'s support returns to
+  `nfwhm` major-axis FWHMs, and the parameter is renamed from `nsigma` to say so. A
+  non-positive-semi-definite `Σf − Σi` now raises `ValueError` instead of being applied.
+  The `gausspari=None` path (a plain convolution by the sampled kernel) is untouched.
+- **Rationale:** there were two independent error sources and the support width only fixes
+  one. (1) Truncating at 5 σ leaves a step of `exp(−12.5) = 3.7e-6` of peak, whose spectral
+  ripple dwarfs the transform's own ~1e-14 floor near Nyquist; at 5 FWHM (11.8 σ) the step
+  is ~4e-31 and the ripple is gone. This is the half issue #312 diagnosed, and the half
+  spimple fixed (`landmanbester/spimple@27a4bc8`). (2) A *sampled* Gaussian's DFT sinks
+  into FFT round-off before Nyquist regardless of support, so past that point the quotient
+  is noise over noise — and unbounded, since pfb's mask is `> 0.0`, not spimple's `> 1e-10`.
+  Source (2) gets *worse* as the beam is better sampled: measured on a band-limited sky at
+  `--super-resolution-factor` 2/3/4 with a matched 2·srf px beam, the two-step invariant
+  (`sky→gi→gf` vs `sky→gf`) broke by 4.0e-10, 1.8e-3 and 1.4e-4 of peak. The closed-form
+  ratio has neither problem (8.1e-10 at srf 2, ~6e-16 above — a kernel-aliasing floor),
+  conserves flux exactly (the sampled division was off by +6% at a 6 px beam and −25% at
+  12 px), and costs two FFTs less per plane.
+- **Consequences:** the support width no longer carries correctness for the deconvolution
+  path — the remaining `gaussian2d` callers only ever *multiply*, where a 3.7e-6 truncation
+  step is harmless — but it is kept wide for spimple parity and because nothing gains from
+  narrowing it. **`restore` can now raise where it used to return garbage:**
+  `restoration.lowest_resolution` takes the max of each axis but the **mean** of the
+  position angles, so a band whose PA differs from the mean can give an indefinite
+  `Σf − Σi` even though both its axes grew. That is a real defect the old code hid by
+  silently amplifying instead of refusing; if it fires in practice the fix belongs in
+  `lowest_resolution` (a PA-aware envelope), not in loosening the check. `nsigma` survives
+  in `fitcleanbeam`, where it does mean standard deviations.
+- **Source:** issue #312; landmanbester/spimple#50 and `landmanbester/spimple@27a4bc8`
+  (where the same regression was found first); the `gaussian2d` regression entered in
+  `1bde45d` (#218), which fixed a genuine width bug and narrowed the support in passing;
+  `src/pfb_imaging/utils/misc.py` (`gauss_cov`, `gauss_ratio_hat`, `convolve2gaussres`,
+  `gaussian2d`); `src/pfb_imaging/utils/restoration.py`;
+  `tests/test_convolve2gaussres.py::test_convolve2gaussres_preserves_position_when_deconvolving`,
+  `…_conserves_flux_through_a_resolution_change`, `…_two_step_matches_direct_across_srf`,
+  `…_refuses_to_sharpen`.
+
 ## Known debt
 
 - `opt/primal_dual.py::primal_dual_numba` contains two `pdb.set_trace()` breakpoints
@@ -1095,6 +1141,12 @@ update it (and this page's `last_verified_commit`) in the same session.
   RA = 0 reads as ~2pi apart when it is 2e-9. Wrap first, then take magnitudes:
   `np.abs((a - b + np.pi) % (2 * np.pi) - np.pi)`. Dec never wraps, so applying it
   elementwise to the (ra, dec) pair is safe.
+- **Never divide two sampled kernels' FFTs.** A sampled Gaussian's DFT sinks into
+  round-off before Nyquist, so the quotient is noise over noise there — and the
+  error grows as the kernel is *better* sampled, which is the opposite of the
+  intuition. When the quotient has a closed form (Gaussians do), evaluate it; see
+  D31. The same reasoning applies to any "divide by the transform of a model
+  kernel" step, and widening the kernel's support only fixes the truncation half.
 - **Warm-cache timing:** back-to-back runs on the same MS read from page cache
   (stimela stats `R GB` ≈ 0); only compare wall times at matching cache state.
 - **stimela deconv memory stats are dominated by fixed Ray overhead** on small tests

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,7 +3,7 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-12T14:10:00Z
+timestamp: 2026-08-12T15:40:00Z
 last_verified_commit: a07eb8a
 ---
 
@@ -907,7 +907,23 @@ update it (and this page's `last_verified_commit`) in the same session.
     backward step already pays per major cycle. **Measured cost is not negligible:** on
     `subset_withbeam_I.dt` (3 bands, 750², 3 partitions/band) a `max_gamma` power
     iteration — one exact sweep plus one CG solve — went **28 s → 115 s (4.1×)**. The
-    exact sweep is common to both, so the whole difference is the CG round trips.
+    exact sweep is common to both, so the whole difference is in the forward solve.
+  - **That difference is three effects, not one**
+    (`scripts/profile_freq_correlated_hessian.py`, same tree, 7 threads/worker,
+    `--cg-tol 1e-3 --cg-maxit 150`; one forward solve **5.8 s → 20.0 s, 3.44×**):
+    1. *the fast path is lost* — **+1.4 s (1.25×)**, one round trip becomes 95, at ~38 ms
+       of Ray overhead each (a `pool.hess_dot` costs 70 ms against 31 ms of FFT work);
+    2. *conditioning* — **+3.8 s**, CG goes 95 → >150 iterations (it hits `cg_maxit`, so
+       the 3.44× is a **floor**). This is `λmin(M)` dropping by up to `gp_cap`, and it is
+       the one cost a per-`dot` benchmark cannot see;
+    3. *costlier dots* — **+8.4 s**, of which only ~0.5 s is the coupling arithmetic.
+       The rest is **BLAS contention**: the `(nband,nband) @ (nband,npix)` matmul takes
+       ~3 ms of wall but ~75 ms of driver CPU, i.e. it lands on ~22 BLAS threads that
+       fight the `nband × nthreads` worker FFT threads for cores. With
+       `OPENBLAS_NUM_THREADS=1` exported (BLAS sizes its pool at import, so `set_envs`
+       is too late) the coupled `dot` drops from **1.83× to 1.01×** of the uncoupled one
+       and the whole solve from **3.44× to 2.07×**. This applies to `pfb deconv` itself,
+       not just the profiler.
   - `λmax(D^½C⁻¹ₙD^½) = λmax(D)` **exactly**, so `λmax(M)`, `hess_norm` and the
     primal-dual step sizes are unchanged. Pinned by
     `test_prior_stats_report_the_spectrum_and_its_contribution_to_m`.
@@ -960,8 +976,9 @@ update it (and this page's `last_verified_commit`) in the same session.
   `tests/test_hess_tree_ray.py`, `tests/test_deconv_hess_norm_cache.py`,
   `tests/test_pfb_solver.py`, `tests/test_preconditioner_consistency.py`,
   `tests/test_deconv.py::test_deconv_driver_runs_with_the_frequency_prior`;
-  `scripts/max_gamma.py --gp-length-scale/--gp-cap` (the measurements above, on
-  `subset_withbeam_I.dt`, `--eta 1e-3`, 11 vs 9 power iterations to `--tol 5e-3`).
+  `scripts/max_gamma.py --gp-length-scale/--gp-cap` (the γ measurements above, on
+  `subset_withbeam_I.dt`, `--eta 1e-3`, 11 vs 9 power iterations to `--tol 5e-3`);
+  `scripts/profile_freq_correlated_hessian.py` (the cost decomposition above).
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1113,7 +1113,7 @@ update it (and this page's `last_verified_commit`) in the same session.
   second term is computed inside `restore_products` and discarded. Nothing in the tree
   records it, so "what did homogenisation do to the residual" could only be answered by
   redoing the convolution with the exact `G` and `PSFPARSN_b` of that run — which is what
-  `scripts/test_spi_ripples.py` has to do, and why it needs a rebuild-vs-`IMAGE` check at
+  `scripts/check_spi_ripples.py` has to do, and why it needs a rebuild-vs-`IMAGE` check at
   all. The question matters because that term is the leading suspect for the ripples left in
   a per-pixel spectral index fit (#312).
 - **Decision:** `--outputs s`/`S` stores it as band variable `CRESIDUAL`, **apparent**
@@ -1138,7 +1138,7 @@ update it (and this page's `last_verified_commit`) in the same session.
   residual — correct, since the restoring resolution *is* native there.
 - **Source:** issue #312; `src/pfb_imaging/utils/restoration.py` (`PRODUCT_VARS`,
   `restore_products`); `src/pfb_imaging/core/restore.py`; `src/pfb_imaging/cli/restore.py`;
-  `scripts/test_spi_ripples.py`; `tests/test_restore.py::test_restore_cresidual_completes_the_restored_image`,
+  `scripts/check_spi_ripples.py`; `tests/test_restore.py::test_restore_cresidual_completes_the_restored_image`,
   `…_is_apparent_and_not_the_raw_residual`, `test_restore_without_s_writes_no_cresidual`.
 
 ## Known debt

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1051,12 +1051,8 @@ update it (and this page's `last_verified_commit`) in the same session.
 - **Consequences:** the support width no longer carries correctness for the deconvolution
   path — the remaining `gaussian2d` callers only ever *multiply*, where a 3.7e-6 truncation
   step is harmless — but it is kept wide for spimple parity and because nothing gains from
-  narrowing it. **`restore` can now raise where it used to return garbage:**
-  `restoration.lowest_resolution` takes the max of each axis but the **mean** of the
-  position angles, so a band whose PA differs from the mean can give an indefinite
-  `Σf − Σi` even though both its axes grew. That is a real defect the old code hid by
-  silently amplifying instead of refusing; if it fires in practice the fix belongs in
-  `lowest_resolution` (a PA-aware envelope), not in loosening the check. `nsigma` survives
+  narrowing it. The new check immediately exposed that `restoration.lowest_resolution`
+  had been producing invalid targets all along — rewritten in D32. `nsigma` survives
   in `fitcleanbeam`, where it does mean standard deviations.
 - **Source:** issue #312; landmanbester/spimple#50 and `landmanbester/spimple@27a4bc8`
   (where the same regression was found first); the `gaussian2d` regression entered in
@@ -1066,6 +1062,50 @@ update it (and this page's `last_verified_commit`) in the same session.
   `tests/test_convolve2gaussres.py::test_convolve2gaussres_preserves_position_when_deconvolving`,
   `…_conserves_flux_through_a_resolution_change`, `…_two_step_matches_direct_across_srf`,
   `…_refuses_to_sharpen`.
+
+### D32 — The common restoring resolution is a Loewner envelope, not a max of axes
+
+- **Context:** `--gausspar 0 0 0` homogenises every band to a common resolution — the
+  input a spectral-index fit needs (spimple). `restoration.lowest_resolution` built that
+  target as `nanmax(emaj)`, `nanmax(emin)`, `nanmean(pa)`. D31's semi-definiteness check
+  turned what had been silent corruption into a visible failure, and it fires on real
+  data: of six representative band sets, only the one with perfectly aligned position
+  angles produced a valid target.
+- **Decision:** the target is the smallest ellipse that dominates every input in the
+  **Loewner order** (`Σf − Σj ⪰ 0` for every input `j`), which is the exact condition for
+  `convolve2gaussres` to be a convolution from all of them. Candidate shapes are formed
+  from the max axes at each of several orientations (the circular mean of the input PAs,
+  plus each input's own PA) crossed with five axis ratios from the widest input's to
+  circular; each is inflated by the smallest scalar that makes it dominate — the largest
+  generalised eigenvalue of the pencil `(Σj, shape)`, closed form for 2×2 — and the
+  smallest resulting ellipse wins. `resolution_deficit` exposes the same quantity so the
+  explicit `--gausspar` branch can fail early with the viable floor instead of failing
+  inside an FFT. The MFS native beam is now part of the input set.
+- **Rationale:** "at least as wide as every input" is a statement about covariances, not
+  about the axes separately — a rotated ellipse pokes out diagonally, so matching axis by
+  axis is necessary but **not sufficient**. (Concretely: eigenvalues 4 and 1 at 45° project
+  to 2.5 on both coordinate axes, and `2.5·I` does not dominate it.) Three separate
+  defects were in that one line. (1) Rotation, above. (2) `nanmean` on position angles,
+  which are defined mod π: PAs of 0.05 and π − 0.05 are near-identical orientations that
+  average to π/2, orthogonal to both — the circular mean on the doubled angle fixes it.
+  (3) The MFS beam is `fitcleanbeam(Σ_b PSF_b)`, a fit to the summed PSF and not an
+  average of the band fits (D29), so nothing bounds it by the per-band envelope, yet it is
+  reconvolved to the same target. The candidate sweep matters because neither extreme is
+  right alone: with aligned PAs the max-axis ellipse is exactly optimal (bit-identical to
+  the old answer, area ratio 1.000), while over a ~1.5 rad PA spread a *circular* beam is
+  tighter than any scaling of the elongated one (2.00× the old area rather than 2.79×).
+- **Consequences:** with aligned PAs nothing changes. Otherwise the restoring beam grows —
+  measured at 1.02× to 2.0× in area over the six cases — which is a real resolution cost
+  and the honest price of a target every band can actually reach. A `1 + 1e-6` margin on
+  the scale keeps the binding input inside D31's tolerance. The search is
+  `(n + 1) × 5 × n` 2×2 eigenproblems per correlation, microseconds. `--gausspar` with an
+  impossible value now raises before any FFT, naming the shortfall factor and the floor.
+- **Source:** issue #312; `src/pfb_imaging/utils/restoration.py` (`lowest_resolution`,
+  `resolution_deficit`, `_mean_pa`); `src/pfb_imaging/core/restore.py`;
+  `tests/test_restore.py::test_lowest_resolution_dominates_every_input` (the six cases),
+  `…_averages_position_angles_modulo_pi`, `…_takes_max_axes_when_the_angles_agree`,
+  `test_restore_zero_gausspar_handles_bands_at_different_angles`,
+  `test_restore_gausspar_sharper_than_the_data_raises`.
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-15T12:00:00Z
-last_verified_commit: eb1bc6d
+timestamp: 2026-09-07T12:00:00Z
+last_verified_commit: 3699b79
 ---
 
 # Design decisions, known debt and recurring gotchas

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,7 +3,7 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-12T16:10:00Z
+timestamp: 2026-08-12T17:05:00Z
 last_verified_commit: a07eb8a
 ---
 
@@ -925,14 +925,39 @@ update it (and this page's `last_verified_commit`) in the same session.
        `λmin(M)` cannot degrade — the two knobs pull opposite ways on CG. Pinned by
        `test_prior_lowers_lambda_min_only_where_the_data_lacks_curvature` and
        `test_prior_needs_more_cg_iterations_and_that_is_expected`;
-    3. *costlier dots* — **+8.4 s**, of which only ~0.5 s is the coupling arithmetic.
-       The rest is **BLAS contention**: the `(nband,nband) @ (nband,npix)` matmul takes
-       ~3 ms of wall but ~75 ms of driver CPU, i.e. it lands on ~22 BLAS threads that
-       fight the `nband × nthreads` worker FFT threads for cores. With
-       `OPENBLAS_NUM_THREADS=1` exported (BLAS sizes its pool at import, so `set_envs`
-       is too late) the coupled `dot` drops from **1.83× to 1.01×** of the uncoupled one
-       and the whole solve from **3.44× to 2.07×**. This applies to `pfb deconv` itself,
-       not just the profiler.
+    3. *costlier dots* — originally **+8.4 s**, of which only ~0.5 s was the coupling
+       arithmetic. The rest was **BLAS spin**: `k = nband` is tiny and `n = npix` huge,
+       so `np.matmul` is memory-bound, but OpenBLAS spread it over every core and those
+       threads then busy-polled for ~100 ms (`THREAD_TIMEOUT`) — straight through the
+       *next* `ray.get`, while the workers needed the cores. Proven by inserting a sleep
+       between the matmul and the round trip: driver CPU during the round trip decayed
+       1598 → 1499 → 1242 → 705 → 14 ms as the sleep went 0 → 5 → 20 → 50 → 100 ms.
+       **Fixed** by `gauss.eta_freq_mul` (below): the solve is now **6.3 s → 12.7 s
+       (2.03×)** and this term is +0.7 s.
+  - **The coupling term is `operators/gauss.eta_freq_mul`, a fused numba kernel**, not
+    numpy. Band-major inside a 2048-pixel tile: band-major makes the inner loop
+    unit-stride and vectorisable, the tile keeps a band slice of `out` in L2 across the
+    `(b,c)` loops, and without the tile the kernel re-streams `out` `nband` times and
+    loses to numpy above ~1024². At 8 bands × 4096² numpy takes 287 ms on 11.5 cores
+    against 83 ms on 15.6. It holds **no scratch cubes** — the numpy form's two
+    `(nband, ny, nx)` buffers were 7.6 GB at 8 × 8000². Numba's TBB pool does not spin
+    into the next round trip (measured to 22 threads). `rarg_numba_patterns.load_data`
+    was tried and rejected: gathering a pixel's band column into a tuple blocks
+    vectorisation, and the result neither vectorises nor parallelises.
+  - **At production size the binding cost is the cube-level CG's transfer and driver
+    memory, not the coupling term.** Measured at 8 × 8000² (a 3.81 GB f8 cube), on an
+    echo actor with the FFT removed: one cube-level round trip is **1.63 s** — `ray.put`
+    of the band slices is 0.28 s and dispatch 0.15 s, so the *return* path (worker
+    result → plasma → the driver's `out[b] = res[0]` memcpy) dominates. The worker's
+    read of a task argument *is* zero-copy (`writeable=False`, a plasma view), but the
+    round trip is not zero-copy end to end: there are three copies per band slice and
+    only that one is free. So a 150-iteration forward solve moves **1.12 TB** through
+    the object store and spends **~4 min in transfer alone** before any gridding. The
+    band-parallel path pays that once, not 150 times. Driver memory is the other half:
+    `pcg_numba` holds 7 cubes (`b, x, r, p, xp, rp, aopp`) = **26.7 GB** at that size,
+    against 3.3 GB per worker for the in-worker path. `BandWorkerPool.hess_dot`
+    allocates its output with `np.empty_like`, not `zeros_like` — every band is
+    overwritten, and zeroing cost 1.07 s per call at this size.
   - `λmax(D^½C⁻¹ₙD^½) = λmax(D)` **exactly**, so `λmax(M)`, `hess_norm` and the
     primal-dual step sizes are unchanged. Pinned by
     `test_prior_stats_report_the_spectrum_and_its_contribution_to_m`.
@@ -993,7 +1018,8 @@ update it (and this page's `last_verified_commit`) in the same session.
   `tests/test_deconv.py::test_deconv_driver_runs_with_the_frequency_prior`;
   `scripts/max_gamma.py --gp-length-scale/--gp-cap` (the γ measurements above, on
   `subset_withbeam_I.dt`, `--eta 1e-3`, 11 vs 9 power iterations to `--tol 5e-3`);
-  `scripts/profile_freq_correlated_hessian.py` (the cost decomposition above).
+  `scripts/profile_freq_correlated_hessian.py` (the cost decomposition above);
+  `src/pfb_imaging/operators/gauss.py` (`eta_freq_mul`), `tests/test_eta_freq_mul.py`.
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1061,7 +1061,7 @@ update it (and this page's `last_verified_commit`) in the same session.
   `gaussian2d`); `src/pfb_imaging/utils/restoration.py`;
   `tests/test_convolve2gaussres.py::test_convolve2gaussres_preserves_position_when_deconvolving`,
   `…_conserves_flux_through_a_resolution_change`, `…_two_step_matches_direct_across_srf`,
-  `…_refuses_to_sharpen`.
+  `…_refuses_to_sharpen`, `…_rejects_xy_ordered_grids`.
 
 ### D32 — The common restoring resolution is a Loewner envelope, not a max of axes
 
@@ -1215,6 +1215,11 @@ update it (and this page's `last_verified_commit`) in the same session.
   RA = 0 reads as ~2pi apart when it is 2e-9. Wrap first, then take magnitudes:
   `np.abs((a - b + np.pi) % (2 * np.pi) - np.pi)`. Dec never wraps, so applying it
   elementwise to the (ra, dec) pair is safe.
+- **`convolve2gaussres` reads the pixel size off `xx`/`yy` on the `gausspari` path,**
+  so the grids must be `np.meshgrid(x, y, indexing="ij")`. numpy's *default* is
+  `indexing="xy"`, which transposes both, makes the inferred spacings zero and every
+  frequency infinite — an all-NaN image. It now raises instead; before the closed form
+  (D31) the kernel was evaluated on the grids themselves and the mistake was invisible.
 - **Never divide two sampled kernels' FFTs.** A sampled Gaussian's DFT sinks into
   round-off before Nyquist, so the quotient is noise over noise there — and the
   error grows as the kernel is *better* sampled, which is the opposite of the

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-06T00:00:00Z
-last_verified_commit: 5a30f2a
+timestamp: 2026-08-07T13:53:02Z
+last_verified_commit: 78de0cf
 ---
 
 # Design decisions, known debt and recurring gotchas
@@ -705,6 +705,11 @@ update it (and this page's `last_verified_commit`) in the same session.
   band-uniformity for a beam-driven mode would need a driver-side reduction of `B2_eff`
   across bands (each worker sees only its own band). Both halves pinned by
   `tests/test_eta_profile.py::test_radial_is_identical_across_bands_and_beam_modes_are_not`.
+  **Since D30** this profile is no longer only a diagonal: `--gp-length-scale` reads `e(x)`
+  as a per-pixel inverse signal variance and couples bands through
+  `D^½C⁻¹ₙD^½`, making `M` the second band-coupling channel after the L21 prox. The
+  workers still apply `e(x)` exactly as described here; the coupling is a driver-side
+  remainder.
 - **Inspecting it:** with `--eta-mode` set, `deconv` writes `<oname>_<suffix>_eta.fits`
   once per run — a `(band, corr, ny, nx)` cube (band on the FREQ axis, so band-to-band
   variation is visible; a 3D array would land it on STOKES because `to4d` prepends) with
@@ -856,6 +861,82 @@ update it (and this page's `last_verified_commit`) in the same session.
   (`convolve2gaussres`); `src/pfb_imaging/utils/fits.py` (`dt2fits` `drop_bands`,
   `psfpars_var`); commits 84dd88b, 8501dee, 4b41d26, a4a6b08, 7b66502, d0bdd6b;
   `tests/test_restore.py`, `tests/test_convolve2gaussres.py`, `tests/test_fits_tree.py`.
+
+### D30 — The preconditioner's frequency prior generalises `--eta` to an nband×nband precision
+
+- **Context:** on a real wide-field mosaic the primary beam tapers the *forward update* at
+  the edges of the field, worst at the top of the band, and structure visible in the
+  residual never reaches the model (issue #307). The forward step already solves
+  `B†HB + K⁻¹` with `K⁻¹ = η·I` (`HessianTree.dot`), so exploiting smoothness in frequency
+  is a matter of replacing that scalar with a matrix — not a new mechanism.
+- **Decision:** `--gp-length-scale` (default None = off, unchanged behaviour) and
+  `--gp-cap` (default 10). The preconditioner becomes
+  `M x = M_data x + D^½ C⁻¹ₙ D^½ x`, with `D = diag_b(e_b(x))` the existing
+  `eta`/`eta_mode` profile and `C⁻¹ₙ` an `nband×nband` normalised precision. `e(x)` is read
+  as the **per-pixel inverse signal variance**, so `K = diag(σ)(C ⊗ I)diag(σ)` with
+  `σ² = 1/e` and `K⁻¹_{bb'}(x) = sqrt(e_b e_b') C⁻¹_{bb'}`. Applied through the identity
+  `D^½C⁻¹ₙD^½ = D + D^½(C⁻¹ₙ − I)D^½` so the **band workers are untouched** and the driver
+  adds only the remainder. Squared exponential on a **linear** frequency metric, length
+  scale a fraction of the band span. Zero-`wsum` bands take part (at their `freq_nominal`
+  fallback, D28) and are interpolated by the prior.
+- **Rationale — the normalisation is the load-bearing part.** `prec = min(λmax/λ, cap)`
+  then `prec /= prec.max()`, anchoring `η` to the **roughest frequency mode present** and
+  relaxing smoother modes by up to `cap` ("relax"). Three alternatives were rejected:
+  - *A spatially uniform `(K⁻¹ − ηI)` coupling on top of `diag(e)`.* Under
+    `--eta-mode radial --eta-cap 1000` the diagonal is `1000η` against a coupling of
+    `η(cap−1) ≈ 100η`, so the prior becomes **10× more white than correlated exactly at
+    the corners where it is needed** — backwards. It is also not any GP's precision
+    matrix, so the hyperparameter has no interpretation.
+  - *"Tighten" (`[η, η·cap]`, `η` on the smoothest mode).* Makes the field-edge update
+    *smaller*, not larger, so it does not address the reported symptom; and
+    `λmax(P) = η·eta_cap·gp_cap = 100` against the `λmax(M) ≈ 1.98` D26 measured, i.e. a
+    50× `hess_norm` inflation and `√50 ≈ 7×` the CG iterations.
+  - *Dividing by `cap` instead of `prec.max()`.* A white kernel has a flat eigenspectrum,
+    every ratio is 1, and the result is a uniform `I/cap` — silently weakening `eta`
+    everywhere instead of degrading to today's behaviour at `ℓ → 0`.
+  A **log-frequency metric was also rejected**: writing `ν = ν̄(1+a)`,
+  `log ν_i − log ν_j ≈ (ν_i−ν_j)/ν̄`, so linear *is* the first-order expansion of log and
+  over a full 2:1 band the two differ by 4% (`log 2 = 0.6931` vs `2/3 = 0.6667`) — far
+  inside the ambiguity in `ℓ`. The GP is over linear flux, so a log metric would not
+  encode power laws anyway; that needs a GP over `log S` vs `log ν`, which is nonlinear
+  and unavailable (the operator must stay linear and PSD for CG).
+- **Consequences:**
+  - **The forward CG moves from band-parallel in-worker to cube-level on the driver**
+    (`HessTreeRay.cg` branches on the prior). The FFT work is unchanged and still happens
+    in the workers; only `cg_maxit` round trips are added, against the `pd_maxit` the
+    backward step already pays per major cycle.
+  - `λmax(D^½C⁻¹ₙD^½) = λmax(D)` **exactly**, so `λmax(M)`, `hess_norm` and the
+    primal-dual step sizes are unchanged. Pinned by
+    `test_prior_stats_report_the_spectrum_and_its_contribution_to_m`.
+  - `λmin(M)` drops by up to `gp_cap`, eroding the stable `γ`. The erosion is bounded by
+    the `η` fraction of `v'Mv` along the maximising direction — D26 measured 21% for the
+    binding mode, giving `14.7 → 18.2` (24%) at `gp_cap=10`, not 10×. **Measure with
+    `scripts/max_gamma.py` before raising the cap.**
+  - The driver-side remainder is **negative** semi-definite (`C⁻¹ₙ`'s eigenvalues are in
+    `(0, 1]`); the total operator is still symmetric positive definite, so CG applies, but
+    nothing may assume that term alone is PSD.
+  - Interpolated flux in zero-`wsum` bands enters L21's 2-norm over bands, so a
+    joint-sparsity decision can be taken partly on a band with no data. Accepted: the loop
+    already extrapolates into those bands via `model_to_ds`'s `nbasisf` refit.
+  - **The fixed-point test cannot guard the prior's sign.** Flipping `dot`'s `+=` to `-=`
+    yields `M_data + D + D^½(I − C⁻¹ₙ)D^½`, still SPD, so D22 says it reaches the same
+    fixed point — and it does (verified). The prior term's value is pinned separately
+    against an explicit dense formula by `test_prior_term_matches_the_dense_congruence`.
+  - `hess_norm` is now cache-keyed on the M-defining options
+    (`eta`, `eta_mode`, `eta_cap`, `gp_length_scale`, `gp_cap`), fixing a **pre-existing
+    bug**: changing `--eta` between runs on the same `.dt` silently reused a stale norm.
+    Trees written before the key existed carry no `hess_norm_opts` and are re-estimated.
+  - Second band-coupling channel in `M` (see D26's band-consistency note — bands
+    previously coupled only through the L21 prox, D3).
+  - **Attribution:** `--nbasisf < nband` already smooths the *model* in frequency every
+    major cycle (`core/deconv.py`, `model_to_ds`). Run GP experiments at the default
+    full-rank `nbasisf` or the two effects cannot be separated.
+- **Source:** issue #307; `src/pfb_imaging/operators/hessian.py` (`freq_correlation`,
+  `freq_precision`, `HessTreeRay`); `src/pfb_imaging/deconv/presets.py`;
+  `src/pfb_imaging/core/deconv.py` (`_M_OPTS`, `_m_signature`, `_cached_hess_norm`);
+  `src/pfb_imaging/cli/deconv.py`; `tests/test_freq_precision.py`,
+  `tests/test_hess_tree_ray.py`, `tests/test_deconv_hess_norm_cache.py`,
+  `tests/test_pfb_solver.py`, `tests/test_preconditioner_consistency.py`.
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,7 +3,7 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-09-07T12:00:00Z
+timestamp: 2026-09-07T18:00:00Z
 last_verified_commit: 3699b79
 ---
 
@@ -958,9 +958,16 @@ update it (and this page's `last_verified_commit`) in the same session.
     against 3.3 GB per worker for the in-worker path. `BandWorkerPool.hess_dot`
     allocates its output with `np.empty_like`, not `zeros_like` — every band is
     overwritten, and zeroing cost 1.07 s per call at this size.
-  - `λmax(D^½C⁻¹ₙD^½) = λmax(D)` **exactly**, so `λmax(M)`, `hess_norm` and the
-    primal-dual step sizes are unchanged. Pinned by
-    `test_prior_stats_report_the_spectrum_and_its_contribution_to_m`.
+  - `λmax(D^½C⁻¹ₙD^½) = λmax(D)` **exactly**, so the prior's own contribution to `M`'s
+    spectrum has the same ceiling as the `η·I` it replaces. Pinned by
+    `test_prior_stats_report_the_spectrum_and_its_contribution_to_m`. Note this **bounds**
+    `λmax(M)`, it does not fix it: `C⁻¹ ⪯ I` gives `M_gp ⪯ M`, so `λmax` can only fall.
+    It does fall, because the eigenvectors do not align and `M`'s top mode is
+    frequency-flat — precisely the mode relaxed to `1/gp_cap`. The drop is at most
+    `η(1 − 1/gp_cap)`, ~9e-4 against the `λmax(M) ≈ 1.98` D26 measured, so `hess_norm`
+    and the primal-dual step sizes move by <0.1% and in the conservative direction
+    (a norm that is too large means steps that are too small). The cache keys on
+    `gp_length_scale`/`gp_cap` regardless, so nothing rests on the approximation.
   - `λmin(M)` drops by up to `gp_cap`, eroding the stable `γ`. The erosion is bounded by
     the `η` fraction of `v'Mv` along the maximising direction — D26 measured 21% for the
     binding mode, predicting `14.7 → 18.2` (24%) at `gp_cap=10`, not 10×.
@@ -1003,6 +1010,11 @@ update it (and this page's `last_verified_commit`) in the same session.
     (`eta`, `eta_mode`, `eta_cap`, `gp_length_scale`, `gp_cap`), fixing a **pre-existing
     bug**: changing `--eta` between runs on the same `.dt` silently reused a stale norm.
     Trees written before the key existed carry no `hess_norm_opts` and are re-estimated.
+    **Expect this once per existing tree:** the first `deconv` run on a `.dt` written
+    before this PR misses the cache by construction and pays a power-method estimate
+    (a handful of cube-level round trips at production size). It is logged —
+    "Preconditioner options changed since the cached hess_norm was written;
+    re-estimating" — and it is a one-off, not a per-run regression.
   - Second band-coupling channel in `M` (see D26's band-consistency note — bands
     previously coupled only through the L21 prox, D3).
   - **Attribution:** `--nbasisf < nband` already smooths the *model* in frequency every
@@ -1143,6 +1155,19 @@ update it (and this page's `last_verified_commit`) in the same session.
 
 ## Known debt
 
+- **`HessTreeRay.cg`'s two branches have opposite `x0` aliasing, and the caller only
+  happens to be safe.** The uncoupled branch (`BandWorkerPool.hess_cg`) allocates a fresh
+  `out` and leaves `x0` untouched; the coupled branch hands `x0` to `pcg_numba`, which
+  binds it as the iterate and mutates it in place, so the returned array *is* `x0`. The
+  one caller, `PFBSolver.forward`, passes `x0 = self._update` and immediately rebinds
+  `self._update` to the return value, which is correct either way — but only by accident,
+  and a second caller that keeps its `x0` would get branch-dependent behaviour with no
+  error. Both docstrings warn; that is mitigation, not a fix. **Follow-up:** make the two
+  branches agree, preferably by having the coupled branch copy (matching
+  `_BandWorkerImpl.cg`, which already copies because Ray hands it a read-only view) and
+  dropping the warnings. Found reviewing #308; not fixed there because it changes the
+  contract of a frozen oracle's caller and deserves its own PR with a test that pins the
+  aliasing on both branches.
 - `opt/primal_dual.py::primal_dual_numba` contains two `pdb.set_trace()` breakpoints
   (zero-model and NaN-eps paths) — hangs unattended runs if triggered. Kept because the
   function is a frozen oracle; remove if it ever stops being one.

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,7 +3,7 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-12T15:40:00Z
+timestamp: 2026-08-12T16:10:00Z
 last_verified_commit: a07eb8a
 ---
 
@@ -915,7 +915,16 @@ update it (and this page's `last_verified_commit`) in the same session.
        of Ray overhead each (a `pool.hess_dot` costs 70 ms against 31 ms of FFT work);
     2. *conditioning* — **+3.8 s**, CG goes 95 → >150 iterations (it hits `cg_maxit`, so
        the 3.44× is a **floor**). This is `λmin(M)` dropping by up to `gp_cap`, and it is
-       the one cost a per-`dot` benchmark cannot see;
+       the one cost a per-`dot` benchmark cannot see. **Slower CG is the designed
+       behaviour, not a bug** — the prior only ever *removes* curvature from `M` (the
+       roughest mode is anchored at `η` and smoother ones are relaxed toward `η/cap`), so
+       `cond(M)` rises by up to `gp_cap` and CG needs ~`√gp_cap` more iterations. It
+       shows up only where the data term has no curvature of its own: on a fully sampled
+       toy the same prior costs 20 → 22 iterations, on one with unsampled uv cells
+       72 → 240. Note this is the **opposite** of `eta_profile`, which is normalised so
+       `λmin(M)` cannot degrade — the two knobs pull opposite ways on CG. Pinned by
+       `test_prior_lowers_lambda_min_only_where_the_data_lacks_curvature` and
+       `test_prior_needs_more_cg_iterations_and_that_is_expected`;
     3. *costlier dots* — **+8.4 s**, of which only ~0.5 s is the coupling arithmetic.
        The rest is **BLAS contention**: the `(nband,nband) @ (nband,npix)` matmul takes
        ~3 ms of wall but ~75 ms of driver CPU, i.e. it lands on ~22 BLAS threads that
@@ -959,7 +968,12 @@ update it (and this page's `last_verified_commit`) in the same session.
   - **The fixed-point test cannot guard the prior's sign.** Flipping `dot`'s `+=` to `-=`
     yields `M_data + D + D^½(I − C⁻¹ₙ)D^½`, still SPD, so D22 says it reaches the same
     fixed point — and it does (verified). The prior term's value is pinned separately
-    against an explicit dense formula by `test_prior_term_matches_the_dense_congruence`.
+    against an explicit dense formula by `test_prior_term_matches_the_dense_congruence`,
+    and structurally by `test_prior_matches_the_kronecker_spectrum`: with one partition
+    shared by every band, `M_data = I⊗A` and `P = ηC⁻¹ₙ⊗I` commute, so the whole spectrum
+    must be `α_k + η·p_j`. That closed form catches the sign flip, a one-sided congruence
+    (dropping either `D^½`), a missing `−I`, and any band/pixel axis mix-up in the
+    `reshape(nband, -1)` — all four verified by mutation.
   - `hess_norm` is now cache-keyed on the M-defining options
     (`eta`, `eta_mode`, `eta_cap`, `gp_length_scale`, `gp_cap`), fixing a **pre-existing
     bug**: changing `--eta` between runs on the same `.dt` silently reused a stale norm.
@@ -973,7 +987,8 @@ update it (and this page's `last_verified_commit`) in the same session.
   `freq_precision`, `HessTreeRay`); `src/pfb_imaging/deconv/presets.py`;
   `src/pfb_imaging/core/deconv.py` (`_M_OPTS`, `_m_signature`, `_cached_hess_norm`);
   `src/pfb_imaging/cli/deconv.py`; `tests/test_freq_precision.py`,
-  `tests/test_hess_tree_ray.py`, `tests/test_deconv_hess_norm_cache.py`,
+  `tests/test_hess_tree_ray.py` (including the Kronecker-spectrum, band-vs-pixel coupling,
+  spatially-varying-eta congruence and CG-iteration guards), `tests/test_deconv_hess_norm_cache.py`,
   `tests/test_pfb_solver.py`, `tests/test_preconditioner_consistency.py`,
   `tests/test_deconv.py::test_deconv_driver_runs_with_the_frequency_prior`;
   `scripts/max_gamma.py --gp-length-scale/--gp-cap` (the γ measurements above, on

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1107,6 +1107,40 @@ update it (and this page's `last_verified_commit`) in the same session.
   `test_restore_zero_gausspar_handles_bands_at_different_angles`,
   `test_restore_gausspar_sharper_than_the_data_raises`.
 
+### D33 — `CRESIDUAL` records what the resolution change did to the residual
+
+- **Context:** the restored image is `MODEL ⊗ G + (RESIDUAL/WSUM) ⊗ [G/PSFPARSN_b]`, and the
+  second term is computed inside `restore_products` and discarded. Nothing in the tree
+  records it, so "what did homogenisation do to the residual" could only be answered by
+  redoing the convolution with the exact `G` and `PSFPARSN_b` of that run — which is what
+  `scripts/test_spi_ripples.py` has to do, and why it needs a rebuild-vs-`IMAGE` check at
+  all. The question matters because that term is the leading suspect for the ripples left in
+  a per-pixel spectral index fit (#312).
+- **Decision:** `--outputs s`/`S` stores it as band variable `CRESIDUAL`, **apparent**
+  (pre-beam-division) and at the restoring resolution. Off by default — it is another cube
+  per band. The `C` prefix means convolved, alongside the tree's existing `B` for
+  beam-attenuated.
+- **Rationale:** apparent because image-plane noise is flat on that scale and `BEAM` is
+  already on the node, so the intrinsic form is one divide away; the reverse is not true
+  where the beam is small. Storing it makes the tree self-describing: `MODEL ⊗ G + CRESIDUAL`
+  reproduces `KIMAGE` exactly, which is the property the tests pin. It also gives
+  `spifit` the array its SNR cut is actually applied to — the rms currently comes from
+  `std(RESIDUAL/WSUM)`, the *raw* residual, while the image being thresholded contains the
+  convolved one, whose rms differs by a band-dependent factor because the broadening needed
+  to reach `G` does. That is tidiness rather than a ripple source: the mask is a single
+  min-over-bands cut, so it shifts which pixels are fitted, not their spectra.
+- **Consequences:** `restore` still never writes `RESIDUAL` — only `PSFPARSF` and the
+  `PRODUCT_VARS` entries, so the raw residual survives untouched and `--outputs F` keeps
+  FFT-ing the raw array. The MFS `CRESIDUAL` FITS is written from the direct MFS path, not
+  by summing bands, for the same reason the restored MFS image is (D29): with no
+  homogenisation the per-band `CRESIDUAL` sit at different resolutions. When `gaussparf`
+  equals a band's own resolution the convolution is skipped and `CRESIDUAL` is that band's
+  residual — correct, since the restoring resolution *is* native there.
+- **Source:** issue #312; `src/pfb_imaging/utils/restoration.py` (`PRODUCT_VARS`,
+  `restore_products`); `src/pfb_imaging/core/restore.py`; `src/pfb_imaging/cli/restore.py`;
+  `scripts/test_spi_ripples.py`; `tests/test_restore.py::test_restore_cresidual_completes_the_restored_image`,
+  `…_is_apparent_and_not_the_raw_residual`, `test_restore_without_s_writes_no_cresidual`.
+
 ## Known debt
 
 - `opt/primal_dual.py::primal_dual_numba` contains two `pdb.set_trace()` breakpoints

--- a/scripts/check_spi_ripples.py
+++ b/scripts/check_spi_ripples.py
@@ -57,7 +57,7 @@ Seven diagnostics, in decreasing order of how decisive they are:
 
 Run (from the repo root, on the box holding the tree)::
 
-    uv run python scripts/test_spi_ripples.py /path/to/out_I.dt --nthreads 16
+    uv run python scripts/check_spi_ripples.py /path/to/out_I.dt --nthreads 16
 
 Writes ``<outdir>/spi_ripples_report.txt`` (read this first),
 ``spi_ripples_diagnostics.npz`` and ``spi_ripples_summary.png``.  Default

--- a/scripts/max_gamma.py
+++ b/scripts/max_gamma.py
@@ -53,18 +53,26 @@ off-axis PSF mismatch; large-scale implicates the short-baseline hole).
 
 import argparse
 import json
+import os
 
-import numpy as np
-import psutil
-import xarray as xr
-from ducc0.misc import resize_thread_pool
+# Ray's uv_run_runtime_env hook (on under `uv run`) relaunches workers via
+# `uv run --frozen python`, rebuilding a venv that lacks the [full] extra where
+# ray itself lives -- workers then die on `import ray` and ray.wait() blocks
+# forever. Same workaround, and same reason, as tests/conftest.py. The constant
+# is read when ray is imported, so this must precede the pfb_imaging imports.
+os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
 
-from pfb_imaging import init_ray, set_envs, setup_ray_worker
-from pfb_imaging.deconv.presets import _build_hess
-from pfb_imaging.operators.band_worker import BandWorkerPool
-from pfb_imaging.operators.hessian import ETA_MODES
-from pfb_imaging.opt.power_method import power_method_numba as power_method
-from pfb_imaging.utils.fits import save_fits, set_wcs
+import numpy as np  # noqa: E402
+import psutil  # noqa: E402
+import xarray as xr  # noqa: E402
+from ducc0.misc import resize_thread_pool  # noqa: E402
+
+from pfb_imaging import init_ray, set_envs, setup_ray_worker  # noqa: E402
+from pfb_imaging.deconv.presets import _build_hess  # noqa: E402
+from pfb_imaging.operators.band_worker import BandWorkerPool  # noqa: E402
+from pfb_imaging.operators.hessian import ETA_MODES  # noqa: E402
+from pfb_imaging.opt.power_method import power_method_numba as power_method  # noqa: E402
+from pfb_imaging.utils.fits import save_fits, set_wcs  # noqa: E402
 
 
 def parse_args():
@@ -78,6 +86,14 @@ def parse_args():
         help="Shape of a spatially varying eta (deconv --eta-mode); default is uniform",
     )
     p.add_argument("--eta-cap", type=float, default=1e2, help="Dynamic range of the --eta-mode profile")
+    p.add_argument(
+        "--gp-length-scale",
+        type=float,
+        default=None,
+        help="GP frequency prior length scale as a fraction of the band span (deconv --gp-length-scale); "
+        "unset disables the prior",
+    )
+    p.add_argument("--gp-cap", type=float, default=10.0, help="Max relaxation of the smoothest mode (deconv --gp-cap)")
     p.add_argument("--niter", type=int, default=15, help="Maximum power iterations")
     p.add_argument("--tol", type=float, default=5e-3, help="Stop when the relative change in lambda falls below this")
     p.add_argument("--nthreads", type=int, default=4, help="Threads per band worker")
@@ -118,18 +134,21 @@ def load_tree(dt_name):
     if "BDIRTY" not in first:
         raise ValueError(f"{dt_name} has no BDIRTY -- re-run pfb imager to regenerate the .dt")
     wsums = np.array([float(dt[n].ds.WSUM.values[0]) for n in nodes])
+    freq_out = np.array([float(dt[n].ds.attrs["freq_out"]) for n in nodes])
     geometry = {
         "nx": first.x.size,
         "ny": first.y.size,
         "nx_psf": first.x_psf.size,
         "ny_psf": first.y_psf.size,
+        # required by _build_hess only when the GP frequency prior is requested
+        "freq_out": freq_out,
     }
     meta = {
         "cell_rad": float(first.attrs["cell_rad"]),
         "radec": [float(first.attrs["ra"]), float(first.attrs["dec"])],
         "l0": float(first.attrs.get("l0", 0.0)),
         "m0": float(first.attrs.get("m0", 0.0)),
-        "freq_out": np.array([float(dt[n].ds.attrs["freq_out"]) for n in nodes]),
+        "freq_out": freq_out,
     }
     cubes = {}
     for key in ("UPDATE", "DIRTY"):
@@ -296,6 +315,7 @@ def main():
     resize_thread_pool(args.nthreads)
     ncpu = int(np.minimum(args.nthreads, psutil.cpu_count(logical=False)))
     env_vars = set_envs(args.nthreads, ncpu)
+    env_vars["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = "0"  # see the module-level note
     init_ray(
         nworkers,
         ray_address=args.ray_address,
@@ -311,6 +331,8 @@ def main():
         "eta": args.eta,
         "eta_mode": args.eta_mode,
         "eta_cap": args.eta_cap,
+        "gp_length_scale": args.gp_length_scale,
+        "gp_cap": args.gp_cap,
         "nthreads": args.nthreads,
         "cg_tol": args.cg_tol,
         "cg_maxit": args.cg_maxit,
@@ -357,6 +379,17 @@ def main():
     lam_m, _ = power_method(hess.dot, (nband, ny, nx), tol=args.pm_tol, maxit=args.pm_maxit, verbosity=0)
     emode = "uniform" if args.eta_mode is None else f"{args.eta_mode} (cap {args.eta_cap:g})"
     print(f"eta = {args.eta:.3e} [{emode}]   lambda_max(M) = {lam_m:.4e}   eta/lambda_max(M) = {args.eta / lam_m:.2e}")
+    prior = hess.get_freq_prior_stats()
+    if prior is None:
+        print("GP frequency prior: off")
+    else:
+        # prec_max == 1 by construction, so lambda_max(M) is unchanged and the
+        # prior only relaxes the smoother frequency modes (wiki D30)
+        print(
+            f"GP frequency prior: length_scale={args.gp_length_scale:g} cap={args.gp_cap:g}   "
+            f"precision spectrum [{prior['prec_min']:.4f}, {prior['prec_max']:.4f}]   "
+            f"eta contribution [{prior['lam_min']:.3e}, {prior['lam_max']:.3e}]"
+        )
     spectrum = spectrum_report(dt, nodes, wsum_tot, wsums, args.eta)
     print()
 
@@ -427,6 +460,9 @@ def main():
         "eta": args.eta,
         "eta_mode": args.eta_mode,
         "eta_cap": args.eta_cap,
+        "gp_length_scale": args.gp_length_scale,
+        "gp_cap": args.gp_cap,
+        "freq_prior": prior,
         "denominator": denom,
         "lambda_max_M": float(lam_m),
         "eta_over_lambda_max_M": args.eta / float(lam_m),
@@ -438,7 +474,9 @@ def main():
         "gamma_divergence_threshold": gamma_max,
         "gamma_recommended": gamma_rec,
     }
-    out = f"{dt_name}_max_gamma.json"
+    # tag the outputs so a with/without-prior pair does not clobber itself
+    tag = "" if args.gp_length_scale is None else f"_gp{args.gp_length_scale:g}_cap{args.gp_cap:g}"
+    out = f"{dt_name}_max_gamma{tag}.json"
     with open(out, "w") as f:
         json.dump(record, f, indent=2)
     print(f"\nwritten: {out}")
@@ -458,7 +496,7 @@ def main():
             l0=meta["l0"],
             m0=meta["m0"],
         )
-        name = f"{dt_name}_max_gamma_eigvec.fits"
+        name = f"{dt_name}_max_gamma{tag}_eigvec.fits"
         save_fits(np.mean(v, axis=0), name, hdr, yx_order=True)
         print(f"written: {name}")
 

--- a/scripts/profile_freq_correlated_hessian.py
+++ b/scripts/profile_freq_correlated_hessian.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python
+"""Profile the deconv preconditioner with and without the GP frequency prior (issue #307).
+
+Without the prior ``M`` is block diagonal over bands: a ``dot`` fans one image
+out to each of the nband workers and gathers nband images back, and a *forward
+solve* costs exactly ONE such round trip -- every worker runs its own CG to
+convergence in process (``BandWorkerPool.hess_cg``).
+
+The prior couples the bands through the driver-side remainder
+``D^.5 (Cinv - I) D^.5`` (wiki D30), which costs three separate things:
+
+1. the band-parallel CG fast path is no longer valid: ``HessTreeRay.cg`` falls
+   back to a cube-level CG on the driver, so the round-trip count per forward
+   solve goes from 1 to one per CG *iteration*;
+2. every one of those ``dot``\\ s pays an ``(nband, nband) @ (nband, npix)``
+   matmul plus two elementwise multiplies on the driver, O(nband^2 * npix); and
+3. ``lambda_min(M)`` drops by up to ``gp_cap``, so CG needs more iterations to
+   reach the same tolerance -- an effect on the *count*, not the cost, of the
+   round trips, and the one a per-``dot`` benchmark cannot see.
+
+The script separates them by timing three forward solves on the same rhs and the
+same worker pool::
+
+    A. hess_off.cg(rhs)            band-parallel in-worker CG (production, prior off)
+    B. pcg_numba(hess_off.dot)     driver-side CG, no coupling term
+    C. hess_on.cg(rhs)             driver-side CG + the coupling term (production, prior on)
+
+``B - A`` is (1); ``C - B`` is (2) and (3) together and is split between them
+using the measured iteration counts. B is not a code path anything runs; it
+exists only to make that split possible. C is run as ``pcg_numba(counted.dot,
+...)``, which is exactly what ``HessTreeRay.cg`` does on the coupled branch, so
+that the ``dot`` calls can be counted and timed.
+
+A per-``dot`` breakdown says where one round trip goes: pure FFT compute (timed
+in a driver-local single-band ``HessianTree``), Ray dispatch latency (an
+argument-free round trip to every worker), and the coupling term on its own.
+
+**Read the driver's CPU column, not just its wall time.** On
+``subset_withbeam_I.dt`` (3 bands, 750^2, 7 threads/worker) the coupling term
+measures 1.9 ms with the driver otherwise idle but adds 63 ms to a ``dot`` in
+situ, because its matmul is spread over every core by BLAS and those threads
+fight the ``nband x nthreads`` worker FFT threads. Exporting
+``OPENBLAS_NUM_THREADS=1`` (before numpy is imported -- ``set_envs`` runs too
+late to change the pool) took the coupled ``dot`` from 1.89x to 0.97x of the
+uncoupled one. That is a property of the deconv driver too, not of this script.
+
+The image size and the band count both matter and only one of them can be
+varied from a given ``.dt``, so a synthetic sweep of the driver-side coupling
+term over nband is reported alongside (``--coupling-nbands``).
+
+Run (from the repo root)::
+
+    uv run python scripts/profile_freq_correlated_hessian.py /path/to/out_I.dt \
+        --gp-length-scale 0.5 --nthreads 8
+
+Writes ``<dt>_freq_prior_profile_gp<ls>_cap<cap>.json``.
+"""
+
+import argparse
+import json
+import os
+from time import process_time, time
+
+# Ray's uv_run_runtime_env hook (on under `uv run`) relaunches workers via
+# `uv run --frozen python`, rebuilding a venv that lacks the [full] extra where
+# ray itself lives -- workers then die on `import ray` and ray.wait() blocks
+# forever. Same workaround, and same reason, as tests/conftest.py. The constant
+# is read when ray is imported, so this must precede the pfb_imaging imports.
+os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+
+# Captured before numpy is imported and before set_envs overwrites them. BLAS
+# sizes its thread pool when it loads, so these -- not what set_envs writes
+# later -- are the values that actually apply to the driver's coupling matmul.
+BLAS_ENV = {k: os.environ.get(k) for k in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS")}
+
+import numpy as np  # noqa: E402
+import psutil  # noqa: E402
+import xarray as xr  # noqa: E402
+from ducc0.misc import resize_thread_pool  # noqa: E402
+
+from pfb_imaging import init_ray, set_envs, setup_ray_worker  # noqa: E402
+from pfb_imaging.deconv.presets import _build_hess  # noqa: E402
+from pfb_imaging.operators.band_worker import BandWorkerPool  # noqa: E402
+from pfb_imaging.operators.hessian import ETA_MODES, HessianTree, freq_precision  # noqa: E402
+from pfb_imaging.opt.pcg import pcg_numba  # noqa: E402
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("dt", help="Path to the imager output <output-filename>_<PRODUCT>.dt")
+    p.add_argument("--eta", type=float, default=1e-3, help="Tikhonov term of the preconditioner (deconv --eta)")
+    p.add_argument(
+        "--eta-mode",
+        default=None,
+        choices=list(ETA_MODES),
+        help="Shape of a spatially varying eta (deconv --eta-mode); default is uniform",
+    )
+    p.add_argument("--eta-cap", type=float, default=1e2, help="Dynamic range of the --eta-mode profile")
+    p.add_argument(
+        "--gp-length-scale",
+        type=float,
+        default=0.5,
+        help="GP frequency prior length scale as a fraction of the band span (deconv --gp-length-scale)",
+    )
+    p.add_argument("--gp-cap", type=float, default=10.0, help="Max relaxation of the smoothest mode (deconv --gp-cap)")
+    p.add_argument("--nthreads", type=int, default=4, help="Threads per band worker")
+    p.add_argument("--nworkers", type=int, default=None, help="Ray workers (default: nband)")
+    p.add_argument("--ray-address", default="local")
+    p.add_argument("--cg-tol", type=float, default=1e-3, help="CG tolerance (deconv --cg-tol)")
+    p.add_argument("--cg-maxit", type=int, default=150, help="CG iteration cap (deconv --cg-maxit)")
+    p.add_argument("--cg-minit", type=int, default=1, help="CG iteration floor (deconv --cg-minit)")
+    p.add_argument(
+        "--cg-verbose",
+        type=int,
+        default=1,
+        help="CG reporting. At 1 each solve prints its outcome, which is the only way to see the per-band "
+        "iteration counts of the in-worker path (the workers print them; Ray forwards them with a pid prefix)",
+    )
+    p.add_argument("--repeat", type=int, default=5, help="Timed repeats of each dot measurement")
+    p.add_argument("--warmup", type=int, default=2, help="Untimed warmup calls before each dot measurement")
+    p.add_argument(
+        "--no-local-probe",
+        action="store_true",
+        help="Skip the driver-local single-band HessianTree. That probe is what separates FFT compute from Ray "
+        "overhead, but it holds one band's PSFHAT and BEAM in the driver -- skip it if that does not fit.",
+    )
+    p.add_argument("--probe-band", type=int, default=0, help="Band index for the driver-local probe")
+    p.add_argument(
+        "--coupling-nbands",
+        default="2,4,8,16",
+        help="Synthetic sweep of the driver-side coupling term over band count at this image size. "
+        "Empty string disables it.",
+    )
+    p.add_argument(
+        "--coupling-max-gb",
+        type=float,
+        default=2.0,
+        help="Skip synthetic band counts whose driver buffers would exceed this",
+    )
+    p.add_argument("--no-solve", action="store_true", help="Skip the three forward solves (dot breakdown only)")
+    return p.parse_args()
+
+
+def fmt(t):
+    """Wall time as ms below a second, else seconds."""
+    return f"{1e3 * t:8.2f} ms" if t < 1.0 else f"{t:8.3f} s "
+
+
+def timeit(fn, repeat, warmup):
+    """Median/min/max wall time of ``fn`` over ``repeat`` calls after ``warmup`` untimed ones.
+
+    Also records driver CPU time (``process_time`` sums every thread in the
+    process), because the driver competes with the band workers for cores:
+    ``cpu/wall`` is how many cores the driver kept busy for the call, and a
+    number well above 1 on a step that looks cheap in wall time is the signature
+    of a multithreaded BLAS call stealing cores from the workers.
+    """
+    for _ in range(warmup):
+        fn()
+    ts, cs = [], []
+    for _ in range(repeat):
+        t0, c0 = time(), process_time()
+        fn()
+        ts.append(time() - t0)
+        cs.append(process_time() - c0)
+    wall = float(np.median(ts))
+    cpu = float(np.median(cs))
+    return {
+        "median": wall,
+        "min": float(np.min(ts)),
+        "max": float(np.max(ts)),
+        "cpu": cpu,
+        "cores_busy": cpu / wall if wall > 0 else np.nan,
+        "n": repeat,
+    }
+
+
+def load_tree(dt_name):
+    """Band nodes, geometry, per-band wsums and a realistic rhs, mirroring core/deconv.py.
+
+    The rhs is the beam-attenuated gradient the forward solver actually consumes
+    (D23): ``BRESIDUAL`` when a previous deconv run left one, else ``BDIRTY``
+    (the major-cycle-0 value), both normalised by the total wsum as the driver
+    does. CG's stopping test is relative, so the scale only matters for realism.
+    """
+    dt = xr.open_datatree(dt_name, engine="zarr", chunks=None)
+    names = [n for n in dt.children if n.startswith("band")]
+    if not names:
+        raise ValueError(f"No band nodes found in {dt_name}")
+    nodes = sorted(names, key=lambda n: int(dt[n].ds.attrs["bandid"]))
+    first = dt[nodes[0]].ds
+    if first.corr.size > 1:
+        raise NotImplementedError("Joint polarisation not supported (matches pfb deconv)")
+    part = next(iter(dt[nodes[0]].children.values()), None)
+    if part is None or "PSFHAT" not in part.ds:
+        raise ValueError(f"{dt_name} has no per-partition PSFHAT -- re-run pfb imager with --psf")
+    wsums = np.array([float(dt[n].ds.WSUM.values[0]) for n in nodes])
+    geometry = {
+        "nx": first.x.size,
+        "ny": first.y.size,
+        "nx_psf": first.x_psf.size,
+        "ny_psf": first.y_psf.size,
+        "freq_out": np.array([float(dt[n].ds.attrs["freq_out"]) for n in nodes]),
+    }
+    key = "BRESIDUAL" if "BRESIDUAL" in first else "BDIRTY"
+    if key not in first:
+        raise ValueError(f"{dt_name} has neither BRESIDUAL nor BDIRTY -- re-run pfb imager to regenerate the .dt")
+    rhs = np.stack([dt[n].ds[key].values[0] for n in nodes]) / wsums.sum()
+    dt.close()
+    return nodes, geometry, wsums, rhs, key
+
+
+def local_band_tree(dt_name, node, geometry, wsum_tot, args):
+    """Driver-local copy of one band's HessianTree: pure FFT compute, no Ray.
+
+    Mirrors the Hessian inputs of ``_BandWorkerImpl.load_band``, including the
+    ``abs`` on the stored complex ``PSFHAT`` (the ``HessianTree`` convention).
+    This is the memory-expensive part of the script -- it holds one band's
+    ``PSFHAT`` and ``BEAM`` in the driver process.
+
+    Returns:
+        ``(tree, nbytes)``: the operator and the bytes it pinned in the driver.
+    """
+    band = xr.open_datatree(dt_name, engine="zarr", chunks=None)[node]
+    parts, nbytes = [], 0
+    for cname in sorted(band.children):
+        child = band[cname].ds
+        psfhat = np.abs(child.PSFHAT.values)
+        beam = child.BEAM.values
+        nbytes += psfhat.nbytes + beam.nbytes
+        parts.append({"psfhat": psfhat, "beam": beam, "wsum": np.asarray(child.attrs["wsum"])})
+    tree = HessianTree(
+        parts,
+        geometry["nx"],
+        geometry["ny"],
+        geometry["nx_psf"],
+        geometry["ny_psf"],
+        eta=args.eta,
+        nthreads=args.nthreads,
+        wsum=wsum_tot,
+        eta_mode=args.eta_mode,
+        eta_cap=args.eta_cap,
+    )
+    tree.dot(np.zeros((geometry["ny"], geometry["nx"])))  # warm the FFT plans, as init_hess does
+    return tree, nbytes
+
+
+class Counted:
+    """``dot`` facade that counts and times the calls a driver-side CG makes."""
+
+    def __init__(self, hess):
+        self._hess = hess
+        self.ncalls = 0
+        self.time = 0.0
+
+    def dot(self, x):
+        t0 = time()
+        out = self._hess.dot(x)
+        self.time += time() - t0
+        self.ncalls += 1
+        return out
+
+
+def coupling_apply(hess):
+    """The driver-side prior remainder on its own, as ``HessTreeRay.dot`` applies it.
+
+    Reaches into the operator's own matrix and buffers rather than rebuilding
+    them, so this times the shipped arithmetic and not a lookalike.
+    """
+    dcinv, s, buf, buf2 = hess._dC, hess._s, hess._buf, hess._buf2
+    nband = hess.nband
+
+    def apply(x):
+        np.multiply(x, s, out=buf)
+        np.matmul(dcinv, buf.reshape(nband, -1), out=buf2.reshape(nband, -1))
+        np.multiply(buf2, s, out=buf2)
+        return buf2
+
+    return apply
+
+
+def coupling_scaling(nbands, ny, nx, eta, max_gb, repeat, warmup):
+    """Driver-side coupling cost vs band count at fixed image size.
+
+    The term is O(nband^2 * npix) in flops and O(nband * npix) in memory, and a
+    single ``.dt`` only exercises one band count -- this sweeps it synthetically
+    on a representative dense precision matrix (a squared-exponential over
+    evenly spaced frequencies, which is what a real band plan gives).
+    """
+    rows = []
+    rng = np.random.default_rng(0)
+    for nb in nbands:
+        gb = 3 * nb * ny * nx * 8 / 2**30  # x plus the two driver buffers
+        if gb > max_gb:
+            print(f"  nband {nb:>3}: skipped, would need {gb:.2f} GB of driver buffers (--coupling-max-gb {max_gb})")
+            continue
+        prec = freq_precision(np.linspace(1.0e9, 1.4e9, nb), 0.5, 10.0)
+        dcinv = prec - np.eye(nb)
+        s = np.full((nb, 1, 1), np.sqrt(eta))
+        x = rng.standard_normal((nb, ny, nx))
+        buf, buf2 = np.empty_like(x), np.empty_like(x)
+
+        def apply(dcinv=dcinv, s=s, x=x, buf=buf, buf2=buf2, nb=nb):
+            np.multiply(x, s, out=buf)
+            np.matmul(dcinv, buf.reshape(nb, -1), out=buf2.reshape(nb, -1))
+            np.multiply(buf2, s, out=buf2)
+
+        t = timeit(apply, repeat, warmup)
+        per_band = t["median"] / nb
+        print(f"  nband {nb:>3}: {fmt(t['median'])}   {1e3 * per_band:6.2f} ms per band   ({gb:.2f} GB of buffers)")
+        rows.append({"nband": nb, "seconds": t["median"], "seconds_per_band": per_band, "buffer_gb": gb})
+        del x, buf, buf2
+    return rows
+
+
+def main():
+    args = parse_args()
+    dt_name = args.dt.rstrip("/")
+    nodes, geometry, wsums, rhs, rhs_key = load_tree(dt_name)
+    nband = len(nodes)
+    ny, nx = geometry["ny"], geometry["nx"]
+    wsum_tot = float(wsums.sum())
+    cube_gb = nband * ny * nx * 8 / 2**30
+
+    if nband < 2:
+        raise SystemExit(
+            f"{dt_name} has {nband} band: the frequency prior needs at least 2 (freq_precision returns None)"
+        )
+
+    resize_thread_pool(args.nthreads)
+    ncpu = int(np.minimum(args.nthreads, psutil.cpu_count(logical=False)))
+    env_vars = set_envs(args.nthreads, ncpu)
+    env_vars["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = "0"  # see the module-level note
+    init_ray(
+        args.nworkers or nband,
+        ray_address=args.ray_address,
+        runtime_env={"env_vars": env_vars, "worker_process_setup_hook": setup_ray_worker},
+    )
+    workers = BandWorkerPool(nband, args.nthreads)
+    workers.load_bands(dt_name, nodes)
+
+    # both facades share the pool: the worker-side operator is identical (same
+    # eta, same eta_mode), so only the driver-side coupling differs and building
+    # one does not disturb the other
+    opts = {
+        "eta": args.eta,
+        "eta_mode": args.eta_mode,
+        "eta_cap": args.eta_cap,
+        "gp_length_scale": None,
+        "gp_cap": args.gp_cap,
+        "nthreads": args.nthreads,
+        "cg_tol": args.cg_tol,
+        "cg_maxit": args.cg_maxit,
+        "cg_verbose": args.cg_verbose,
+    }
+    hess_off = _build_hess(None, geometry, opts, workers=workers, wsums=wsums)
+    hess_on = _build_hess(
+        None, geometry, dict(opts, gp_length_scale=args.gp_length_scale), workers=workers, wsums=wsums
+    )
+    prior = hess_on.get_freq_prior_stats()
+    if prior is None:
+        raise SystemExit(
+            f"the prior is inactive on this tree (freq_out = {geometry['freq_out']}): "
+            "it needs at least two distinct band frequencies"
+        )
+
+    emode = "uniform" if args.eta_mode is None else f"{args.eta_mode} (cap {args.eta_cap:g})"
+    print(f"\n{dt_name}")
+    print(f"  {nband} bands, {ny}x{nx}, psf {geometry['ny_psf']}x{geometry['nx_psf']}, {args.nthreads} threads/worker")
+    print(f"  eta = {args.eta:.3e} [{emode}], rhs = {rhs_key}/wsum_tot, cube = {cube_gb * 1e3:.1f} MB")
+    print(
+        f"  prior: length_scale={args.gp_length_scale:g} cap={args.gp_cap:g}, "
+        f"precision spectrum [{prior['prec_min']:.4f}, {prior['prec_max']:.4f}]"
+    )
+    print(
+        f"  cores: {psutil.cpu_count(logical=False)} physical / {psutil.cpu_count(logical=True)} logical; "
+        f"the workers alone claim {nband} x {args.nthreads} = {nband * args.nthreads} FFT threads"
+    )
+    print("  driver BLAS env at import: " + " ".join(f"{k}={v}" for k, v in BLAS_ENV.items()))
+
+    # --- one Hessian application -------------------------------------------
+    print("\n" + "=" * 78)
+    print(f"ONE HESSIAN APPLICATION (median of {args.repeat} after {args.warmup} warmup)")
+    print("=" * 78)
+    x = rhs.copy()
+    dots = {}
+    # dispatch floor: an argument-free round trip to every worker. get_eta
+    # returns a scalar for uniform eta and this band's (ncorr, ny, nx) profile
+    # under --eta-mode, so with a profile it measures dispatch plus a one-way
+    # cube transfer rather than dispatch alone.
+    dots["ray_dispatch_floor"] = timeit(lambda: workers._map("get_eta", [()] * nband), args.repeat, args.warmup)
+    dots["pool_hess_dot"] = timeit(lambda: workers.hess_dot(x), args.repeat, args.warmup)
+    dots["dot_prior_off"] = timeit(lambda: hess_off.dot(x), args.repeat, args.warmup)
+    dots["dot_prior_on"] = timeit(lambda: hess_on.dot(x), args.repeat, args.warmup)
+    dots["coupling_term"] = timeit(lambda: coupling_apply(hess_on)(x), args.repeat, args.warmup)
+
+    local_bytes = 0
+    if not args.no_local_probe:
+        tree, local_bytes = local_band_tree(dt_name, nodes[args.probe_band], geometry, wsum_tot, args)
+        xb = rhs[args.probe_band]
+        dots["one_band_fft_local"] = timeit(lambda: tree.dot(xb), args.repeat, args.warmup)
+
+    print(f"  {'':<22} {'wall':>11}  {'driver cpu':>11}  cores busy on the driver")
+    for k in (
+        "ray_dispatch_floor",
+        "one_band_fft_local",
+        "pool_hess_dot",
+        "coupling_term",
+        "dot_prior_off",
+        "dot_prior_on",
+    ):
+        if k in dots:
+            d = dots[k]
+            print(f"  {k:<22} {fmt(d['median'])}  {fmt(d['cpu'])}  {d['cores_busy']:5.1f}")
+    overhead = dots["pool_hess_dot"]["median"] - dots.get("one_band_fft_local", {}).get("median", np.nan)
+    overhead_str = "?" if np.isnan(overhead) else fmt(overhead)
+    if not np.isnan(overhead):
+        print(
+            f"\n  Ray overhead per dot   {fmt(overhead)}  "
+            f"({100 * overhead / dots['pool_hess_dot']['median']:.0f}% of the fan-out; "
+            f"{fmt(dots['ray_dispatch_floor']['median'])} of it is bare dispatch latency)"
+        )
+        print("    = pool fan-out minus the same FFT work done locally on one band;")
+        print("      the bands run concurrently, so one band's compute is the ideal parallel wall time.")
+    extra = dots["dot_prior_on"]["median"] - dots["dot_prior_off"]["median"]
+    ratio_dot = dots["dot_prior_on"]["median"] / dots["dot_prior_off"]["median"]
+    coupling = dots["coupling_term"]["median"]
+    print(f"\n  dot with the prior costs {ratio_dot:.2f}x one without it (+{fmt(extra)})")
+    print(f"    the coupling arithmetic alone, driver otherwise idle:  {fmt(coupling)}")
+    print(f"    the same term measured in situ (prior on minus off):   {fmt(extra)}")
+    if extra > 3 * coupling and dots["coupling_term"]["cores_busy"] > 2:
+        # measured on subset_withbeam_I.dt: 1.9 ms of arithmetic showing up as
+        # 63 ms per dot, gone (0.97x) with OPENBLAS_NUM_THREADS=1 in the env
+        print(
+            f"\n  ^ the gap is CONTENTION, not arithmetic: the (nband, nband) @ (nband, npix) matmul\n"
+            f"    runs on ~{dots['coupling_term']['cores_busy']:.0f} BLAS threads in the driver, which fight the\n"
+            f"    {nband} x {args.nthreads} worker FFT threads for cores. The matmul is bandwidth-bound and gains\n"
+            f"    almost nothing from those threads. Confirm by re-running with OPENBLAS_NUM_THREADS=1\n"
+            f"    exported in the environment (it must be set before numpy is imported, so the env var,\n"
+            f"    not set_envs, is what does it)."
+        )
+    print(f"\n  per dot the driver ships {2e3 * cube_gb:.1f} MB through the object store (out and back)")
+
+    solves = {}
+    if not args.no_solve:
+        # --- the forward solve ---------------------------------------------
+        print("\n" + "=" * 78)
+        print("ONE FORWARD SOLVE")
+        print("=" * 78)
+        cg_kw = dict(tol=args.cg_tol, maxit=args.cg_maxit, minit=args.cg_minit)
+        print(f"  (cg_tol {args.cg_tol:g}, cg_maxit {args.cg_maxit}; at cg-verbose > 0 each CG reports its outcome)")
+
+        t0 = time()
+        xa = hess_off.cg(rhs.copy(), **cg_kw)
+        ta = time() - t0
+        print(f"  A  prior off, in-worker band-parallel CG  {fmt(ta)}    1 round trip")
+
+        counted_off = Counted(hess_off)
+        t0 = time()
+        xb_sol = pcg_numba(counted_off.dot, rhs.copy(), verbosity=args.cg_verbose, **cg_kw)
+        tb = time() - t0
+        dot_b = counted_off.time / max(counted_off.ncalls, 1)
+        print(
+            f"  B  prior off, driver-side CG               {fmt(tb)}  {counted_off.ncalls:>3} round trips"
+            f"   ({fmt(dot_b)}/dot)"
+        )
+
+        counted_on = Counted(hess_on)
+        t0 = time()
+        xc = pcg_numba(counted_on.dot, rhs.copy(), verbosity=args.cg_verbose, **cg_kw)
+        tc = time() - t0
+        dot_c = counted_on.time / max(counted_on.ncalls, 1)
+        capped = counted_on.ncalls > args.cg_maxit
+        print(
+            f"  C  prior on,  driver-side CG               {fmt(tc)}  {counted_on.ncalls:>3} round trips"
+            f"   ({fmt(dot_c)}/dot){'   [hit cg-maxit]' if capped else ''}"
+        )
+        if capped:
+            print("     C did not converge inside cg-maxit, so its cost is a floor, not a like-for-like solve.")
+
+        # A and B solve the same system by different routes, so they must agree
+        # to the CG tolerance; C is a different operator and is expected not to
+        d_ab = float(np.linalg.norm(xb_sol - xa) / np.linalg.norm(xa))
+        d_ac = float(np.linalg.norm(xc - xa) / np.linalg.norm(xa))
+        print(
+            f"\n  ||B-A||/||A|| = {d_ab:.2e} (same system, must match to tol)   "
+            f"||C-A||/||A|| = {d_ac:.2e} (the prior's effect on the step)"
+        )
+
+        # exact split of C - B into "more iterations" and "costlier iterations",
+        # both measured, plus whatever is left in the driver's own CG algebra
+        t_iters = (counted_on.ncalls - counted_off.ncalls) * dot_b
+        t_perdot = counted_on.ncalls * (dot_c - dot_b)
+        t_algebra = (tc - tb) - t_iters - t_perdot
+        arith = counted_on.ncalls * dots["coupling_term"]["median"]
+        print("\n  where the extra time goes:")
+        print(f"    A -> B  the band-parallel CG fast path is lost   +{fmt(tb - ta)}  ({tb / ta:5.2f}x)")
+        print(f"            {counted_off.ncalls} round trips instead of 1, at ~{overhead_str} of Ray overhead each")
+        print(f"    B -> C  the prior's two costs                    +{fmt(tc - tb)}  ({tc / tb:5.2f}x)")
+        print(
+            f"      conditioning: {counted_off.ncalls} -> {counted_on.ncalls} CG iterations  "
+            f"+{fmt(t_iters)}   (lambda_min(M) drops by up to gp_cap)"
+        )
+        print(f"      costlier dots: {fmt(dot_b)} -> {fmt(dot_c)} each     +{fmt(t_perdot)}")
+        print(f"        of which real coupling arithmetic          ~{fmt(arith)}   (the rest is BLAS contention)")
+        print(
+            f"      driver CG vector algebra                     {'+' if t_algebra >= 0 else '-'}{fmt(abs(t_algebra))}"
+        )
+        print(f"\n  FORWARD SOLVE: {fmt(ta)} -> {fmt(tc)}   ({tc / ta:.2f}x)")
+        print(f"  object store traffic: {2e3 * cube_gb:.1f} MB -> {2e3 * cube_gb * counted_on.ncalls:.1f} MB")
+        solves = {
+            "A_prior_off_in_worker": {"seconds": ta, "round_trips": 1},
+            "B_prior_off_driver_cg": {
+                "seconds": tb,
+                "round_trips": counted_off.ncalls,
+                "dot_seconds": counted_off.time,
+                "seconds_per_dot": dot_b,
+            },
+            "C_prior_on_driver_cg": {
+                "seconds": tc,
+                "round_trips": counted_on.ncalls,
+                "dot_seconds": counted_on.time,
+                "seconds_per_dot": dot_c,
+                "hit_cg_maxit": capped,
+            },
+            "cost_of_losing_fast_path": tb - ta,
+            "cost_of_prior": tc - tb,
+            "cost_of_extra_iterations": t_iters,
+            "cost_of_costlier_dots": t_perdot,
+            "coupling_arithmetic_est": arith,
+            "cost_of_driver_algebra": t_algebra,
+            "total_ratio": tc / ta,
+            "rel_diff_B_A": d_ab,
+            "rel_diff_C_A": d_ac,
+        }
+
+    scaling = []
+    if args.coupling_nbands:
+        print("\n" + "=" * 78)
+        print(f"DRIVER-SIDE COUPLING TERM vs BAND COUNT (synthetic, at {ny}x{nx})")
+        print("=" * 78)
+        nbs = [int(v) for v in args.coupling_nbands.split(",") if v.strip()]
+        scaling = coupling_scaling(nbs, ny, nx, args.eta, args.coupling_max_gb, args.repeat, args.warmup)
+        print("  O(nband^2 * npix) in flops: the per-band figure is what grows.")
+
+    record = {
+        "dt": dt_name,
+        "nband": nband,
+        "nx": nx,
+        "ny": ny,
+        "nx_psf": geometry["nx_psf"],
+        "nthreads_per_worker": args.nthreads,
+        "cores_physical": psutil.cpu_count(logical=False),
+        "cores_logical": psutil.cpu_count(logical=True),
+        "blas_env_at_import": BLAS_ENV,
+        "eta": args.eta,
+        "eta_mode": args.eta_mode,
+        "eta_cap": args.eta_cap,
+        "gp_length_scale": args.gp_length_scale,
+        "gp_cap": args.gp_cap,
+        "freq_prior": prior,
+        "rhs": rhs_key,
+        "cube_gb": cube_gb,
+        "local_probe_bytes": local_bytes,
+        "cg": {"tol": args.cg_tol, "maxit": args.cg_maxit, "minit": args.cg_minit},
+        "dot": dots,
+        "solve": solves,
+        "coupling_scaling": scaling,
+    }
+    out = f"{dt_name}_freq_prior_profile_gp{args.gp_length_scale:g}_cap{args.gp_cap:g}.json"
+    with open(out, "w") as f:
+        json.dump(record, f, indent=2)
+    print(f"\nwritten: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_freq_correlated_hessian.py
+++ b/scripts/profile_freq_correlated_hessian.py
@@ -35,14 +35,15 @@ A per-``dot`` breakdown says where one round trip goes: pure FFT compute (timed
 in a driver-local single-band ``HessianTree``), Ray dispatch latency (an
 argument-free round trip to every worker), and the coupling term on its own.
 
-**Read the driver's CPU column, not just its wall time.** On
-``subset_withbeam_I.dt`` (3 bands, 750^2, 7 threads/worker) the coupling term
-measures 1.9 ms with the driver otherwise idle but adds 63 ms to a ``dot`` in
-situ, because its matmul is spread over every core by BLAS and those threads
-fight the ``nband x nthreads`` worker FFT threads. Exporting
-``OPENBLAS_NUM_THREADS=1`` (before numpy is imported -- ``set_envs`` runs too
-late to change the pool) took the coupled ``dot`` from 1.89x to 0.97x of the
-uncoupled one. That is a property of the deconv driver too, not of this script.
+**Read the driver's CPU column, not just its wall time.** This is how the
+coupling term's original numpy form was caught: it measured 1.9 ms with the
+driver otherwise idle but added 63 ms to a ``dot`` in situ, because BLAS spread
+its matmul over every core and those threads then busy-polled for ~100 ms --
+straight through the next ``ray.get``, while the workers needed the cores. The
+term is now ``gauss.eta_freq_mul``, a fused numba kernel, and the forward solve
+went 20.0 s -> 12.7 s on this tree. The check below stays as a regression guard:
+a cheap-looking kernel that leaves threads spinning is more expensive than a
+slower one that does not, and only the CPU column shows it.
 
 The image size and the band count both matter and only one of them can be
 varied from a given ``.dt``, so a synthetic sweep of the driver-side coupling
@@ -81,6 +82,7 @@ from ducc0.misc import resize_thread_pool  # noqa: E402
 from pfb_imaging import init_ray, set_envs, setup_ray_worker  # noqa: E402
 from pfb_imaging.deconv.presets import _build_hess  # noqa: E402
 from pfb_imaging.operators.band_worker import BandWorkerPool  # noqa: E402
+from pfb_imaging.operators.gauss import eta_freq_mul  # noqa: E402
 from pfb_imaging.operators.hessian import ETA_MODES, HessianTree, freq_precision  # noqa: E402
 from pfb_imaging.opt.pcg import pcg_numba  # noqa: E402
 
@@ -264,17 +266,17 @@ class Counted:
 def coupling_apply(hess):
     """The driver-side prior remainder on its own, as ``HessTreeRay.dot`` applies it.
 
-    Reaches into the operator's own matrix and buffers rather than rebuilding
-    them, so this times the shipped arithmetic and not a lookalike.
+    Uses the operator's own matrix, profile and chunk count rather than
+    rebuilding them, so this times the shipped kernel and not a lookalike. The
+    accumulator is scratch owned by this script -- the operator no longer holds
+    any (that was the point of the fused kernel).
     """
-    dcinv, s, buf, buf2 = hess._dC, hess._s, hess._buf, hess._buf2
-    nband = hess.nband
+    dcinv, s, nchunk = hess._dC, hess._s, hess._nchunk
+    acc = np.zeros((hess.nband, hess.ny, hess.nx))
 
     def apply(x):
-        np.multiply(x, s, out=buf)
-        np.matmul(dcinv, buf.reshape(nband, -1), out=buf2.reshape(nband, -1))
-        np.multiply(buf2, s, out=buf2)
-        return buf2
+        acc.fill(0.0)
+        return eta_freq_mul(acc, dcinv, s, x, nchunk=nchunk)
 
     return apply
 
@@ -428,16 +430,16 @@ def main():
     print(f"\n  dot with the prior costs {ratio_dot:.2f}x one without it (+{fmt(extra)})")
     print(f"    the coupling arithmetic alone, driver otherwise idle:  {fmt(coupling)}")
     print(f"    the same term measured in situ (prior on minus off):   {fmt(extra)}")
-    if extra > 3 * coupling and dots["coupling_term"]["cores_busy"] > 2:
-        # measured on subset_withbeam_I.dt: 1.9 ms of arithmetic showing up as
-        # 63 ms per dot, gone (0.97x) with OPENBLAS_NUM_THREADS=1 in the env
+    # regression guard: a kernel that is cheap in isolation but expensive in
+    # situ is leaving threads spinning into the next ray.get. Thresholds are set
+    # above the few ms of run-to-run noise on the fan-out measurement.
+    if extra > 5 * coupling and extra > 0.2 * dots["dot_prior_off"]["median"]:
         print(
-            f"\n  ^ the gap is CONTENTION, not arithmetic: the (nband, nband) @ (nband, npix) matmul\n"
-            f"    runs on ~{dots['coupling_term']['cores_busy']:.0f} BLAS threads in the driver, which fight the\n"
-            f"    {nband} x {args.nthreads} worker FFT threads for cores. The matmul is bandwidth-bound and gains\n"
-            f"    almost nothing from those threads. Confirm by re-running with OPENBLAS_NUM_THREADS=1\n"
-            f"    exported in the environment (it must be set before numpy is imported, so the env var,\n"
-            f"    not set_envs, is what does it)."
+            f"\n  ^ the gap is CONTENTION, not arithmetic: the coupling kernel runs on\n"
+            f"    ~{dots['coupling_term']['cores_busy']:.0f} driver threads which are still spinning during the next\n"
+            f"    ray.get, when the {nband} x {args.nthreads} worker FFT threads need the cores. This is what the\n"
+            f"    numpy matmul used to do (~100 ms of OpenBLAS THREAD_TIMEOUT spin per 3 ms call).\n"
+            f"    Check what the coupling term dispatches to; numba's TBB pool does not do this."
         )
     print(f"\n  per dot the driver ships {2e3 * cube_gb:.1f} MB through the object store (out and back)")
 

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -426,18 +426,27 @@ def uv_diagnostics(resids, psfs, psfparsn, gcommon, freqs, cell_rad, say):
     gx, gy = grids(npy, npx)
     fake = np.stack([gaussian2d(gx, gy, p, normalise=False).T for p in psfparsn])
     fhat = np.stack([np.abs(np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(p)))) for p in fake])
-    checks = []
+    # Check the statistic actually reported -- the residual-power-weighted mean --
+    # not the worst radial bin. The bin straddling the ghat cut is a numerical
+    # edge and deviates ~1e-3 on real beams while the mean is exact to 1e-5, so
+    # testing the max just cries wolf.
+    checks, worst_bin = [], 0.0
     for b in range(nband):
         tb = transfer((npy, npx), gauss_cov(psfparsn[b]), cov_g)
         with np.errstate(invalid="ignore", divide="ignore"):
             e = np.where(ghat > gcut, fhat[b] * tb / np.maximum(ghat, 1e-30), np.nan)
-        checks.append(float(np.nanmax(np.abs(radial_profile(e, nbins=140)[1] - 1.0))))
-    worst = max(checks)
+        w = np.nan_to_num(radial_profile(rhat[b] ** 2, nbins=140)[1])
+        ep = radial_profile(e, nbins=140)[1]
+        ok = np.isfinite(ep) & (w > 0)
+        checks.append(abs(float(np.sum(ep[ok] * w[ok]) / max(np.sum(w[ok]), 1e-30)) - 1.0) if ok.any() else np.nan)
+        worst_bin = max(worst_bin, float(np.nanmax(np.abs(ep - 1.0))))
+    worst = np.nanmax(checks)
     if worst > 1e-3:
-        say(f"  SELF-CHECK FAILED: E is {worst:.3e} from 1 for exactly Gaussian PSFs.")
+        say(f"  SELF-CHECK FAILED: <E_b> is {worst:.3e} from 1 for exactly Gaussian PSFs.")
         say("  The numbers below are measuring a convention error, not the data. Stop here.")
     else:
-        say(f"  (self-check: E = 1 to {worst:.1e} when the PSFs are exactly Gaussian)")
+        say(f"  (self-check: <E_b> = 1 to {worst:.1e} on exactly Gaussian PSFs; worst single")
+        say(f"  radial bin {worst_bin:.1e}, which is the numerical edge at the Ghat cut)")
 
     say("DIAGNOSTIC 0 -- the uv plane (this is what restore --outputs F writes).")
     say("  Support and hole are read off the sampling function FFT(PSF/WSUM); the residual")

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -19,8 +19,21 @@ law, and a per-pixel fit reads that as spectral index: coherent, spatially
 periodic ripples, strongest where the residual carries a large fraction of the
 flux (the diffuse emission), weakest on the bright deconvolved structure.
 
-Six diagnostics, in decreasing order of how decisive they are:
+Seven diagnostics, in decreasing order of how decisive they are:
 
+0. **The uv plane**, which ``pfb restore --outputs F`` already writes as FITS.
+   Homogenisation is a pure multiplication there, so the whole question can be
+   settled in one place.  The sampling function ``FFT(PSF/WSUM)`` gives the
+   support and the hole, both of which scale as ``nu`` -- so no two bands carry
+   the same set of angular scales, neither the finest nor the coarsest, and the
+   coarsest end corrupts extended emission whatever the sidelobes do.  Then the
+   consistency ratio ``E_b = FFT(PSF_b) T_b / Ghat``, weighted by where the
+   residual actually has power, says how far the Gaussian reconvolution ``T_b``
+   is from scaling the residual correctly: ``E_b == 1`` iff band b's dirty beam
+   really is the Gaussian ``PSFPARSN_b``.  Its trend across bands is a uniform
+   spurious alpha; its scatter is the scale-dependent part that ripples.  A
+   self-check feeds the machinery exactly Gaussian PSFs and asserts ``E == 1``,
+   so a convention error cannot masquerade as a detection.
 1. **Sidelobes survive homogenisation.**  Convolve each band's stored PSF from
    ``PSFPARSN_b`` to ``G`` -- exactly what restore does to the residual -- and
    compare bands.  The cores must agree by construction; if the sidelobes do
@@ -347,6 +360,147 @@ def psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, psf_size, nthread
         "psf_corr_raw": np.array(corr_raw),
         "psf_corr_scaled": np.array(corr_scaled),
         "beam_volume_ratio": np.array(eps),
+    }, psfs
+
+
+def uv_diagnostics(resids, psfs, psfparsn, gcommon, freqs, cell_rad, say):
+    """Diagnostic 0: the uv plane, which ``pfb restore --outputs F`` already writes.
+
+    ``FFT(RESIDUAL_b / WSUM_b)`` is the gridded residual visibility and
+    ``FFT(PSF_b / WSUM_b)`` is the sampling function itself.  Homogenisation is a
+    pure multiplication in this plane, so the whole question can be settled here.
+
+    Support and hole come from the PSF, which is the sampling function exactly
+    and carries no noise; the residual is used only to weight *where* in the uv
+    plane the errors actually matter.  Both edges scale as ``nu``: the finest
+    structure each band carries shrinks with frequency, and so does the coarsest,
+    which corrupts extended emission independently of any sidelobe argument.
+
+    The decisive quantity is the consistency ratio::
+
+        E_b(u) = Phat_b(u) T_b(u) / Ghat(u),
+        T_b(u) = sqrt(|S_G|/|S_b|) exp(-2 pi^2 u^T (S_G - S_b) u)
+
+    ``T_b`` is the Gaussian reconvolution restore applies.  If band b's dirty
+    beam really were the Gaussian ``PSFPARSN_b``, then ``Phat_b T_b`` would equal
+    the common clean beam ``Ghat`` and ``E_b`` would be 1 at every u, for every
+    band.  Wherever ``E_b`` departs from 1 the residual is being mis-scaled, and
+    wherever ``E_b`` differs *between bands* that mis-scaling is frequency
+    dependent -- which is precisely a spurious spectral index.
+    """
+    from pfb_imaging.utils.misc import gauss_cov
+
+    nband, ny, nx = resids.shape
+    win = np.hanning(ny)[:, None] * np.hanning(nx)[None, :]
+    rhat = np.stack([np.abs(np.fft.fftshift(np.fft.fft2(r * win))) for r in resids])
+    phat = np.stack([np.abs(np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(p)))) for p in psfs])
+
+    def transfer(shape, cov_i, cov_f):
+        n0, n1 = shape
+        ky = np.fft.fftshift(np.fft.fftfreq(n0))[:, None] * np.ones((1, n1))
+        kx = np.ones((n0, 1)) * np.fft.fftshift(np.fft.fftfreq(n1))[None, :]
+        d = cov_f - cov_i
+        amp = np.sqrt(np.linalg.det(cov_f) / np.linalg.det(cov_i))
+        # gauss_cov indexes (x, y) but these arrays are (y, x)-ordered (wiki D19),
+        # so axis 0 pairs with d[1, 1] and axis 1 with d[0, 0]. Transposing the
+        # covariance leaves the cross term alone.
+        return amp * np.exp(-2 * np.pi**2 * (d[1, 1] * ky**2 + 2 * d[0, 1] * kx * ky + d[0, 0] * kx**2))
+
+    cov_g = gauss_cov(gcommon)
+    npy, npx = psfs.shape[1:]
+    # The target every band should reach. It must be built with the SAME
+    # convention as phat -- the FFT of the peak-1 sampled beam -- so that a band
+    # whose dirty beam really is the Gaussian PSFPARSN_b gives E_b == 1 exactly:
+    # phat_b = Ghat_b there, and Ghat_b * (Ghat / Ghat_b) = Ghat.
+    gxx, gyy = grids(npy, npx)
+    gkern = gaussian2d(gxx, gyy, gcommon, normalise=False).T
+    ghat = np.abs(np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(gkern))))
+    gcut = 1e-6 * ghat.max()
+
+    # Self-check: feed the machinery PSFs that really ARE the Gaussians PSFPARSN
+    # claims. E must come back exactly 1, for every band and every position
+    # angle. Two convention bugs were caught this way -- a (y, x) vs (x, y)
+    # transpose in the transfer function, and zeros averaged in where the mask
+    # bites -- both of which faked a band-dependent signal. Cheap, so it runs.
+    gx, gy = grids(npy, npx)
+    fake = np.stack([gaussian2d(gx, gy, p, normalise=False).T for p in psfparsn])
+    fhat = np.stack([np.abs(np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(p)))) for p in fake])
+    checks = []
+    for b in range(nband):
+        tb = transfer((npy, npx), gauss_cov(psfparsn[b]), cov_g)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            e = np.where(ghat > gcut, fhat[b] * tb / np.maximum(ghat, 1e-30), np.nan)
+        checks.append(float(np.nanmax(np.abs(radial_profile(e, nbins=140)[1] - 1.0))))
+    worst = max(checks)
+    if worst > 1e-3:
+        say(f"  SELF-CHECK FAILED: E is {worst:.3e} from 1 for exactly Gaussian PSFs.")
+        say("  The numbers below are measuring a convention error, not the data. Stop here.")
+    else:
+        say(f"  (self-check: E = 1 to {worst:.1e} when the PSFs are exactly Gaussian)")
+
+    say("DIAGNOSTIC 0 -- the uv plane (this is what restore --outputs F writes).")
+    say("  Support and hole are read off the sampling function FFT(PSF/WSUM); the residual")
+    say("  FFT weights where those errors matter. u is in cycles/pixel.")
+    say(f"{'band':>5} {'u_max':>9} {'u_max*nu0/nu':>13} {'u_min':>9} {'u_min*nu0/nu':>13} {'max scale/px':>13}")
+    umax, umin = [], []
+    for b in range(nband):
+        r, prof = radial_profile(phat[b], nbins=140)
+        prof = np.nan_to_num(prof)
+        u = r / npy
+        floor = np.median(prof[int(0.9 * len(prof)) :])
+        lvl = floor + 0.05 * (prof.max() - floor)
+        above = np.where(prof > lvl)[0]
+        umax.append(float(u[above[-1]]) if len(above) else np.nan)
+        umin.append(float(u[above[0]]) if len(above) else np.nan)
+        say(
+            f"{b:5d} {umax[-1]:9.5f} {umax[-1] * freqs[0] / freqs[b]:13.5f} {umin[-1]:9.5f} "
+            f"{umin[-1] * freqs[0] / freqs[b]:13.5f} {1 / max(umin[-1], 1e-9):13.1f}"
+        )
+    say("  Columns 3 and 5 rescale columns 2 and 4 back to band 0. Flat columns mean the uv")
+    say("  support really does scale as nu, so no two bands carry the same set of angular")
+    say("  scales -- neither the finest (u_max) nor the coarsest (u_min).")
+    if np.allclose(umin, umin[0]) and umin[0] <= 2.0 / npy:
+        say("  NOTE: u_min sits in the first radial bin for every band, so the short-baseline")
+        say("  hole is unresolved at this cutout size and the u_min columns say nothing.")
+    say()
+    say("  Consistency ratio E_b = FFT(PSF_b) * T_b / Ghat, weighted by residual power.")
+    say("  E_b == 1 everywhere would mean the Gaussian reconvolution scales the residual")
+    say("  exactly right. Departures are mis-scaling; band-to-band differences are a")
+    say("  spurious spectral index.")
+    say(f"{'band':>5} {'<E_b>':>10} {'rms(E_b - 1)':>14} {'kept vs band 0':>16}")
+    ebar, edev, eprof = [], [], []
+    for b in range(nband):
+        tb = transfer((npy, npx), gauss_cov(psfparsn[b]), cov_g)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            e = np.where(ghat > gcut, phat[b] * tb / np.maximum(ghat, 1e-30), np.nan)
+        # weight by where the residual has power, resampled onto the psf grid
+        w = np.nan_to_num(radial_profile(rhat[b] ** 2, nbins=140)[1])
+        # NOT nan_to_num: radial_profile skips NaN, but zeros would be averaged in
+        # and drag every bin straddling the cut towards zero
+        er, ep = radial_profile(e, nbins=140)
+        eprof.append(ep)
+        ok = np.isfinite(ep) & (w > 0)
+        m = float(np.sum(ep[ok] * w[ok]) / max(np.sum(w[ok]), 1e-30)) if ok.any() else np.nan
+        d = float(np.sqrt(np.sum((ep[ok] - 1) ** 2 * w[ok]) / max(np.sum(w[ok]), 1e-30))) if ok.any() else np.nan
+        ebar.append(m)
+        edev.append(d)
+        say(f"{b:5d} {m:10.4f} {d:14.4f} {m / max(ebar[0], 1e-30):16.4f}")
+    trend = np.log(max(ebar[-1], 1e-12) / max(ebar[0], 1e-12)) / np.log(freqs[-1] / freqs[0])
+    say(f"  band-to-band trend in <E_b> implies a spurious alpha of {trend:+.4f}, uniform over")
+    say("  every pixel the residual touches. rms(E_b - 1) is the scale-dependent part on top")
+    say("  of that -- the piece that varies across the image and shows up as ripples.")
+    say()
+
+    return {
+        "uv_u": np.array(radial_profile(phat[0], nbins=140)[0]) / npy,
+        "uv_sampling_amp": np.stack([np.nan_to_num(radial_profile(p, nbins=140)[1]) for p in phat]),
+        "uv_residual_amp": np.stack([np.nan_to_num(radial_profile(r, nbins=140)[1]) for r in rhat]),
+        "uv_consistency": np.stack(eprof),
+        "uv_umax": np.array(umax),
+        "uv_umin": np.array(umin),
+        "uv_ebar": np.array(ebar),
+        "uv_edev": np.array(edev),
+        "uv_cell_rad": np.array(cell_rad),
     }
 
 
@@ -429,22 +583,23 @@ def main():
         say(f"  (--size {args.size} was clamped to the image)")
     say()
 
-    bundle = psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, args.psf_size, args.nthreads, say)
+    bundle, psfs = psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, args.psf_size, args.nthreads, say)
 
     # ---- rebuild the restored image, term by term -------------------------
     say("Rebuilding the restored cutout term by term (this repeats what restore did).")
     sel = dict(corr=0, y=slice(y0, y1), x=slice(x0, x1))
-    mconv, rconv, rconv1, beams = [], [], [], []
+    mconv, rconv, rconv1, beams, resids = [], [], [], [], []
     for b, node in enumerate(keep):
         ds = dt[node].ds
         model = np.asarray(ds[args.model_name].isel(**sel).values, dtype=np.float64)
         resid = np.asarray(ds[args.residual_name].isel(**sel).values, dtype=np.float64) / wsums[b]
         beams.append(np.asarray(ds.BEAM.isel(**sel).values, dtype=np.float64)[trim])
+        resids.append(resid[trim])
         mconv.append(conv(model, gcommon, nthreads=args.nthreads)[trim])
         rconv.append(conv(resid, gcommon, gausspari=psfparsn[b], nthreads=args.nthreads)[trim])
         rconv1.append(conv(resid, gcommon, gausspari=psfparsn[b], nthreads=args.nthreads, pfrac=1.0)[trim])
     mconv, rconv, rconv1 = np.stack(mconv), np.stack(rconv), np.stack(rconv1)
-    beams = np.stack(beams)
+    beams, resids = np.stack(beams), np.stack(resids)
 
     with np.errstate(invalid="ignore", divide="ignore"):
         image_full = mconv + np.where(beams > 0, rconv / beams, 0.0)
@@ -462,6 +617,8 @@ def main():
             say("  --gausspar, or with a different pfrac? Interpret the alpha maps with care.")
         del stored
     say()
+
+    bundle.update(uv_diagnostics(resids, psfs, psfparsn, gcommon, freqs, float(ref.attrs["cell_rad"]), say))
 
     # ---- mask, matching what spifit would cut on --------------------------
     # spifit takes the rms as std(RESIDUAL/WSUM); reproduce that, but report a
@@ -655,6 +812,32 @@ def write_png(path, bundle, say):
     ax[1, 3].set_xlabel("frequency [MHz]")
     ax[1, 3].set_title("sidelobe correlation with band 0", fontsize=10)
     ax[1, 3].legend(fontsize=8)
+
+    # the uv plane: where the residual has power, and what homogenisation does there
+    fig2, bx = plt.subplots(1, 3, figsize=(17, 4.6))
+    u, amp, tra = bundle["uv_u"], bundle["uv_residual_amp"], bundle["uv_consistency"]
+    for b in range(amp.shape[0]):
+        c = plt.cm.viridis(b / max(amp.shape[0] - 1, 1))
+        bx[0].loglog(u, np.maximum(amp[b], 1e-30), color=c, label=f"{bundle['freqs'][b] / 1e6:.0f} MHz")
+        bx[1].loglog(u, np.maximum(bundle["uv_sampling_amp"][b], 1e-30), color=c)
+        bx[2].loglog(u, np.clip(tra[b], 1e-3, 1e3), color=c)
+    for a, t in zip(
+        bx,
+        (
+            "|FFT(residual)| per band",
+            "sampling function |FFT(PSF)|",
+            "consistency ratio E_b (1 = exact)",
+        ),
+    ):
+        a.set_xlabel("|u| [cycles/pixel]")
+        a.set_title(t, fontsize=10)
+    bx[0].legend(fontsize=7)
+    bx[2].axhline(1.0, color="k", lw=0.8, ls="--")
+    bx[2].set_ylim(1e-1, 1e1)  # E blows up where Ghat has decayed and nothing is left to scale
+    fig2.tight_layout()
+    fig2.savefig(path.replace(".png", "_uv.png"), dpi=110)
+    plt.close(fig2)
+    say(f"wrote {path.replace('.png', '_uv.png')}")
 
     fig.tight_layout()
     fig.savefig(path, dpi=110)

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python
+"""Diagnose the ripples in a per-pixel spectral index fit of a restored ``.dt``.
+
+Runs where the tree lives and writes a few MB of cutouts and summary statistics
+that can be pulled back for inspection.  Nothing here modifies the tree.
+
+The hypothesis under test (pfb-imaging issue #312, wiki D31/D32).  ``pfb restore``
+builds the intrinsic band image as::
+
+    IMAGE_b = MODEL_b (x) G  +  (RESIDUAL_b / WSUM_b) (x) [G / PSFPARSN_b] / BEAM_b
+
+The second term reconvolves the residual from the band's *fitted Gaussian*
+``PSFPARSN_b`` to the common restoring beam ``G``.  But the residual's actual
+resolution is the dirty beam -- the uv sampling function -- which is Gaussian
+only in its core.  A Gaussian reconvolution matches the cores across bands and
+cannot move the sidelobes, whose angular scale goes as ``1/nu``.  Each pixel
+therefore sees a flux that oscillates with frequency on top of the true power
+law, and a per-pixel fit reads that as spectral index: coherent, spatially
+periodic ripples, strongest where the residual carries a large fraction of the
+flux (the diffuse emission), weakest on the bright deconvolved structure.
+
+Six diagnostics, in decreasing order of how decisive they are:
+
+1. **Sidelobes survive homogenisation.**  Convolve each band's stored PSF from
+   ``PSFPARSN_b`` to ``G`` -- exactly what restore does to the residual -- and
+   compare bands.  The cores must agree by construction; if the sidelobes do
+   not, the mechanism above is demonstrated on the actual data.
+2. **The dirty beam scales as 1/nu.**  Correlate band b's PSF sidelobes with
+   band 0's, raw and after rescaling band 0 radially by ``nu_b / nu_0``.  A big
+   jump confirms the frequency dependence that drives the ripples.
+3. **alpha with and without the residual.**  Fit the per-pixel power law on
+   ``MODEL (x) G`` alone and on the full intrinsic image.  Their difference map
+   isolates what the residual term does to the spectral index; if it carries the
+   striping, the case is closed.
+4. **Restoration flux units.**  The main-lobe volume of the dirty beam over the
+   clean beam volume, per band.  It is not 1 and it is not constant in
+   frequency, which biases the restored spectrum wherever the residual matters.
+5. **FFT padding.**  ``restore_products`` convolves at ``pfrac=0.2``.  For a
+   source filling the frame that wraps, and it wraps differently per band.
+   Refit with ``pfrac=1.0`` and difference.
+6. **Beam model.**  Azimuthal profile of alpha about the pointing centre, plus
+   the angular and radial power spectra of the alpha maps.  A primary beam error
+   gives concentric structure; a PSF error gives the striping.
+
+Run (from the repo root, on the box holding the tree)::
+
+    uv run python scripts/test_spi_ripples.py /path/to/out_I.dt --nthreads 16
+
+Writes ``<outdir>/spi_ripples_report.txt`` (read this first),
+``spi_ripples_diagnostics.npz`` and ``spi_ripples_summary.png``.  Default
+``--size 512`` keeps the bundle under ~15 MB; shrink it if that is too much.
+"""
+
+import argparse
+import os
+import textwrap
+
+import numpy as np
+import xarray as xr
+from ducc0.misc import resize_thread_pool
+from scipy.ndimage import map_coordinates
+
+from pfb_imaging.utils.misc import convolve2gaussres, gaussian2d
+
+FWHM = 2 * np.sqrt(2 * np.log(2))
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("dt", help="Path to the restored tree, <output-filename>_<PRODUCT>.dt")
+    p.add_argument("--outdir", default=None, help="Where to write the bundle (default: alongside the tree)")
+    p.add_argument("--size", type=int, default=512, help="Side of the analysed cutout, in pixels")
+    p.add_argument(
+        "--centre",
+        default=None,
+        help="Cutout centre as 'y,x' in pixels. Default is the image centre; aim it at a "
+        "diffuse region where the ripples are visible",
+    )
+    p.add_argument("--psf-size", type=int, default=256, help="Side of the PSF window used for the sidelobe tests")
+    p.add_argument("--timeid", type=int, default=None, help="Which timeid to analyse (default: the first)")
+    p.add_argument("--drop-bands", type=int, nargs="*", default=(), help="Band ids to exclude, as spifit would")
+    p.add_argument("--threshold", type=float, default=2.5, help="SNR cut, matching the spifit run being diagnosed")
+    p.add_argument("--pb-min", type=float, default=0.15, help="Beam cut, matching the spifit run being diagnosed")
+    p.add_argument(
+        "--rms",
+        type=float,
+        default=None,
+        help="Override the noise estimate (Jy/beam) with the value the spifit run reported, "
+        "so the mask matches the alpha map being diagnosed",
+    )
+    p.add_argument("--model-name", default="MODEL")
+    p.add_argument("--residual-name", default="RESIDUAL")
+    p.add_argument("--image-name", default="IMAGE", help="Stored restored product, used as a consistency check")
+    p.add_argument("--nthreads", type=int, default=8)
+    p.add_argument("--maxiter", type=int, default=50, help="Gauss-Newton iterations in the alpha fit")
+    p.add_argument("--no-png", action="store_true")
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
+
+
+def grids(ny, nx):
+    """The (X, Y)-ordered coordinate grids convolve2gaussres expects (wiki D19)."""
+    x = -(nx // 2) + np.arange(nx)
+    y = -(ny // 2) + np.arange(ny)
+    return np.meshgrid(x, y, indexing="ij")
+
+
+def conv(image, gaussparf, gausspari=None, nthreads=1, pfrac=0.2):
+    """restore_products' convolution, on a single (ny, nx) plane."""
+    ny, nx = image.shape
+    xx, yy = grids(ny, nx)
+    out = convolve2gaussres(
+        image[None],
+        xx,
+        yy,
+        np.asarray(gaussparf, dtype=float),
+        nthreads=nthreads,
+        gausspari=None if gausspari is None else np.asarray(gausspari, dtype=float),
+        pfrac=pfrac,
+        norm_kernel=False,
+        yx_order=True,
+    )[0]
+    return np.ascontiguousarray(out)
+
+
+def fit_alpha(cube, weights, freqs, nu_ref, maxiter=50, tol=1e-6):
+    """Weighted Gauss-Newton fit of I(nu) = I0 (nu/nu_ref)**alpha, per pixel.
+
+    Mirrors spimple.utils.fit_spi._fit_spi_components_impl (beam folded into the
+    weights, which is the intrinsic-scale form), vectorised over pixels.
+
+    Args:
+        cube: (nband, npix) fluxes.
+        weights: (nband, npix) or (nband,) inverse-variance weights.
+        freqs: (nband,) frequencies.
+        nu_ref: reference frequency.
+
+    Returns:
+        (alpha, i0, converged) each (npix,); converged is a bool array.
+    """
+    cube = np.asarray(cube, dtype=np.float64)
+    nband, npix = cube.shape
+    w = (freqs / nu_ref).astype(np.float64)[:, None]  # (nband, 1)
+    wgt = np.broadcast_to(np.atleast_2d(weights.T).T if weights.ndim > 1 else weights[:, None], (nband, npix))
+
+    # initialise from a log-space linear fit where every band is positive, which
+    # is most of the mask; elsewhere fall back to a flat spectrum
+    pos = np.all(cube > 0, axis=0)
+    alpha = np.full(npix, -0.7)
+    lw = np.log(w[:, 0])
+    with np.errstate(invalid="ignore", divide="ignore"):
+        ly = np.log(np.where(cube > 0, cube, 1.0))
+    sw = wgt.sum(axis=0)
+    mx = (wgt * lw[:, None]).sum(axis=0) / sw
+    my = (wgt * ly).sum(axis=0) / sw
+    cov = (wgt * (lw[:, None] - mx) * (ly - my)).sum(axis=0)
+    var = (wgt * (lw[:, None] - mx) ** 2).sum(axis=0)
+    alpha[pos] = np.where(var > 0, cov / np.maximum(var, 1e-30), -0.7)[pos]
+    alpha = np.clip(alpha, -6.0, 6.0)
+    i0 = np.maximum((wgt * cube).sum(axis=0) / sw, 1e-12)
+
+    converged = np.zeros(npix, dtype=bool)
+    for _ in range(maxiter):
+        jac1 = w**alpha  # (nband, npix)
+        model = i0 * jac1
+        jac0 = model * np.log(w)
+        res = cube - model
+        h00 = (jac0 * wgt * jac0).sum(axis=0)
+        h01 = (jac0 * wgt * jac1).sum(axis=0)
+        h11 = (jac1 * wgt * jac1).sum(axis=0)
+        jr0 = (jac0 * wgt * res).sum(axis=0)
+        jr1 = (jac1 * wgt * res).sum(axis=0)
+        det = h00 * h11 - h01**2
+        det = np.where(np.abs(det) < 1e-30, 1e-30, det)
+        da = (h11 * jr0 - h01 * jr1) / det
+        di = (-h01 * jr0 + h00 * jr1) / det
+        step = np.maximum(np.abs(da), np.abs(di / np.maximum(np.abs(i0), 1e-12)))
+        alpha = np.clip(alpha + da, -8.0, 8.0)
+        i0 = i0 + di
+        converged = step < tol
+        if converged.all():
+            break
+    return alpha, i0, converged
+
+
+def radial_profile(image, nbins=120, centre=None):
+    """Azimuthal mean and the radii it was taken at, ignoring NaN."""
+    ny, nx = image.shape
+    cy, cx = (ny // 2, nx // 2) if centre is None else centre
+    y, x = np.mgrid[:ny, :nx]
+    r = np.hypot(y - cy, x - cx)
+    bins = np.linspace(0, r.max(), nbins + 1)
+    idx = np.digitize(r.ravel(), bins) - 1
+    flat = image.ravel()
+    prof = np.full(nbins, np.nan)
+    for b in range(nbins):
+        sel = (idx == b) & np.isfinite(flat)
+        if sel.any():
+            prof[b] = flat[sel].mean()
+    return 0.5 * (bins[1:] + bins[:-1]), prof
+
+
+def power_spectra(image, mask, smooth=8):
+    """Radial and angular power spectra of the fine structure in a masked map.
+
+    Returns (wavelengths_px, radial_power, pa_deg, angular_power). The map is
+    high-passed mask-aware first, so the astrophysical gradient does not swamp
+    the ripples, and apodised so the mask edge does not ring.
+    """
+    from scipy.ndimage import gaussian_filter
+
+    m = mask.astype(float)
+    filled = np.where(mask, image, 0.0)
+    num = gaussian_filter(filled * m, smooth)
+    den = gaussian_filter(m, smooth)
+    hp = (filled - np.where(den > 1e-3, num / np.maximum(den, 1e-9), 0.0)) * m
+
+    n = min(hp.shape)
+    hp = hp[:n, :n]
+    win = np.hanning(n)[:, None] * np.hanning(n)[None, :]
+    hat = np.fft.fftshift(np.abs(np.fft.fft2(hp * win)) ** 2)
+    ky = np.fft.fftshift(np.fft.fftfreq(n))[:, None] * np.ones((1, n))
+    kx = np.ones((n, 1)) * np.fft.fftshift(np.fft.fftfreq(n))[None, :]
+    kr = np.hypot(kx, ky)
+    hat[kr < 3.0 / n] = 0.0
+
+    bins = np.geomspace(3.0 / n, 0.5, 41)
+    idx = np.digitize(kr.ravel(), bins)
+    rad = np.array([hat.ravel()[idx == b].mean() if (idx == b).any() else np.nan for b in range(1, len(bins))])
+    kmid = 0.5 * (bins[1:] + bins[:-1])
+
+    pa = np.rad2deg(np.arctan2(ky, kx)) % 180
+    band = (kr > 0.01) & (kr < 0.25)
+    edges = np.arange(0, 181, 10)
+    ang = np.array([hat[band & (pa >= lo) & (pa < lo + 10)].mean() for lo in edges[:-1]])
+    return 1.0 / kmid, rad, 0.5 * (edges[1:] + edges[:-1]), ang
+
+
+def psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, psf_size, nthreads, say):
+    """Diagnostics 1, 2 and 4: sidelobes, their 1/nu scaling, and flux units.
+
+    Returns a dict of arrays for the bundle.
+    """
+    ref = dt[keep[0]].ds
+    _, nyp, nxp = ref.PSF.shape
+    h = int(min(psf_size, nyp, nxp)) // 2
+    sy = slice(nyp // 2 - h, nyp // 2 + h)
+    sx = slice(nxp // 2 - h, nxp // 2 + h)
+    n = 2 * h
+
+    psfs, homog = [], []
+    for b, node in enumerate(keep):
+        p = np.asarray(dt[node].ds.PSF.isel(corr=0, y_psf=sy, x_psf=sx).values, dtype=np.float64) / wsums[b]
+        psfs.append(p)
+        # exactly what restore does to the residual: PSFPARSN_b -> G
+        homog.append(conv(p, gcommon, gausspari=psfparsn[b], nthreads=nthreads))
+    psfs = np.stack(psfs)
+    homog = np.stack(homog)
+
+    yy, xx = np.mgrid[:n, :n]
+    r = np.hypot(yy - n // 2, xx - n // 2)
+    # "main lobe" = inside the common restoring beam's major axis; everything
+    # beyond it is sidelobe as far as the restoration is concerned
+    core = r <= gcommon[0]
+    wings = r > 1.5 * gcommon[0]
+
+    # --- diagnostic 1: does homogenisation equalise the sidelobes? ----------
+    say("DIAGNOSTIC 1 -- do the sidelobes survive homogenisation to the common beam?")
+    say("  Each band's PSF is convolved from PSFPARSN_b to PSFPARSF, which is exactly what")
+    say("  restore does to RESIDUAL. The cores must agree by construction. If the wings do")
+    say("  not, a Gaussian reconvolution cannot equalise them and the residual carries")
+    say("  band-dependent structure into the fit.")
+    say(f"{'band':>5} {'core rms diff':>15} {'wing rms diff':>15} {'wing rms':>12} {'ratio wing/core':>16}")
+    core_diff, wing_diff, wing_rms = [], [], []
+    p0 = homog[0]
+    p0c = np.sqrt(np.mean(p0[core] ** 2))
+    for b in range(len(keep)):
+        d = homog[b] - p0
+        cd = np.sqrt(np.mean(d[core] ** 2)) / p0c
+        wd = np.sqrt(np.mean(d[wings] ** 2)) / p0c
+        wr = np.sqrt(np.mean(homog[b][wings] ** 2)) / p0c
+        core_diff.append(cd)
+        wing_diff.append(wd)
+        wing_rms.append(wr)
+        say(f"{b:5d} {cd:15.3e} {wd:15.3e} {wr:12.3e} {wd / max(cd, 1e-30):16.1f}")
+    say("  Read: wing rms diff >> core rms diff means homogenisation matched the cores and")
+    say("  left the sidelobes mismatched -- the mechanism behind the ripples.")
+    say()
+
+    # --- diagnostic 2: do the sidelobes scale as 1/nu? ---------------------
+    say("DIAGNOSTIC 2 -- do the dirty beam's sidelobes scale as 1/nu?")
+    say("  Correlation of band b's PSF wings with band 0's, raw and after rescaling band 0")
+    say("  radially by nu_b/nu_0. A jump from raw to rescaled confirms the frequency")
+    say("  dependence that turns a static sidelobe pattern into a spectral signal.")
+    say(f"{'band':>5} {'nu_b/nu_0':>10} {'corr raw':>10} {'corr rescaled':>15}")
+    corr_raw, corr_scaled = [], []
+    cy = cx = n // 2
+    for b in range(len(keep)):
+        s = freqs[b] / freqs[0]
+        # PSF_b(x) ~ PSF_0(x * nu_b/nu_0) if the beam shrinks as 1/nu
+        coords = np.array([(yy - cy) * s + cy, (xx - cx) * s + cx])
+        p0s = map_coordinates(psfs[0], coords, order=1, mode="constant", cval=0.0)
+        a, braw, bsc = psfs[b][wings], psfs[0][wings], p0s[wings]
+
+        def cc(u, v):
+            u = u - u.mean()
+            v = v - v.mean()
+            d = np.sqrt((u * u).sum() * (v * v).sum())
+            return float((u * v).sum() / d) if d > 0 else np.nan
+
+        corr_raw.append(cc(a, braw))
+        corr_scaled.append(cc(a, bsc))
+        say(f"{b:5d} {s:10.4f} {corr_raw[-1]:10.4f} {corr_scaled[-1]:15.4f}")
+    say()
+
+    # --- diagnostic 4: restoration flux units ------------------------------
+    say("DIAGNOSTIC 4 -- clean beam volume vs dirty beam main-lobe volume.")
+    say("  MODEL (x) G is Jy per clean beam; RESIDUAL is Jy per dirty beam. The restored sum")
+    say("  is only consistent if the ratio below is 1 and constant in frequency. It is")
+    say("  neither, so the residual enters the spectrum with a band-dependent scale.")
+    xxg, yyg = grids(n, n)
+    say(f"{'band':>5} {'dirty mainlobe':>16} {'clean volume':>14} {'ratio':>10} {'vs band 0':>11}")
+    eps = []
+    for b in range(len(keep)):
+        gk = gaussian2d(xxg, yyg, psfparsn[b], normalise=False).T
+        dirty_vol = float(psfs[b][core].sum())
+        clean_vol = float(gk[core].sum())
+        eps.append(dirty_vol / clean_vol if clean_vol else np.nan)
+        say(f"{b:5d} {dirty_vol:16.4e} {clean_vol:14.4e} {eps[-1]:10.5f} {eps[-1] / eps[0]:11.5f}")
+    spread = (max(eps) - min(eps)) / np.mean(eps)
+    say(f"  spread across bands: {100 * spread:.2f} percent of the mean")
+    say()
+
+    prof = np.stack([radial_profile(p, nbins=120)[1] for p in psfs])
+    rad = radial_profile(psfs[0], nbins=120)[0]
+    return {
+        "psf_radial_r": rad,
+        "psf_radial": prof,
+        "psf_homog": homog.astype(np.float32),
+        "psf_core_diff": np.array(core_diff),
+        "psf_wing_diff": np.array(wing_diff),
+        "psf_wing_rms": np.array(wing_rms),
+        "psf_corr_raw": np.array(corr_raw),
+        "psf_corr_scaled": np.array(corr_scaled),
+        "beam_volume_ratio": np.array(eps),
+    }
+
+
+def main():
+    args = parse_args()
+    resize_thread_pool(args.nthreads)
+    outdir = args.outdir or os.path.dirname(os.path.abspath(args.dt.rstrip("/"))) or "."
+    os.makedirs(outdir, exist_ok=True)
+    lines = []
+
+    def say(msg=""):
+        print(msg, flush=True)
+        lines.append(msg)
+
+    say(f"spi ripple diagnostics for {args.dt}")
+    say("=" * 78)
+
+    # ---- tree, bands, geometry -------------------------------------------
+    dt = xr.open_datatree(args.dt, engine="zarr", chunks={})
+    band_nodes = [n for n in dt.children if n.startswith("band")]
+    if not band_nodes:
+        raise SystemExit(f"{args.dt} has no band nodes")
+    tids = sorted({int(dt[n].ds.attrs["timeid"]) for n in band_nodes})
+    tid = tids[0] if args.timeid is None else args.timeid
+    nodes = sorted(
+        (n for n in band_nodes if int(dt[n].ds.attrs["timeid"]) == tid),
+        key=lambda n: int(dt[n].ds.attrs["bandid"]),
+    )
+    dropped = set(args.drop_bands or ())
+    keep = [n for n in nodes if int(dt[n].ds.attrs["bandid"]) not in dropped]
+    keep = [n for n in keep if float(np.sum(dt[n].ds.WSUM.values)) > 0]
+    if len(keep) < 2:
+        raise SystemExit("Need at least two live bands")
+
+    ref = dt[keep[0]].ds
+    ncorr, ny, nx = ref[args.model_name].shape
+    cell_deg = np.rad2deg(float(ref.attrs["cell_rad"]))
+    nband = len(keep)
+    freqs = np.array([float(dt[n].ds.attrs["freq_out"]) for n in keep])
+    wsums = np.array([float(np.atleast_1d(dt[n].ds.WSUM.values)[0]) for n in keep])
+    psfparsn = np.stack([np.asarray(dt[n].ds.PSFPARSN.values, dtype=float)[0] for n in keep])
+    has_psfparsf = "PSFPARSF" in ref
+    gcommon = np.asarray(ref.PSFPARSF.values, dtype=float)[0] if has_psfparsf else psfparsn.max(axis=0)
+
+    say(f"timeid {tid}: {nband} live bands of {len(nodes)}, image {ny} x {nx}, cell {cell_deg * 3600:.3f} arcsec")
+    say(f"frequencies {freqs[0] / 1e6:.1f} - {freqs[-1] / 1e6:.1f} MHz (ratio {freqs[-1] / freqs[0]:.3f})")
+    say(
+        f"common restoring beam PSFPARSF = ({gcommon[0]:.3f}, {gcommon[1]:.3f}) px, pa {np.rad2deg(gcommon[2]):.2f} deg"
+    )
+    if not has_psfparsf:
+        say("  WARNING: no PSFPARSF -- the tree was not homogenised; using max axes as the target")
+    say()
+    say("per band: native beam PSFPARSN, and how far it is from the common target")
+    say(f"{'band':>5} {'freq/MHz':>10} {'emaj':>8} {'emin':>8} {'pa/deg':>8} {'wsum':>11} {'emaj_G/emaj_b':>14}")
+    for b, n in enumerate(keep):
+        say(
+            f"{int(dt[n].ds.attrs['bandid']):5d} {freqs[b] / 1e6:10.2f} {psfparsn[b, 0]:8.3f} {psfparsn[b, 1]:8.3f} "
+            f"{np.rad2deg(psfparsn[b, 2]):8.2f} {wsums[b]:11.4e} {gcommon[0] / psfparsn[b, 0]:14.4f}"
+        )
+    say()
+
+    # ---- cutout window ----------------------------------------------------
+    if args.centre:
+        cy, cx = (int(v) for v in args.centre.split(","))
+    else:
+        cy, cx = ny // 2, nx // 2
+    # clamp so a cutout larger than the image, or a centre near an edge, still works
+    size = int(min(args.size, ny, nx))
+    half = size // 2
+    size = 2 * half
+    cy = int(np.clip(cy, half, ny - half))
+    cx = int(np.clip(cx, half, nx - half))
+    margin = int(np.ceil(4 * gcommon[0]))
+    y0, y1 = max(0, cy - half - margin), min(ny, cy + half + margin)
+    x0, x1 = max(0, cx - half - margin), min(nx, cx + half + margin)
+    ty0, tx0 = cy - half - y0, cx - half - x0
+    trim = (slice(ty0, ty0 + size), slice(tx0, tx0 + size))
+    say(f"cutout centred on (y={cy}, x={cx}), {size} px analysed with a {margin} px convolution margin")
+    if size < args.size:
+        say(f"  (--size {args.size} was clamped to the image)")
+    say()
+
+    bundle = psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, args.psf_size, args.nthreads, say)
+
+    # ---- rebuild the restored image, term by term -------------------------
+    say("Rebuilding the restored cutout term by term (this repeats what restore did).")
+    sel = dict(corr=0, y=slice(y0, y1), x=slice(x0, x1))
+    mconv, rconv, rconv1, beams = [], [], [], []
+    for b, node in enumerate(keep):
+        ds = dt[node].ds
+        model = np.asarray(ds[args.model_name].isel(**sel).values, dtype=np.float64)
+        resid = np.asarray(ds[args.residual_name].isel(**sel).values, dtype=np.float64) / wsums[b]
+        beams.append(np.asarray(ds.BEAM.isel(**sel).values, dtype=np.float64)[trim])
+        mconv.append(conv(model, gcommon, nthreads=args.nthreads)[trim])
+        rconv.append(conv(resid, gcommon, gausspari=psfparsn[b], nthreads=args.nthreads)[trim])
+        rconv1.append(conv(resid, gcommon, gausspari=psfparsn[b], nthreads=args.nthreads, pfrac=1.0)[trim])
+    mconv, rconv, rconv1 = np.stack(mconv), np.stack(rconv), np.stack(rconv1)
+    beams = np.stack(beams)
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        image_full = mconv + np.where(beams > 0, rconv / beams, 0.0)
+        image_p1 = mconv + np.where(beams > 0, rconv1 / beams, 0.0)
+
+    # consistency: does the rebuild match what restore stored?
+    if args.image_name in ref:
+        stored = np.stack(
+            [np.asarray(dt[n].ds[args.image_name].isel(**sel).values, dtype=np.float64)[trim] for n in keep]
+        )
+        err = np.nanmax(np.abs(image_full - stored)) / np.nanmax(np.abs(stored))
+        say(f"  rebuild vs stored {args.image_name}: max relative difference {err:.3e}")
+        if err > 1e-3:
+            say("  WARNING: the rebuild does not match the tree. Was restore run at a different")
+            say("  --gausspar, or with a different pfrac? Interpret the alpha maps with care.")
+        del stored
+    say()
+
+    # ---- mask, matching what spifit would cut on --------------------------
+    # spifit takes the rms as std(RESIDUAL/WSUM); reproduce that, but report a
+    # MAD estimate too -- over a cutout full of source the std is signal, not noise
+    rms_b = np.array([float(np.std(rconv[b])) for b in range(nband)])
+    mad_b = np.array([float(1.4826 * np.median(np.abs(rconv[b] - np.median(rconv[b])))) for b in range(nband)])
+    weights_b = wsums / wsums.max()
+    rms_mfs = float(np.sum(rms_b * weights_b) / weights_b.sum())
+    mad_mfs = float(np.sum(mad_b * weights_b) / weights_b.sum())
+    if args.rms is not None:
+        rms_mfs = args.rms
+        say(f"mask: rms {rms_mfs:.4e} Jy/beam (from --rms)")
+    else:
+        say(f"mask: rms {rms_mfs:.4e} Jy/beam (std, as spifit computes it); MAD estimate {mad_mfs:.4e}")
+        if rms_mfs > 3 * mad_mfs:
+            say("      NOTE: std is much larger than MAD, so it is measuring source not noise.")
+            say("      Pass --rms with the value your spifit run reported to match its mask.")
+    thresh = args.threshold * rms_mfs
+    apparent = image_full * beams  # spifit compares on the apparent scale
+    mask = (beams.min(axis=0) > args.pb_min) & np.isfinite(apparent).all(axis=0) & (apparent.min(axis=0) > thresh)
+    say(f"      threshold {args.threshold} x rms = {thresh:.4e} Jy/beam")
+    say(f"      {int(mask.sum())} of {mask.size} pixels fitted ({100 * mask.mean():.1f} percent)")
+    if mask.sum() < 500:
+        say("      WARNING: very few pixels. Lower --threshold, pass --rms, or move --centre.")
+    say()
+
+    # ---- diagnostics 3 and 5: alpha with and without the residual ---------
+    idx = np.argwhere(mask)
+    nu_ref = float(np.sum(freqs * wsums) / np.sum(wsums))
+    pb = beams[:, idx[:, 0], idx[:, 1]]
+    wfit = weights_b[:, None] * pb**2  # intrinsic-scale weights, as spifit uses
+
+    say("DIAGNOSTIC 3 -- what does the residual term do to alpha?")
+    say(f"  Reference frequency {nu_ref / 1e6:.2f} MHz. Fitting {len(idx)} pixels three ways.")
+    maps, good = {}, np.ones(len(idx), dtype=bool)
+    for name, cube in (("full", image_full), ("model", mconv), ("pfrac1", image_p1)):
+        a, i0, ok = fit_alpha(cube[:, idx[:, 0], idx[:, 1]], wfit, freqs, nu_ref, maxiter=args.maxiter)
+        m = np.full(mask.shape, np.nan, dtype=np.float32)
+        m[idx[:, 0], idx[:, 1]] = np.where(ok, a, np.nan)
+        maps[name] = m
+        good &= ok
+        say(
+            f"  alpha[{name:6}] median {np.nanmedian(a[ok]) if ok.any() else np.nan:7.3f}  "
+            f"std {np.nanstd(a[ok]) if ok.any() else np.nan:7.3f}  "
+            f"unconverged {100 * (1 - ok.mean()):5.1f} percent"
+        )
+    # compare only where every fit converged, else the statistic is contaminated
+    # by pixels the model-only fit could not constrain (no model flux there)
+    dalpha = maps["full"] - maps["model"]
+    dg = dalpha[idx[good, 0], idx[good, 1]]
+    say(f"  comparing on the {int(good.sum())} pixels ({100 * good.mean():.1f} percent) where all three converged")
+    say(f"  alpha[full] - alpha[model]: median {np.nanmedian(dg):.4f}, std {np.nanstd(dg):.4f}")
+    a_model = maps["model"][idx[good, 0], idx[good, 1]]
+    say(f"  for reference, alpha[model] over the same pixels has std {np.nanstd(a_model):.4f}")
+    say("  The first std is the spectral index the residual term invents; the second is the")
+    say("  spread the deconvolved sky actually has. If the first is comparable to or larger")
+    say("  than the second, the ripples are the residual and not the sky.")
+    say()
+
+    resfrac = np.full(mask.shape, np.nan, dtype=np.float32)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        rf = np.abs(rconv / np.maximum(beams, 1e-12)) / (np.abs(mconv) + np.abs(rconv / np.maximum(beams, 1e-12)))
+    resfrac[mask] = np.nanmedian(rf, axis=0)[mask]
+    say(f"  median residual flux fraction over the mask: {np.nanmedian(resfrac[mask]):.3f}")
+    say("  (the fraction of each pixel's restored flux that comes from the residual term)")
+    say()
+
+    say("DIAGNOSTIC 5 -- is the pfrac=0.2 padding in restore_products contributing?")
+    dp = maps["pfrac1"] - maps["full"]
+    say(f"  alpha[pfrac=1] - alpha[pfrac=0.2]: median {np.nanmedian(dp):.4f}, std {np.nanstd(dp):.4f}")
+    say("  A std comparable to the ripple amplitude means FFT wrap-around is a real")
+    say("  contributor and restore_products should pad more.")
+    say()
+
+    # ---- diagnostic 6: geometry of the ripples ---------------------------
+    say("DIAGNOSTIC 6 -- geometry: is it striping (PSF) or rings (primary beam)?")
+    spectra = {}
+    for name in ("full", "model"):
+        wl, rad, pa, ang = power_spectra(np.nan_to_num(maps[name]), mask)
+        spectra[name] = (wl, rad, pa, ang)
+    wl, rad_full, pa, ang_full = spectra["full"]
+    peak = int(np.nanargmax(rad_full))
+    say(
+        f"  alpha[full] fine-structure power peaks at {wl[peak]:.1f} px = "
+        f"{wl[peak] / gcommon[0]:.2f} restoring beams = {wl[peak] * cell_deg * 3600:.1f} arcsec"
+    )
+    aniso = np.nanmax(ang_full) / np.nanmin(ang_full)
+    say(f"  angular anisotropy {aniso:.2f} (peak at PA {pa[int(np.nanargmax(ang_full))]:.0f} deg)")
+    say("  A high anisotropy at a fixed PA is PSF striping. A flat angular spectrum with a")
+    say("  strong radial signal about the pointing centre is a primary beam error.")
+    rr, aprof = radial_profile(np.where(mask, maps["full"], np.nan), nbins=80)
+    say()
+
+    # ---- write the bundle -------------------------------------------------
+    bundle.update(
+        alpha_full=maps["full"],
+        alpha_model=maps["model"],
+        alpha_pfrac1=maps["pfrac1"],
+        dalpha_residual=dalpha.astype(np.float32),
+        dalpha_pfrac=dp.astype(np.float32),
+        residual_fraction=resfrac,
+        mask=mask,
+        beam_band0=beams[0].astype(np.float32),
+        freqs=freqs,
+        wsums=wsums,
+        psfparsn=psfparsn,
+        gcommon=gcommon,
+        cell_deg=np.array(cell_deg),
+        nu_ref=np.array(nu_ref),
+        rms_per_band=rms_b,
+        centre=np.array([cy, cx]),
+        image_shape=np.array([ny, nx]),
+        ps_wavelength=wl,
+        ps_radial_full=rad_full,
+        ps_radial_model=spectra["model"][1],
+        ps_pa=pa,
+        ps_angular_full=ang_full,
+        ps_angular_model=spectra["model"][3],
+        alpha_radial_r=rr,
+        alpha_radial=aprof,
+    )
+    npz = os.path.join(outdir, "spi_ripples_diagnostics.npz")
+    np.savez_compressed(npz, **bundle)
+    say(f"wrote {npz} ({os.path.getsize(npz) / 1e6:.1f} MB)")
+
+    if not args.no_png:
+        write_png(os.path.join(outdir, "spi_ripples_summary.png"), bundle, say)
+
+    report = os.path.join(outdir, "spi_ripples_report.txt")
+    with open(report, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    print(f"wrote {report}")
+    print(
+        textwrap.dedent(f"""
+        Pull these back:
+          {report}
+          {npz}
+          {os.path.join(outdir, "spi_ripples_summary.png")}
+    """)
+    )
+
+
+def write_png(path, bundle, say):
+    """Panels: the alpha maps, what the residual adds, and the spectra."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(2, 4, figsize=(22, 10))
+    mask = bundle["mask"]
+
+    def show(a, key, title, cmap="plasma", robust=True):
+        arr = np.where(mask, bundle[key], np.nan)
+        lo, hi = np.nanpercentile(arr, [2, 98]) if robust else (None, None)
+        im = a.imshow(arr, origin="lower", cmap=cmap, vmin=lo, vmax=hi)
+        a.set_title(title, fontsize=10)
+        a.set_xticks([])
+        a.set_yticks([])
+        plt.colorbar(im, ax=a, fraction=0.046)
+
+    show(ax[0, 0], "alpha_full", "alpha from the full restored image")
+    show(ax[0, 1], "alpha_model", "alpha from MODEL (x) G only")
+    show(ax[0, 2], "dalpha_residual", "what the residual term adds to alpha", cmap="RdBu_r")
+    show(ax[0, 3], "residual_fraction", "residual fraction of the restored flux", cmap="viridis")
+
+    ax[1, 0].plot(bundle["ps_wavelength"], bundle["ps_radial_full"], label="alpha full")
+    ax[1, 0].plot(bundle["ps_wavelength"], bundle["ps_radial_model"], label="alpha model")
+    ax[1, 0].set_xscale("log")
+    ax[1, 0].set_yscale("log")
+    ax[1, 0].set_xlabel("wavelength [px]")
+    ax[1, 0].set_title("radial power spectrum of alpha", fontsize=10)
+    ax[1, 0].legend(fontsize=8)
+
+    ax[1, 1].plot(bundle["ps_pa"], bundle["ps_angular_full"], label="alpha full")
+    ax[1, 1].plot(bundle["ps_pa"], bundle["ps_angular_model"], label="alpha model")
+    ax[1, 1].set_xlabel("PA of the wavevector [deg]")
+    ax[1, 1].set_title("angular power (striping direction)", fontsize=10)
+    ax[1, 1].legend(fontsize=8)
+
+    # band 0 is the reference and identically zero; plotting it flattens the axis
+    nb = len(bundle["freqs"])
+    ax[1, 2].semilogy(range(1, nb), bundle["psf_core_diff"][1:], "o-", label="core")
+    ax[1, 2].semilogy(range(1, nb), bundle["psf_wing_diff"][1:], "s-", label="wings")
+    ax[1, 2].set_xlabel("band")
+    ax[1, 2].set_title("PSF difference from band 0 after homogenisation", fontsize=10)
+    ax[1, 2].legend(fontsize=8)
+
+    ax[1, 3].plot(bundle["freqs"] / 1e6, bundle["psf_corr_raw"], "o-", label="raw")
+    ax[1, 3].plot(bundle["freqs"] / 1e6, bundle["psf_corr_scaled"], "s-", label="rescaled by nu")
+    ax[1, 3].set_xlabel("frequency [MHz]")
+    ax[1, 3].set_title("sidelobe correlation with band 0", fontsize=10)
+    ax[1, 3].legend(fontsize=8)
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=110)
+    plt.close(fig)
+    say(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -605,6 +605,16 @@ def main():
         image_full = mconv + np.where(beams > 0, rconv / beams, 0.0)
         image_p1 = mconv + np.where(beams > 0, rconv1 / beams, 0.0)
 
+    # if restore stored CRESIDUAL (--outputs s), check the rebuild against it
+    # directly rather than only through the restored image
+    if "CRESIDUAL" in ref:
+        cres = np.stack([np.asarray(dt[n].ds.CRESIDUAL.isel(**sel).values, dtype=np.float64)[trim] for n in keep])
+        e = np.nanmax(np.abs(rconv - cres)) / max(np.nanmax(np.abs(cres)), 1e-30)
+        say(f"  rebuild vs stored CRESIDUAL: max relative difference {e:.3e}")
+        del cres
+    else:
+        say("  (no CRESIDUAL in the tree; re-run restore with --outputs s to store it)")
+
     # consistency: does the rebuild match what restore stored?
     if args.image_name in ref:
         stored = np.stack(

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -86,8 +86,9 @@ def parse_args():
     p.add_argument(
         "--centre",
         default=None,
-        help="Cutout centre as 'y,x' in pixels. Default is the image centre; aim it at a "
-        "diffuse region where the ripples are visible",
+        help="Cutout centre as 'y,x' array indices into the full image (not offsets from "
+        "its centre). Default is the image centre; aim it at a diffuse region where the "
+        "ripples are visible. Clamped so the window stays inside the image",
     )
     p.add_argument("--psf-size", type=int, default=256, help="Side of the PSF window used for the sidelobe tests")
     p.add_argument("--timeid", type=int, default=None, help="Which timeid to analyse (default: the first)")
@@ -651,8 +652,23 @@ def main():
     mask = (beams.min(axis=0) > args.pb_min) & np.isfinite(apparent).all(axis=0) & (apparent.min(axis=0) > thresh)
     say(f"      threshold {args.threshold} x rms = {thresh:.4e} Jy/beam")
     say(f"      {int(mask.sum())} of {mask.size} pixels fitted ({100 * mask.mean():.1f} percent)")
-    if mask.sum() < 500:
-        say("      WARNING: very few pixels. Lower --threshold, pass --rms, or move --centre.")
+    if mask.sum() < 200:
+        # stop here rather than write a bundle of NaN: on a remote run that
+        # costs a download before anyone notices the maps are empty
+        peak = float(np.nanmax(apparent.min(axis=0))) if np.isfinite(apparent).any() else np.nan
+        bmin = float(np.nanmax(beams.min(axis=0)))
+        raise SystemExit(
+            f"\nOnly {int(mask.sum())} pixels pass the cuts -- not enough to diagnose anything.\n"
+            f"  brightest pixel (min over bands, apparent): {peak:.4e} Jy/beam\n"
+            f"  threshold currently:                        {thresh:.4e} Jy/beam\n"
+            f"  best beam value in the cutout:              {bmin:.3f} (--pb-min is {args.pb_min})\n"
+            f"Aim --centre at emission (it is (y, x) array indices into the full "
+            f"{ny} x {nx} image, so the middle is {ny // 2},{nx // 2}), pass --rms with the "
+            f"value your spifit run reported, or lower --threshold."
+        )
+    if mask.sum() < 2000:
+        say("      WARNING: few pixels. The power spectra will be noisy; consider a")
+        say("      brighter --centre or a lower --threshold.")
     say()
 
     # ---- diagnostics 3 and 5: alpha with and without the residual ---------

--- a/src/pfb_imaging/cabs/deconv.yml
+++ b/src/pfb_imaging/cabs/deconv.yml
@@ -155,6 +155,23 @@ cabs:
         default: 100.0
         metadata:
           rich_help_panel: PFB
+      gp-length-scale:
+        info:
+          Correlation length of the frequency prior in the preconditioner.
+          Given as a fraction of the imaged band span.
+          By default the prior is uncorrelated and eta damps every band independently.
+          This reshapes the forward update without moving the fixed point, so the flux scale is unchanged.
+        dtype: Optional[float]
+        metadata:
+          rich_help_panel: PFB
+      gp-cap:
+        info:
+          Dynamic range of the frequency prior.
+          Ignored when gp-length-scale is unset.
+        dtype: float
+        default: 10.0
+        metadata:
+          rich_help_panel: PFB
       gamma:
         info:
           Step size of update.

--- a/src/pfb_imaging/cabs/restore.yml
+++ b/src/pfb_imaging/cabs/restore.yml
@@ -41,6 +41,7 @@ cabs:
           (d)irty, (m)odel, (r)esidual, (k) restored with intrinsic model and apparent residual.
           (a) restored fully apparent, (i) restored fully intrinsic (primary beam corrected).
           (c)lean beam image, (f)ft of the residual.
+          (s)moothed residual, the residual convolved to the restoring resolution.
           Use capitals to produce corresponding cubes.
         default: kK
         metadata:

--- a/src/pfb_imaging/cli/deconv.py
+++ b/src/pfb_imaging/cli/deconv.py
@@ -206,6 +206,23 @@ def deconv(
             rich_help_panel="PFB",
         ),
     ] = 100.0,
+    gp_length_scale: Annotated[
+        float | None,
+        typer.Option(
+            help="Correlation length of the frequency prior in the preconditioner. "
+            "Given as a fraction of the imaged band span. "
+            "By default the prior is uncorrelated and eta damps every band independently. "
+            "This reshapes the forward update without moving the fixed point, so the flux scale is unchanged.",
+            rich_help_panel="PFB",
+        ),
+    ] = None,
+    gp_cap: Annotated[
+        float,
+        typer.Option(
+            help="Dynamic range of the frequency prior. Ignored when gp-length-scale is unset.",
+            rich_help_panel="PFB",
+        ),
+    ] = 10.0,
     gamma: Annotated[
         float,
         typer.Option(
@@ -518,6 +535,8 @@ def deconv(
                     eta=eta,
                     eta_mode=eta_mode,
                     eta_cap=eta_cap,
+                    gp_length_scale=gp_length_scale,
+                    gp_cap=gp_cap,
                     gamma=gamma,
                     nbasisf=nbasisf,
                     positivity=positivity,
@@ -578,6 +597,8 @@ def deconv(
                 eta=eta,
                 eta_mode=eta_mode,
                 eta_cap=eta_cap,
+                gp_length_scale=gp_length_scale,
+                gp_cap=gp_cap,
                 gamma=gamma,
                 nbasisf=nbasisf,
                 positivity=positivity,
@@ -647,6 +668,8 @@ def deconv(
             eta=eta,
             eta_mode=eta_mode,
             eta_cap=eta_cap,
+            gp_length_scale=gp_length_scale,
+            gp_cap=gp_cap,
             gamma=gamma,
             nbasisf=nbasisf,
             positivity=positivity,

--- a/src/pfb_imaging/cli/restore.py
+++ b/src/pfb_imaging/cli/restore.py
@@ -101,6 +101,7 @@ def restore(
             "(d)irty, (m)odel, (r)esidual, (k) restored with intrinsic model and apparent residual. "
             "(a) restored fully apparent, (i) restored fully intrinsic (primary beam corrected). "
             "(c)lean beam image, (f)ft of the residual. "
+            "(s)moothed residual, the residual convolved to the restoring resolution. "
             "Use capitals to produce corresponding cubes.",
             rich_help_panel="Output",
         ),

--- a/src/pfb_imaging/core/deconv.py
+++ b/src/pfb_imaging/core/deconv.py
@@ -43,6 +43,8 @@ def deconv(
     eta: float = 0.001,
     eta_mode: str | None = None,
     eta_cap: float = 100.0,
+    gp_length_scale: float | None = None,
+    gp_cap: float = 10.0,
     gamma: float = 0.95,
     nbasisf: int | None = None,
     positivity: int = 1,
@@ -180,7 +182,7 @@ def deconv(
     freq_out = np.array([dt[n].ds.attrs["freq_out"] for n in nodes])
     time_out = np.array([first.attrs["time_out"]])
     iter0 = int(first.attrs.get("niters", 0))
-    geometry = {"nx": nx, "ny": ny, "nx_psf": nx_psf, "ny_psf": ny_psf}
+    geometry = {"nx": nx, "ny": ny, "nx_psf": nx_psf, "ny_psf": ny_psf, "freq_out": freq_out}
 
     # load band cubes and attrs required on driver (MODEL/RESIDUAL/UPDATE/WSUM)
     # partition data (UVW/WEIGHT/MASK/FREQ/BEAM/PSFHAT/DIRTY) is read worker-side by BandWorkerPool.load_bands

--- a/src/pfb_imaging/core/deconv.py
+++ b/src/pfb_imaging/core/deconv.py
@@ -21,6 +21,44 @@ from pfb_imaging.utils.naming import set_output_names
 
 log = pfb_logging.get_logger("DECONV")
 
+# The options that define the preconditioner M. hess_norm is lambda_max(M) and is
+# cached in the band attrs across runs, so it is only reusable when every one of
+# these matches -- otherwise the primal-dual step sizes are derived from the norm
+# of a different operator.
+_M_OPTS = ("eta", "eta_mode", "eta_cap", "gp_length_scale", "gp_cap")
+
+
+def _m_signature(opts):
+    """JSON string identifying the preconditioner these options build.
+
+    Args:
+        opts: The deconv options dict.
+
+    Returns:
+        A sorted-key JSON string, safe to store as a zarr attribute.
+    """
+    return json.dumps({k: opts.get(k) for k in _M_OPTS}, sort_keys=True)
+
+
+def _cached_hess_norm(attrs, opts):
+    """Cached ``hess_norm`` when it was written for this preconditioner, else None.
+
+    Args:
+        attrs: A band node's attrs.
+        opts: The deconv options dict.
+
+    Returns:
+        The cached ``lambda_max(M)``, or None when it is absent or was written
+        for different preconditioner options. Trees written before this
+        signature existed carry no ``hess_norm_opts`` and are re-estimated,
+        which is the safe direction.
+    """
+    if "hess_norm" not in attrs:
+        return None
+    if attrs.get("hess_norm_opts") != _m_signature(opts):
+        return None
+    return float(attrs["hess_norm"])
+
 
 def deconv(
     output_filename: str,
@@ -230,10 +268,13 @@ def deconv(
     hdr_mfs = set_wcs(cell_deg, cell_deg, nx, ny, radec, np.mean(freq_out), casambm=False, l0=l0, m0=m0)
 
     # hess_norm from the tree cache when available; solver estimates it otherwise
-    if hess_norm is None and "hess_norm" in first.attrs:
-        hess_norm = first.attrs["hess_norm"]
-        opts_dict["hess_norm"] = hess_norm
-        log.info(f"Using previously estimated hess_norm of {hess_norm:.3e}")
+    if hess_norm is None:
+        hess_norm = _cached_hess_norm(first.attrs, opts_dict)
+        if hess_norm is not None:
+            opts_dict["hess_norm"] = hess_norm
+            log.info(f"Using previously estimated hess_norm of {hess_norm:.3e}")
+        elif "hess_norm" in first.attrs:
+            log.info("Preconditioner options changed since the cached hess_norm was written; re-estimating.")
 
     if minor_cycle not in PRESETS:
         log.error_and_raise(f"Unknown minor_cycle '{minor_cycle}'", ValueError)
@@ -422,6 +463,7 @@ def deconv(
                     "rmax": best_rmax,
                     "niters": k + 1,
                     "hess_norm": hess_norm,
+                    "hess_norm_opts": _m_signature(opts_dict),
                 },
             )
             ds_out.to_zarr(dt_name, group=n, mode="a")

--- a/src/pfb_imaging/core/deconv.py
+++ b/src/pfb_imaging/core/deconv.py
@@ -312,6 +312,16 @@ def deconv(
             f"({etas.max() / etas.min():.1f}x), band-to-band spread {100 * spread:.2f}% -> {name}"
         )
 
+    # the prior is the only band-coupling channel in M besides the prox, so its
+    # spectrum is what to read when a GP run converges differently (issue #307)
+    stats = getattr(getattr(solver, "hess", None), "get_freq_prior_stats", lambda: None)()
+    if stats is not None:
+        log.info(
+            f"GP prior spectrum: precision {stats['prec_min']:.3e} to {stats['prec_max']:.3e} "
+            f"({stats['prec_max'] / stats['prec_min']:.1f}x relaxation); contribution to M "
+            f"{stats['lam_min']:.3e} to {stats['lam_max']:.3e}"
+        )
+
     if rms_outside_model and model.any():
         rms = np.std(residual_mfs[model_mfs == 0])
     else:

--- a/src/pfb_imaging/core/restore.py
+++ b/src/pfb_imaging/core/restore.py
@@ -27,6 +27,7 @@ from pfb_imaging.utils.restoration import (
     beams_table,
     clean_beam,
     lowest_resolution,
+    resolution_deficit,
     restore_products,
     write_fits,
 )
@@ -180,11 +181,29 @@ def restore(
             log.info(
                 f"Using specified resolution of ({gausspar[0]:.3e} deg, {gausspar[1]:.3e} deg, {gausspar[2]:.3e} deg)"
             )
+            # fail here rather than inside the FFT: a target sharper than some
+            # band along some direction is a deconvolution (wiki D31)
+            native = np.concatenate([psfparsn, gausspar_mfs_native[None]], axis=0)
+            deficit = np.nanmax(resolution_deficit(target, native))
+            if deficit > 1.0:
+                floor = lowest_resolution(native)
+                log.error_and_raise(
+                    f"--gausspar ({gausspar[0]:.3e}, {gausspar[1]:.3e}, {gausspar[2]:.3e}) deg is sharper than "
+                    f"the data along some direction, by a factor {np.sqrt(deficit):.4f} in each axis. Restoring "
+                    f"to it is a deconvolution, not a convolution. The lowest resolution that works here is "
+                    f"({floor[0, 0] * cell_deg:.3e}, {floor[0, 1] * cell_deg:.3e}, "
+                    f"{np.rad2deg(floor[0, 2]):.3e}) deg, which --gausspar 0 0 0 selects automatically.",
+                    ValueError,
+                )
             gaussparf = np.tile(target, (nband, 1, 1))
             gaussparf_mfs = target
             gausspari_band, gausspari_mfs = psfparsn, gausspar_mfs_native
         elif gausspar is not None:
-            target = lowest_resolution(psfparsn)
+            # the MFS residual is reconvolved to this target too, from its own
+            # native beam, so that beam has to be inside the envelope. It is a
+            # fit to the summed PSF, not an average of the band fits (D29), and
+            # is not bounded by them.
+            target = lowest_resolution(np.concatenate([psfparsn, gausspar_mfs_native[None]], axis=0))
             log.info(
                 f"Using lowest resolution of ({target[0, 0] * cell_deg:.3e} deg, "
                 f"{target[0, 1] * cell_deg:.3e} deg, {np.rad2deg(target[0, 2]):.3e} deg)"

--- a/src/pfb_imaging/core/restore.py
+++ b/src/pfb_imaging/core/restore.py
@@ -57,6 +57,9 @@ def restore(
         residual_name: band variable holding the residual image.
         suffix: namespaces the FITS outputs only, never the tree path.
         outputs: product letters, lowercase for MFS and uppercase for cubes.
+            ``s`` stores ``CRESIDUAL``, the residual convolved to the restoring
+            resolution -- the term the restored images add to the model, kept
+            because nothing else records what the resolution change did to it.
         gausspar: restoring resolution ``(emaj, emin, pa)`` in degrees, degrees
             and degrees. ``(0, 0, 0)`` selects the lowest-resolution band. None
             restores each band at its native resolution.
@@ -108,7 +111,7 @@ def restore(
         log.error_and_raise(f"No band nodes found in {dt_name}", ValueError)
 
     dropped = set(drop_bands or ())
-    products = tuple(k for k in ("a", "i", "k") if k in outputs.lower())
+    products = tuple(k for k in ("a", "i", "k", "s") if k in outputs.lower())
     timeids = sorted({int(dt[n].ds.attrs["timeid"]) for n in band_nodes})
     log.info(f"Number of output times = {len(timeids)}")
 

--- a/src/pfb_imaging/deconv/presets.py
+++ b/src/pfb_imaging/deconv/presets.py
@@ -48,6 +48,16 @@ def _build_hess(partitions_per_band, geometry, opts, workers=None, wsums=None):
             f"GP frequency prior: length_scale={opts['gp_length_scale']} of the band span, "
             f"cap={opts.get('gp_cap', 10.0)}; band 0 correlation with each band: " + " ".join(f"{v:.2f}" for v in row)
         )
+    elif opts.get("gp_length_scale") is not None:
+        # freq_precision returns None for a single band or a degenerate band
+        # span. Say so: the request was explicit, and the nband > 1 case logs a
+        # whole correlation row, which makes silence here read as "it is on".
+        nu = np.atleast_1d(np.asarray(geometry["freq_out"], dtype=float))
+        log.warning(
+            f"--gp-length-scale {opts['gp_length_scale']} was requested but there is nothing to correlate: "
+            f"{nu.size} band(s) spanning {nu.max() - nu.min():.3e} Hz. "
+            "Running with an uncorrelated eta, i.e. as if the option were unset."
+        )
     # --eta is a fraction of the TOTAL wsum: the band operators are normalised
     # by wsum_tot, so the Tikhonov term is a uniform +eta*x on every band
     # (eta*wsum_tot in raw units), invariant to how the data is split into

--- a/src/pfb_imaging/deconv/presets.py
+++ b/src/pfb_imaging/deconv/presets.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pfb_imaging.deconv.pfb import PFBSolver
 from pfb_imaging.operators.band_worker import BandWorkerPool
-from pfb_imaging.operators.hessian import HessTreeRay, freq_precision
+from pfb_imaging.operators.hessian import HessTreeRay, freq_correlation, freq_precision
 from pfb_imaging.operators.psi import IdentityPsi, PsiNocopytRay
 from pfb_imaging.opt.forward_backward import ForwardBackward
 from pfb_imaging.opt.pcg import PCG
@@ -42,6 +42,12 @@ def _build_hess(partitions_per_band, geometry, opts, workers=None, wsums=None):
         if opts.get("gp_length_scale") is not None
         else None
     )
+    if freq_prec is not None:
+        row = freq_correlation(geometry["freq_out"], opts["gp_length_scale"])[0]
+        log.info(
+            f"GP frequency prior: length_scale={opts['gp_length_scale']} of the band span, "
+            f"cap={opts.get('gp_cap', 10.0)}; band 0 correlation with each band: " + " ".join(f"{v:.2f}" for v in row)
+        )
     # --eta is a fraction of the TOTAL wsum: the band operators are normalised
     # by wsum_tot, so the Tikhonov term is a uniform +eta*x on every band
     # (eta*wsum_tot in raw units), invariant to how the data is split into

--- a/src/pfb_imaging/deconv/presets.py
+++ b/src/pfb_imaging/deconv/presets.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pfb_imaging.deconv.pfb import PFBSolver
 from pfb_imaging.operators.band_worker import BandWorkerPool
-from pfb_imaging.operators.hessian import HessTreeRay
+from pfb_imaging.operators.hessian import HessTreeRay, freq_precision
 from pfb_imaging.operators.psi import IdentityPsi, PsiNocopytRay
 from pfb_imaging.opt.forward_backward import ForwardBackward
 from pfb_imaging.opt.pcg import PCG
@@ -33,6 +33,15 @@ def _build_hess(partitions_per_band, geometry, opts, workers=None, wsums=None):
     else:
         wsum_b = np.asarray(wsums, dtype=float)
     wsum_tot = wsum_b.sum()
+    # GP prior over frequency (issue #307): generalises the scalar eta to an
+    # nband x nband precision. None when --gp-length-scale is unset, which keeps
+    # the band-parallel in-worker CG path. Short-circuited on the option so
+    # geometry["freq_out"] is only required of callers that ask for the prior.
+    freq_prec = (
+        freq_precision(geometry["freq_out"], opts["gp_length_scale"], opts.get("gp_cap", 10.0))
+        if opts.get("gp_length_scale") is not None
+        else None
+    )
     # --eta is a fraction of the TOTAL wsum: the band operators are normalised
     # by wsum_tot, so the Tikhonov term is a uniform +eta*x on every band
     # (eta*wsum_tot in raw units), invariant to how the data is split into
@@ -46,6 +55,7 @@ def _build_hess(partitions_per_band, geometry, opts, workers=None, wsums=None):
         etas=opts["eta"],
         eta_mode=opts.get("eta_mode"),
         eta_cap=opts.get("eta_cap", 1e2),
+        freq_prec=freq_prec,
         nthreads=opts["nthreads"],
         wsums=wsum_tot,
         cg_tol=opts["cg_tol"],

--- a/src/pfb_imaging/operators/band_worker.py
+++ b/src/pfb_imaging/operators/band_worker.py
@@ -468,10 +468,21 @@ class BandWorkerPool:
     def hess_dot(self, x):
         # empty, not zeros: every band is overwritten below, and zeroing costs a
         # full pass over the cube -- 1.07 s at 8 bands x 8000^2, paid once per
-        # CG iteration on the band-coupled forward path
+        # CG iteration on the band-coupled forward path. That makes "every band
+        # is overwritten" load-bearing rather than merely true, so check it:
+        # _map's local branch returns ONE result whatever nband is (it exists
+        # only for nband == 1) and its Ray branch zips against self.actors, so
+        # either mismatch would leave uninitialised rows instead of the zeros
+        # the old allocation happened to supply.
+        if x.shape[0] != self.nband:
+            raise ValueError(f"got {x.shape[0]} bands for {self.nband} workers")
         out = np.empty_like(x)
+        nwritten = 0
         for b, res in enumerate(self._map("hess_dot", [(x[b],) for b in range(self.nband)])):
             out[b] = res[0]
+            nwritten += 1
+        if nwritten != self.nband:
+            raise ValueError(f"{nwritten} band results for {self.nband} workers")
         return out
 
     def get_eta(self, ny, nx):

--- a/src/pfb_imaging/operators/band_worker.py
+++ b/src/pfb_imaging/operators/band_worker.py
@@ -466,7 +466,10 @@ class BandWorkerPool:
         )
 
     def hess_dot(self, x):
-        out = np.zeros_like(x)
+        # empty, not zeros: every band is overwritten below, and zeroing costs a
+        # full pass over the cube -- 1.07 s at 8 bands x 8000^2, paid once per
+        # CG iteration on the band-coupled forward path
+        out = np.empty_like(x)
         for b, res in enumerate(self._map("hess_dot", [(x[b],) for b in range(self.nband)])):
             out[b] = res[0]
         return out

--- a/src/pfb_imaging/operators/gauss.py
+++ b/src/pfb_imaging/operators/gauss.py
@@ -20,6 +20,125 @@ def freqmul(aop, x):
     return out
 
 
+# Pixels per tile. The (b, c) loops re-touch one band slice of ``out`` per band,
+# so the tile must be small enough that the slice stays in L2 -- otherwise the
+# kernel re-streams ``out`` nband times from memory and loses to numpy at
+# production sizes. 2048 pixels is 16 KB per band slice; measured best or tied
+# best from 750^2 to 4096^2, and 131072 is ~2x worse everywhere.
+_ETA_FREQ_TILE = 2048
+
+_ETA_FREQ_JIT = {"nogil": True, "cache": True, "error_model": "numpy", "fastmath": True, "parallel": True}
+
+
+@njit(**_ETA_FREQ_JIT)
+def _eta_freq_mul_uniform(out, amat, x, tile, nchunk):
+    """``out[b, p] += sum_c amat[b, c] * x[c, p]`` on ``(nband, npix)`` arrays."""
+    nband, npix = x.shape
+    step = (npix + nchunk - 1) // nchunk
+    for g in prange(nchunk):
+        lo = g * step
+        hi = min(lo + step, npix)
+        for t0 in range(lo, hi, tile):
+            t1 = min(t0 + tile, hi)
+            for b in range(nband):
+                for c in range(nband):
+                    a = amat[b, c]
+                    # unit stride in p: this is the loop that vectorises, and the
+                    # reason band-major beats a pixel-major gather
+                    for p in range(t0, t1):
+                        out[b, p] += a * x[c, p]
+
+
+@njit(**_ETA_FREQ_JIT)
+def _eta_freq_mul_profile(out, dcinv, s, x, tile, nchunk):
+    """``out[b, p] += s[b, p] * sum_c dcinv[b, c] * s[c, p] * x[c, p]``."""
+    nband, npix = x.shape
+    step = (npix + nchunk - 1) // nchunk
+    for g in prange(nchunk):
+        lo = g * step
+        hi = min(lo + step, npix)
+        for t0 in range(lo, hi, tile):
+            t1 = min(t0 + tile, hi)
+            for b in range(nband):
+                for c in range(nband):
+                    a = dcinv[b, c]
+                    for p in range(t0, t1):
+                        out[b, p] += s[b, p] * a * s[c, p] * x[c, p]
+
+
+def eta_freq_mul(out, dcinv, s, x, nchunk=1):
+    """Fused frequency congruence, accumulated in place: ``out += D^½ dcinv D^½ x``.
+
+    Computes ``out[b] += s[b] * Σ_c dcinv[b, c] * s[c] * x[c]`` over the band
+    axis in one pass, replacing the four-pass numpy form
+
+    .. code-block:: python
+
+        np.multiply(x, s, out=buf)
+        np.matmul(dcinv, buf.reshape(nband, -1), out=buf2.reshape(nband, -1))
+        np.multiply(buf2, s, out=buf2)
+        out += buf2
+
+    which is what ``HessTreeRay.dot`` applies for the GP frequency prior (wiki
+    D30). Two reasons this exists, both measured:
+
+    * **numpy's ``matmul`` poisons the next Ray round trip.** ``k = nband`` is
+      tiny and ``n = npix`` huge, so the call is memory-bound, yet OpenBLAS
+      spreads it over every core and those threads then busy-poll for ~100 ms
+      (``THREAD_TIMEOUT``). That window covers the following ``ray.get``, during
+      which the band workers need the cores: a 3 ms matmul added ~60 ms to a
+      70 ms round trip. Numba's TBB pool does not do this -- measured at up to
+      22 threads, the next round trip stays at its 0.2-core baseline.
+    * **It is faster anyway.** At 8 bands x 4096², numpy takes 287 ms on 11.5
+      cores; this takes 83 ms on 15.6 (3.5x), or 118 ms on 6.9 at
+      ``nchunk=8``. It also drops the two ``(nband, ny, nx)`` scratch buffers the
+      numpy form needs -- 2 GB at that size.
+
+    Args:
+        out: ``(nband, ny, nx)`` accumulator, updated in place. Must be
+            C-contiguous.
+        dcinv: ``(nband, nband)`` frequency coupling, ``C⁻¹ₙ - I`` for the prior.
+        s: ``D^½``, either per-band -- shape ``(nband,)`` or ``(nband, 1, 1)``,
+            the uniform-eta case -- or a full ``(nband, ny, nx)`` profile.
+        x: ``(nband, ny, nx)`` operand. Must be C-contiguous.
+        nchunk: Number of pixel chunks to fan out over numba's thread pool.
+            ``1`` runs serially. Sets the parallelism without touching the
+            process-wide thread count.
+
+    Returns:
+        ``out``, for convenience; the update is in place.
+
+    Raises:
+        ValueError: On a shape mismatch, a non-contiguous ``out``/``x``, or an
+            ``s`` that is neither per-band nor a full profile.
+    """
+    nband = dcinv.shape[0]
+    if dcinv.shape != (nband, nband):
+        raise ValueError(f"dcinv must be square, got {dcinv.shape}")
+    if out.shape != x.shape or x.shape[0] != nband:
+        raise ValueError(f"expected out and x of shape ({nband}, ny, nx), got {out.shape} and {x.shape}")
+    # reshape(nband, -1) silently copies a non-contiguous array, which would
+    # throw the accumulation away for `out` and read the wrong thing for `x`
+    if not out.flags.c_contiguous or not x.flags.c_contiguous:
+        raise ValueError("out and x must be C-contiguous")
+    nchunk = max(1, int(nchunk))
+    out2, x2 = out.reshape(nband, -1), x.reshape(nband, -1)
+
+    s = np.asarray(s)
+    if s.size == nband:
+        # per-band scalars: the whole congruence folds into one matrix, so the
+        # kernel never touches s and does nband^2 fewer multiplies per pixel
+        sb = s.reshape(nband)
+        _eta_freq_mul_uniform(out2, sb[:, None] * dcinv * sb[None, :], x2, _ETA_FREQ_TILE, nchunk)
+    elif s.shape == x.shape:
+        if not s.flags.c_contiguous:
+            raise ValueError("a full s profile must be C-contiguous")
+        _eta_freq_mul_profile(out2, dcinv, s.reshape(nband, -1), x2, _ETA_FREQ_TILE, nchunk)
+    else:
+        raise ValueError(f"s must have {nband} elements or shape {x.shape}, got {s.shape}")
+    return out
+
+
 @njit(parallel=True, nogil=True, cache=True, inline="always")
 def make_kernel(nx_psf, ny_psf, sigma0, length_scale):
     cov = np.zeros((1, nx_psf, ny_psf), dtype=np.float64)

--- a/src/pfb_imaging/operators/gauss.py
+++ b/src/pfb_imaging/operators/gauss.py
@@ -1,5 +1,4 @@
 import numpy as np
-from africanus.gps.kernels import exponential_squared as expsq
 from ducc0.fft import c2r, r2c
 from numba import njit, prange
 
@@ -169,6 +168,11 @@ class MockArray(object):
 
 class Gauss(object):
     def __init__(self, sigma0, nband, nx, ny, nthreads=8):
+        # deferred: heavy import (~0.36 s) on a rarely-taken path -- this class
+        # is the only user, while eta_freq_mul in this module is imported by
+        # operators.hessian on every deconv run
+        from africanus.gps.kernels import exponential_squared as expsq
+
         self.nthreads = nthreads
         self.nx = nx
         self.ny = ny

--- a/src/pfb_imaging/operators/hessian.py
+++ b/src/pfb_imaging/operators/hessian.py
@@ -440,6 +440,83 @@ def eta_profile(partitions, eta, mode, ny, nx, cap=1e2):
     return eta * np.minimum(f, cap)
 
 
+def freq_correlation(freq_out, length_scale):
+    """Squared-exponential correlation matrix over the imaged band.
+
+    Evaluated at the given frequencies, which need not be evenly spaced --
+    ``freq_out`` is the wsum-weighted effective frequency and is data-dependent
+    (wiki D28). The metric is linear in frequency with the length scale given as
+    a fraction of the band span, so the knob reads directly ("correlated over
+    half the band") and transfers between UHF and L-band runs. A log-frequency
+    metric is the same thing to 4% over a full 2:1 band, so the extra
+    parameterisation is not worth carrying.
+
+    Args:
+        freq_out: ``(nband,)`` band frequencies in Hz.
+        length_scale: Correlation length as a fraction of the ``freq_out`` span.
+
+    Returns:
+        ``(nband, nband)`` unit-diagonal correlation matrix.
+    """
+    freq_out = np.asarray(freq_out, dtype=np.float64)
+    span = float(freq_out.max() - freq_out.min())
+    d = (freq_out[:, None] - freq_out[None, :]) / (length_scale * span)
+    return np.exp(-0.5 * d**2)
+
+
+def freq_precision(freq_out, length_scale, cap=10.0):
+    """Normalised frequency precision for the preconditioner's GP prior (issue #307).
+
+    Generalises ``--eta`` from a scalar to an ``nband x nband`` matrix: today's
+    preconditioner carries ``K_nu^-1 = eta * I``, and this returns the ``C^-1_n``
+    that replaces the identity. The prior enters ``M`` **only** -- it is absent
+    from ``gridder.residual_from_partitions`` -- so the fixed point and the flux
+    scale are untouched and it only reshapes each forward update (wiki D22/D26).
+
+    The spectrum is normalised so ``eta`` is the precision on the **roughest
+    frequency mode present** and smoother modes are damped up to ``cap`` times
+    less. This is the "relax" convention: it makes the field-edge update *grow*
+    along the frequency-smooth direction that borrows from bands where the beam
+    is still open, which is the symptom issue #307 reports. Anchoring at the
+    rough end (dividing by ``prec.max()``, not by ``cap``) is load-bearing:
+    dividing by ``cap`` would make a white kernel return ``I/cap``, silently
+    weakening ``eta`` everywhere instead of degrading to today's behaviour.
+
+    Args:
+        freq_out: ``(nband,)`` band frequencies in Hz.
+        length_scale: Correlation length as a fraction of the band span, or None
+            to disable the prior.
+        cap: Ceiling on how far the smoothest mode may be relaxed. Bounds the
+            drop in ``lambda_min(M)`` and hence the erosion of the stable gamma.
+
+    Returns:
+        ``(nband, nband)`` symmetric positive-definite matrix whose largest
+        eigenvalue is exactly 1 and whose smallest is at least ``1/cap``, or
+        None when the prior is disabled (no length scale, fewer than two bands,
+        or every band at one frequency).
+
+    Raises:
+        ValueError: non-positive ``length_scale``, or ``cap < 1``.
+    """
+    if length_scale is None:
+        return None
+    if length_scale <= 0.0:
+        raise ValueError(f"gp_length_scale must be > 0 (got {length_scale}); use None to disable the prior")
+    if cap < 1.0:
+        raise ValueError(f"gp_cap must be >= 1 (got {cap}); cap=1 is the uniform-eta limit")
+    freq_out = np.asarray(freq_out, dtype=np.float64)
+    if freq_out.size < 2 or freq_out.max() == freq_out.min():
+        return None
+    corr = freq_correlation(freq_out, length_scale)
+    lam, evec = np.linalg.eigh(corr)
+    # roundoff can push the smallest eigenvalues slightly negative; they are the
+    # roughest modes and belong at the cap, so floor them rather than divide by them
+    ratio = lam.max() / np.maximum(lam, lam.max() * 1e-12)
+    prec = np.minimum(ratio, cap)
+    prec /= prec.max()  # roughest mode present -> exactly 1 (see the docstring)
+    return (evec * prec) @ evec.T
+
+
 class HessianTree(object):
     """Sum-over-partitions PSF-convolution Hessian for the DataTree imager.
 

--- a/src/pfb_imaging/operators/hessian.py
+++ b/src/pfb_imaging/operators/hessian.py
@@ -640,6 +640,10 @@ class HessTreeRay:
         etas: Tikhonov parameter, scalar or per-band sequence.
         eta_mode, eta_cap: optional spatially varying ``eta``; each worker builds
             the profile from its own band's beams (see ``eta_profile``).
+        freq_prec: Optional ``(nband, nband)`` frequency precision from
+            ``freq_precision``. When given, bands couple through the
+            preconditioner and the forward CG runs at cube level on the driver
+            instead of band-parallel inside the workers (issue #307).
         nthreads: total FFT threads (ignored when ``workers`` is passed; the
             pool's per-band thread budget applies).
         wsums: optional normalisation override, scalar or per-band sequence
@@ -658,6 +662,7 @@ class HessTreeRay:
         etas=0.0,
         eta_mode=None,
         eta_cap=1e2,
+        freq_prec=None,
         nthreads=1,
         wsums=None,
         cg_tol=1e-3,
@@ -695,8 +700,43 @@ class HessTreeRay:
         self._pool = workers
         self._pool.init_hess(partitions_per_band, nx, ny, nx_psf, ny_psf, etas, wsums, eta_mode, eta_cap)
 
+        # GP prior over frequency (issue #307). Applied through the identity
+        #   D^.5 Cinv D^.5 = D + D^.5 (Cinv - I) D^.5
+        # so the workers keep applying their own eta/eta_mode term (the D) and
+        # the driver adds only the remainder. That remainder is NEGATIVE
+        # semi-definite (Cinv's eigenvalues are in (0, 1]); the total operator
+        # is still symmetric positive definite, so CG applies -- but nothing may
+        # assume this term alone is PSD.
+        self._dC = None
+        self._s = None
+        if freq_prec is not None:
+            freq_prec = np.asarray(freq_prec, dtype=np.float64)
+            if freq_prec.shape != (self.nband, self.nband):
+                raise ValueError(f"freq_prec has shape {freq_prec.shape}, expected {(self.nband, self.nband)}")
+            self._dC = freq_prec - np.eye(self.nband)
+            if eta_mode is None:
+                # uniform eta: a per-band scalar, so no (nband, ny, nx) cube is
+                # fetched or held (that is ~1 GB of f8 at 4096^2 x 8 bands)
+                self._s = np.sqrt(etas)[:, None, None]
+            else:
+                self._s = np.sqrt(self._pool.get_eta(ny, nx))
+            # reused every dot() on the CG hot path; allocating two
+            # (nband, ny, nx) temporaries per application would dominate at
+            # production image sizes (matches HessianTree's FFT scratch)
+            self._buf = np.empty((self.nband, ny, nx))
+            self._buf2 = np.empty((self.nband, ny, nx))
+
     def dot(self, x):
-        return self._pool.hess_dot(x)
+        out = self._pool.hess_dot(x)
+        if self._dC is not None:
+            # BLAS matmul over the band axis rather than utils.misc.freqmul,
+            # which is njit(parallel=False); reshape of a C-contiguous buffer is
+            # a view, so out= writes through
+            np.multiply(x, self._s, out=self._buf)
+            np.matmul(self._dC, self._buf.reshape(self.nband, -1), out=self._buf2.reshape(self.nband, -1))
+            np.multiply(self._buf2, self._s, out=self._buf2)
+            out += self._buf2
+        return out
 
     def hdot(self, x):
         return self.dot(x)

--- a/src/pfb_imaging/operators/hessian.py
+++ b/src/pfb_imaging/operators/hessian.py
@@ -742,11 +742,34 @@ class HessTreeRay:
         return self.dot(x)
 
     def cg(self, rhs, x0=None, tol=None, maxit=None, minit=None):
-        """Distributed per-band CG solve of ``hess @ update = rhs``."""
+        """Solve ``hess @ update = rhs``.
+
+        Without a frequency prior the solve is band-parallel: one Ray dispatch
+        per band per call, each worker iterating its own CG to convergence in
+        process. A frequency prior couples the bands, so the solve moves to a
+        cube-level CG on the driver -- one dispatch per band per CG *iteration*.
+        The FFT work is unchanged and still happens in the workers; only the
+        round trips are added (the backward step already fans ``dot`` out this
+        way, up to ``pd_maxit`` times per major cycle).
+
+        Warning:
+            On the coupled path ``x0`` is bound as the iterate and updated
+            **in place** by ``pcg_numba``; the returned array IS ``x0``.
+        """
         tol = self.cg_tol if tol is None else tol
         maxit = self.cg_maxit if maxit is None else maxit
         minit = self.cg_minit if minit is None else minit
-        return self._pool.hess_cg(rhs, x0, tol, maxit, minit, self.cg_verbose)
+        if self._dC is None:
+            return self._pool.hess_cg(rhs, x0, tol, maxit, minit, self.cg_verbose)
+        return pcg(
+            self.dot,
+            rhs,
+            x0=x0,
+            tol=tol,
+            maxit=maxit,
+            minit=minit,
+            verbosity=self.cg_verbose,
+        )
 
     def get_eta(self):
         """Tikhonov coefficient per band as an ``(nband, ny, nx)`` cube."""

--- a/src/pfb_imaging/operators/hessian.py
+++ b/src/pfb_imaging/operators/hessian.py
@@ -784,8 +784,15 @@ class HessTreeRay:
             spectrum, whose maximum is exactly 1 by construction) and
             ``eta_max``/``lam_min``/``lam_max`` (the same scaled by the largest
             eta, i.e. the prior's actual contribution to ``M``'s spectrum).
-            ``lam_max == eta_max`` is the invariant that keeps ``lambda_max(M)``
-            -- hence ``hess_norm`` and the primal-dual step sizes -- unchanged.
+            ``lam_max == eta_max`` is the invariant that bounds ``lambda_max(M)``
+            by its pre-prior value. Because ``Cinv <= I`` in the Loewner order,
+            ``M_gp <= M`` and ``lambda_max`` can only fall -- not stay equal, as
+            the eigenvectors do not align, and the top mode is frequency-flat,
+            i.e. exactly the one relaxed to ``1/cap``. The drop is at most
+            ``eta * (1 - 1/cap)``, ~9e-4 at the default ``eta=1e-3``, and
+            reusing the larger pre-prior ``hess_norm`` errs toward smaller
+            primal-dual steps. The cache still keys on the prior's options
+            (``core.deconv._M_OPTS``) rather than relying on that.
         """
         if self._dC is None:
             return None

--- a/src/pfb_imaging/operators/hessian.py
+++ b/src/pfb_imaging/operators/hessian.py
@@ -775,6 +775,29 @@ class HessTreeRay:
         """Tikhonov coefficient per band as an ``(nband, ny, nx)`` cube."""
         return self._pool.get_eta(self.ny, self.nx)
 
+    def get_freq_prior_stats(self):
+        """Spectrum of the frequency prior, or None when it is disabled.
+
+        Returns:
+            dict with ``prec_min``/``prec_max`` (the normalised precision
+            spectrum, whose maximum is exactly 1 by construction) and
+            ``eta_max``/``lam_min``/``lam_max`` (the same scaled by the largest
+            eta, i.e. the prior's actual contribution to ``M``'s spectrum).
+            ``lam_max == eta_max`` is the invariant that keeps ``lambda_max(M)``
+            -- hence ``hess_norm`` and the primal-dual step sizes -- unchanged.
+        """
+        if self._dC is None:
+            return None
+        lam = np.linalg.eigvalsh(self._dC + np.eye(self.nband))
+        eta_max = float(np.max(self._s)) ** 2
+        return {
+            "prec_min": float(lam.min()),
+            "prec_max": float(lam.max()),
+            "eta_max": eta_max,
+            "lam_min": float(lam.min()) * eta_max,
+            "lam_max": float(lam.max()) * eta_max,
+        }
+
     def get_mem(self):
         """Per-worker post-gc memory telemetry (empty for the local path)."""
         return self._pool.get_mem()

--- a/src/pfb_imaging/operators/hessian.py
+++ b/src/pfb_imaging/operators/hessian.py
@@ -7,6 +7,7 @@ from ducc0.fft import c2r, r2c
 from ducc0.misc import empty_noncritical
 from ducc0.wgridder.experimental import dirty2vis, vis2dirty
 
+from pfb_imaging.operators.gauss import eta_freq_mul
 from pfb_imaging.opt.pcg import pcg_numba as pcg
 from pfb_imaging.utils.misc import taperf
 
@@ -717,25 +718,25 @@ class HessTreeRay:
             if eta_mode is None:
                 # uniform eta: a per-band scalar, so no (nband, ny, nx) cube is
                 # fetched or held (that is ~1 GB of f8 at 4096^2 x 8 bands)
-                self._s = np.sqrt(etas)[:, None, None]
+                self._s = np.sqrt(etas)
             else:
                 self._s = np.sqrt(self._pool.get_eta(ny, nx))
-            # reused every dot() on the CG hot path; allocating two
-            # (nband, ny, nx) temporaries per application would dominate at
-            # production image sizes (matches HessianTree's FFT scratch)
-            self._buf = np.empty((self.nband, ny, nx))
-            self._buf2 = np.empty((self.nband, ny, nx))
+            # pixel chunks for the fused kernel: sets its fan-out without
+            # touching the process-wide numba thread count
+            self._nchunk = max(1, int(nthreads))
 
     def dot(self, x):
         out = self._pool.hess_dot(x)
         if self._dC is not None:
-            # BLAS matmul over the band axis rather than utils.misc.freqmul,
-            # which is njit(parallel=False); reshape of a C-contiguous buffer is
-            # a view, so out= writes through
-            np.multiply(x, self._s, out=self._buf)
-            np.matmul(self._dC, self._buf.reshape(self.nband, -1), out=self._buf2.reshape(self.nband, -1))
-            np.multiply(self._buf2, self._s, out=self._buf2)
-            out += self._buf2
+            # One fused numba pass instead of four numpy ones, and no scratch
+            # cubes: at 8 bands x 8000^2 the numpy form held 7.6 GB of them in
+            # the driver, on top of the ~27 GB the cube-level CG already needs.
+            # numpy's matmul is also the wrong tool here -- k=nband is tiny and
+            # n=npix huge, so it is memory-bound, yet OpenBLAS spreads it over
+            # every core and those threads busy-poll for ~100 ms afterwards,
+            # straight through the next ray.get while the workers need the
+            # cores. See gauss.eta_freq_mul for the measurements.
+            eta_freq_mul(out, self._dC, self._s, x, nchunk=self._nchunk)
         return out
 
     def hdot(self, x):

--- a/src/pfb_imaging/utils/misc.py
+++ b/src/pfb_imaging/utils/misc.py
@@ -176,6 +176,81 @@ def get_padding_info(nx, ny, pfrac):
     return padding, unpad_x, unpad_y
 
 
+def gauss_cov(gausspar):
+    """Real-space covariance of a Gaussian given as (emaj, emin, pa).
+
+    Args:
+        gausspar: (emaj, emin, pa) with the axes as FWHM in grid units and pa
+            in radians, using gaussian2d's rotation convention.
+
+    Returns:
+        (2, 2) covariance in squared grid units, i.e. the inverse of the
+        quadratic form gaussian2d exponentiates.
+    """
+    smaj, smin, pa = gausspar
+    fwhm_conv = 2 * np.sqrt(2 * np.log(2))
+    rmat = np.array([[-np.sin(pa), -np.cos(pa)], [np.cos(pa), -np.sin(pa)]])
+    sigmas = np.diag([(smaj / fwhm_conv) ** 2, (smin / fwhm_conv) ** 2])
+    return rmat @ sigmas @ rmat.T
+
+
+def gauss_ratio_hat(gausspari, gaussparf, shape, dx=1.0, dy=1.0, normalise=False):
+    """Transform of the kernel taking resolution gausspari to gaussparf.
+
+    The ratio of two Gaussian transforms is itself a Gaussian, so it is written
+    down rather than obtained by dividing two sampled kernels' FFTs:
+
+        Kf(k) / Ki(k) = sqrt(|Sf| / |Si|) exp(-2 pi^2 k^T (Sf - Si) k)
+
+    That division is the failure mode of issue #312. A sampled Gaussian's DFT
+    sinks into round-off well before Nyquist, so beyond some |k| the quotient is
+    noise over noise -- unbounded, since nothing masks it -- and the resulting
+    ringing displaces sources. Widening gaussian2d's support fixes the
+    truncation half of that, but not the round-off half, which grows with
+    --super-resolution-factor. Evaluating the ratio directly has neither
+    problem, conserves flux exactly, and costs two FFTs less per plane.
+
+    Args:
+        gausspari: (emaj, emin, pa) initial resolution, FWHM in grid units.
+        gaussparf: (emaj, emin, pa) target resolution, FWHM in grid units.
+        shape: (nx, ny) real-space shape of the padded grid.
+        dx: Grid spacing along the first axis, in the units of gausspar.
+        dy: Grid spacing along the second axis, in the units of gausspar.
+        normalise: Match norm_kernel=True, where both kernels carry unit volume
+            and the ratio therefore has unit DC gain.
+
+    Returns:
+        (nx, ny // 2 + 1) real array matching the layout of an r2c transform of
+        the padded grid.
+
+    Raises:
+        ValueError: If gaussparf is not at least as wide as gausspari in every
+            direction. The operation is then a deconvolution, which this
+            amplifies without bound rather than performing.
+    """
+    covi = gauss_cov(gausspari)
+    covf = gauss_cov(gaussparf)
+    dcov = covf - covi
+    # a positive semi-definite difference is exactly the condition for the
+    # ratio to be a convolution rather than a deconvolution. A rotation between
+    # the two position angles can make it indefinite even when both axes grow.
+    evals = np.linalg.eigvalsh(dcov)
+    tol = 1e-8 * max(np.trace(covi), np.trace(covf))
+    if evals.min() < -tol:
+        raise ValueError(
+            f"Cannot convolve from {tuple(np.asarray(gausspari, dtype=float))} to "
+            f"{tuple(np.asarray(gaussparf, dtype=float))}: the target resolution is sharper than the "
+            f"initial one along some direction (smallest eigenvalue of the covariance difference is "
+            f"{evals.min():.3e}). This is a deconvolution, not a convolution."
+        )
+    nx, ny = shape
+    kx = np.fft.fftfreq(nx, d=dx)[:, None]
+    ky = np.fft.rfftfreq(ny, d=dy)[None, :]
+    quad = dcov[0, 0] * kx**2 + 2 * dcov[0, 1] * kx * ky + dcov[1, 1] * ky**2
+    amp = 1.0 if normalise else np.sqrt(np.linalg.det(covf) / np.linalg.det(covi))
+    return amp * np.exp(-2 * np.pi**2 * quad)
+
+
 def convolve2gaussres(
     image, xx, yy, gaussparf, nthreads=1, gausspari=None, pfrac=0.5, norm_kernel=False, yx_order=False
 ):
@@ -195,7 +270,9 @@ def convolve2gaussres(
         nthreads: Number of threads to use for the FFT's.
         gausspari: Initial resolution, same shapes as gaussparf. By default
             the image is assumed to be a clean component image with no
-            associated resolution.
+            associated resolution. When given, the resolution change is applied
+            with the closed-form transform ratio (see gauss_ratio_hat), so
+            gaussparf must be at least as wide as gausspari.
         pfrac: Padding used for the FFT based convolution. Will pad by
             pfrac/2 on both sides of image.
         norm_kernel: Normalise the Gaussian kernel to have volume 1.
@@ -211,7 +288,8 @@ def convolve2gaussres(
 
     Raises:
         ValueError: If gausspari is per-plane (ndim > 1) and its length does
-            not match the number of planes in image.
+            not match the number of planes in image, or if gaussparf is sharper
+            than gausspari along some direction (see gauss_ratio_hat).
         AssertionError: If gaussparf is per-plane (ndim > 1) and its length
             does not match the number of planes in image.
     """
@@ -228,42 +306,38 @@ def convolve2gaussres(
     image = np.pad(image, padding, mode="constant")
     imhat = r2c(ifftshift(image, axes=ax), axes=ax, forward=True, nthreads=nthreads, inorm=0)
 
-    if np.ndim(gaussparf) == 1:  # single final resolution shared by all planes
-        gausskern = gaussian2d(xx, yy, gaussparf, normalise=norm_kernel)
-        gausskern = np.pad(gausskern, padding[1:], mode="constant")
-        gausskernhat = r2c(ifftshift(gausskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0)
-        gausskernhat = np.broadcast_to(gausskernhat[None], imhat.shape)
-    else:
+    if np.ndim(gaussparf) > 1:
         assert np.shape(gaussparf)[0] == nband
-        gausskernhat = np.zeros_like(imhat)
-        for b in range(nband):
-            gausskern = gaussian2d(xx, yy, gaussparf[b], normalise=norm_kernel)
-            gausskern = np.pad(gausskern, padding[1:], mode="constant")
-            r2c(
-                ifftshift(gausskern, axes=(0, 1)),
-                out=gausskernhat[b],
-                axes=(0, 1),
-                forward=True,
-                nthreads=nthreads,
-                inorm=0,
-            )
 
-    # convolve to desired resolution
     if gausspari is None:
-        imhat *= gausskernhat
+        # no initial resolution: a plain convolution by the sampled kernel
+        if np.ndim(gaussparf) == 1:  # single final resolution shared by all planes
+            gausskern = gaussian2d(xx, yy, gaussparf, normalise=norm_kernel)
+            gausskern = np.pad(gausskern, padding[1:], mode="constant")
+            gausskernhat = r2c(ifftshift(gausskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0)
+            imhat *= gausskernhat[None]
+        else:
+            for b in range(nband):
+                gausskern = gaussian2d(xx, yy, gaussparf[b], normalise=norm_kernel)
+                gausskern = np.pad(gausskern, padding[1:], mode="constant")
+                gausskernhat = r2c(
+                    ifftshift(gausskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0
+                )
+                imhat[b] *= gausskernhat
     else:
+        # resolution change: use the closed-form ratio of the two transforms
+        # rather than dividing sampled kernels (issue #312, gauss_ratio_hat)
         gausspari = np.asarray(gausspari)
+        shape = (nx + np.sum(padding[1]), ny + np.sum(padding[2]))
+        # gausspar is in the units of the grids, so the frequency axes need
+        # their spacing; every caller passes pixels, but do not assume it
+        xs, ys = np.squeeze(xx), np.squeeze(yy)
+        dx = float(xs[1, 0] - xs[0, 0]) if xs.ndim == 2 and nx > 1 else 1.0
+        dy = float(ys[0, 1] - ys[0, 0]) if ys.ndim == 2 and ny > 1 else 1.0
         for b in range(nband):
             gpi = gausspari if gausspari.ndim == 1 else gausspari[b]
-            thiskern = gaussian2d(xx, yy, gpi, normalise=norm_kernel)
-            thiskern = np.pad(thiskern, padding[1:], mode="constant")
-            thiskernhat = r2c(ifftshift(thiskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0)
-
-            convkernhat = np.zeros_like(thiskernhat)
-            msk = np.abs(thiskernhat) > 0.0
-            convkernhat[msk] = gausskernhat[b, msk] / thiskernhat[msk]
-
-            imhat[b] *= convkernhat
+            gpf = gaussparf if np.ndim(gaussparf) == 1 else gaussparf[b]
+            imhat[b] *= gauss_ratio_hat(gpi, gpf, shape, dx=dx, dy=dy, normalise=norm_kernel)
 
     image = fftshift(c2r(imhat, axes=ax, forward=False, lastsize=lastsize, inorm=2, nthreads=nthreads), axes=ax)[
         :, unpad_x, unpad_y
@@ -566,13 +640,19 @@ def construct_mappings(
     )
 
 
-def gaussian2d(xin, yin, gausspar=(1.0, 1.0, 0.0), normalise=True, nsigma=5):
+def gaussian2d(xin, yin, gausspar=(1.0, 1.0, 0.0), normalise=True, nfwhm=5):
     """
     xin         - grid of x coordinates
     yin         - grid of y coordinates
     gausspar    - (emaj, emin, pa) with emaj/emin as FWHM in units of xin/yin and pa in radians.
     normalise   - normalise kernel to have volume 1
-    nsigma      - compute kernel out to this many standard deviations of the major axis
+    nfwhm       - compute kernel out to this many major-axis FWHMs
+
+    The support is deliberately far outside the core, and the parameter counts
+    FWHMs rather than standard deviations to say so (issue #312): 5 sigma
+    truncates at 3.7e-6 of peak, whose spectral ripple swamps the transform's
+    own ~1e-14 floor near Nyquist, while 5 FWHM (11.8 sigma) truncates at
+    ~1e-30 and the transform is clean everywhere.
     """
     smaj, smin, pa = gausspar
     fwhm_conv = 2 * np.sqrt(2 * np.log(2))
@@ -585,9 +665,8 @@ def gaussian2d(xin, yin, gausspar=(1.0, 1.0, 0.0), normalise=True, nsigma=5):
     rmat = np.array([[-np.sin(pa), -np.cos(pa)], [np.cos(pa), -np.sin(pa)]])
     amat = np.dot(np.dot(rmat, amat), rmat.T)
     sout = xin.shape
-    # only compute the result out to nsigma standard deviations
-    sigma_maj = smaj / fwhm_conv
-    extent = (nsigma * sigma_maj) ** 2
+    # only compute the result out to nfwhm major-axis FWHMs (see the docstring)
+    extent = (nfwhm * smaj) ** 2
     xflat = xin.squeeze()
     yflat = yin.squeeze()
     idx, idy = np.where(xflat**2 + yflat**2 <= extent)

--- a/src/pfb_imaging/utils/misc.py
+++ b/src/pfb_imaging/utils/misc.py
@@ -334,6 +334,14 @@ def convolve2gaussres(
         xs, ys = np.squeeze(xx), np.squeeze(yy)
         dx = float(xs[1, 0] - xs[0, 0]) if xs.ndim == 2 and nx > 1 else 1.0
         dy = float(ys[0, 1] - ys[0, 0]) if ys.ndim == 2 and ny > 1 else 1.0
+        if dx == 0.0 or dy == 0.0:
+            # np.meshgrid's default indexing="xy" transposes the grids, which
+            # makes both differences zero and every frequency infinite. Say so:
+            # the resulting all-NaN image is otherwise silent.
+            raise ValueError(
+                f"xx/yy must be (X, Y)-ordered grids, i.e. np.meshgrid(x, y, indexing='ij'); "
+                f"the inferred grid spacing is ({dx}, {dy})"
+            )
         for b in range(nband):
             gpi = gausspari if gausspari.ndim == 1 else gausspari[b]
             gpf = gaussparf if np.ndim(gaussparf) == 1 else gaussparf[b]

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -18,6 +18,7 @@ must say which scale it is on. Three are offered, keyed by their CLI letter.
 
 import numpy as np
 import xarray as xr
+from scipy.linalg import eigh
 
 from pfb_imaging.utils.fits import create_beams_table, save_fits, set_wcs
 from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam
@@ -46,22 +47,104 @@ def clean_beam(psf, wsum):
     return np.array(fitcleanbeam(norm, yx_order=True))
 
 
-def lowest_resolution(gausspars):
-    """Reduce per-band resolutions to the lowest-resolution one.
+def _mean_pa(pas):
+    """Circular mean of position angles, which are defined modulo pi.
+
+    ``np.nanmean`` is wrong for angles: PAs of 0.05 and pi - 0.05 describe two
+    nearly identical orientations but average to pi/2, which is orthogonal to
+    both. Doubling before averaging maps the modulo-pi circle onto a full one.
+    """
+    pas = np.asarray(pas, dtype=float)
+    return 0.5 * np.arctan2(np.nanmean(np.sin(2 * pas)), np.nanmean(np.cos(2 * pas)))
+
+
+def resolution_deficit(target, gausspars):
+    """How far short of dominating every input the target resolution falls.
 
     Args:
-        gausspars: ``(nband, ncorr, 3)`` in pixels, pixels, radians. NaN rows
-            (fully flagged bands) are skipped.
+        target: ``(ncorr, 3)`` candidate restoring resolution.
+        gausspars: ``(n, ncorr, 3)`` resolutions it must be convolvable from.
+            NaN rows are skipped.
 
     Returns:
-        ``(ncorr, 3)``: the largest major and minor axes over bands and the mean
-        position angle.
+        ``(ncorr,)`` largest factor by which ``target``'s axes must grow, as a
+        ratio of areas. At most 1.0 means the target is valid; above 1.0 the
+        target is sharper than some input along some direction, and each axis
+        must grow by its square root. NaN where every input is NaN.
     """
+    # deferred: import cycle with utils.misc (see lowest_resolution)
+    from pfb_imaging.utils.misc import gauss_cov
+
+    target = np.asarray(target, dtype=float)
     gausspars = np.asarray(gausspars, dtype=float)
-    out = np.empty(gausspars.shape[1:], dtype=float)
-    out[:, 0] = np.nanmax(gausspars[:, :, 0], axis=0)
-    out[:, 1] = np.nanmax(gausspars[:, :, 1], axis=0)
-    out[:, 2] = np.nanmean(gausspars[:, :, 2], axis=0)
+    out = np.full(gausspars.shape[1], np.nan, dtype=float)
+    for c in range(gausspars.shape[1]):
+        rows = gausspars[:, c, :]
+        rows = rows[~np.isnan(rows).any(axis=1)]
+        if not len(rows):
+            continue
+        shape = gauss_cov(target[c])
+        out[c] = max(eigh(gauss_cov(row), shape, eigvals_only=True).max() for row in rows)
+    return out
+
+
+def lowest_resolution(gausspars):
+    """Smallest common resolution every input Gaussian can be convolved to.
+
+    "At least as wide as every input" is a statement about the covariances in
+    the Loewner order -- ``Sf - Sj`` positive semi-definite for every input j --
+    not about the axes separately. Taking the max of each axis and the mean of
+    the position angles satisfies the second and not the first: a rotated
+    ellipse pokes out diagonally, and convolving to such a target is a
+    deconvolution along some direction. ``convolve2gaussres`` now refuses it
+    (wiki D31), where it used to silently amplify noise.
+
+    So the max-axis, mean-PA ellipse is used only as a candidate *shape*. Each
+    candidate is inflated by the smallest scalar that makes it dominate every
+    input -- the largest generalised eigenvalue, exact in closed form -- and the
+    smallest resulting ellipse wins. Candidates are the circular-mean PA plus
+    each input's own PA, so when one input is the widest at its own angle the
+    result is that input, with no inflation at all.
+
+    Args:
+        gausspars: ``(n, ncorr, 3)`` in pixels, pixels, radians, over whatever
+            set must be dominated -- the per-band beams, and the MFS beam too
+            when it is reconvolved to the same target. NaN rows (fully flagged
+            bands) are skipped.
+
+    Returns:
+        ``(ncorr, 3)``: a resolution at least as low as every input, in every
+        direction. Rows are NaN where every input is NaN.
+    """
+    # deferred: import cycle with utils.misc, which imports utils.fits, which
+    # this module also imports -- gauss_cov is only needed on this path
+    from pfb_imaging.utils.misc import gauss_cov
+
+    gausspars = np.asarray(gausspars, dtype=float)
+    out = np.full(gausspars.shape[1:], np.nan, dtype=float)
+    for c in range(gausspars.shape[1]):
+        rows = gausspars[:, c, :]
+        rows = rows[~np.isnan(rows).any(axis=1)]
+        if not len(rows):
+            continue
+        covs = [gauss_cov(row) for row in rows]
+        emaj, emin = rows[:, 0].max(), rows[:, 1].max()
+        best = None
+        # candidate orientations, and candidate axis ratios between the widest
+        # input's and circular. Neither alone is enough: when the inputs share a
+        # PA the max-axis ellipse wins, and when they are spread over a wide
+        # range of angles a rounder beam contains them more tightly.
+        for pa in np.concatenate([[_mean_pa(rows[:, 2])], rows[:, 2]]):
+            for ratio in np.linspace(emin / emaj, 1.0, 5):
+                shape = gauss_cov((emaj, emaj * ratio, pa))
+                # smallest s with s * shape >= cov, i.e. the largest generalised
+                # eigenvalue of the pencil (cov, shape). A margin keeps the
+                # binding input inside gauss_ratio_hat's definiteness check.
+                scale = (1.0 + 1e-6) * max(eigh(cov, shape, eigvals_only=True).max() for cov in covs)
+                area = emaj * emaj * ratio * scale
+                if best is None or area < best[0]:
+                    best = (area, np.sqrt(scale) * emaj, np.sqrt(scale) * emaj * ratio, pa)
+        out[c] = best[1:]
     return out
 
 

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -24,8 +24,9 @@ from pfb_imaging.utils.fits import create_beams_table, save_fits, set_wcs
 from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam
 
 # CLI letter -> DataTree variable name. The B prefix follows the tree's
-# convention for beam-attenuated quantities (BDIRTY, BRESIDUAL).
-PRODUCT_VARS = {"a": "BIMAGE", "i": "IMAGE", "k": "KIMAGE"}
+# convention for beam-attenuated quantities (BDIRTY, BRESIDUAL); the C prefix on
+# CRESIDUAL means convolved to the restoring resolution.
+PRODUCT_VARS = {"a": "BIMAGE", "i": "IMAGE", "k": "KIMAGE", "s": "CRESIDUAL"}
 
 
 def clean_beam(psf, wsum):
@@ -160,8 +161,12 @@ def restore_products(model, residual, beam, gaussparf, gausspari=None, products=
         gausspari: ``(ncorr, 3)`` intrinsic resolution of ``residual``, or None
             to skip the residual reconvolution. None is correct whenever
             ``gaussparf`` is the residual's own resolution.
-        products: iterable over ``"a"`` (apparent), ``"i"`` (intrinsic) and
-            ``"k"`` (intrinsic model plus apparent residual).
+        products: iterable over ``"a"`` (apparent), ``"i"`` (intrinsic),
+            ``"k"`` (intrinsic model plus apparent residual) and ``"s"``, the
+            residual convolved to ``gaussparf`` on its own. ``"s"`` is not a
+            restored image; it is the term the other three add to the model, and
+            it is stored because nothing else in the tree records what the
+            resolution change actually did to the residual.
         pb_min: beam floor below which the intrinsic image is zeroed, matching
             the cutoff convention in ``utils/spi.py``.
         nthreads: threads for the convolution FFTs.
@@ -201,6 +206,10 @@ def restore_products(model, residual, beam, gaussparf, gausspari=None, products=
         # (B*m) (x) G, NOT B*(m (x) G) -- convolution does not commute with
         # multiplication by a spatially varying beam, so mconv cannot be reused
         out["a"] = convolve2gaussres(beam * model, xx, yy, gaussparf, **kw) + rconv
+    if "s" in products:
+        # apparent, pre-beam-division: BEAM is on the node, so the intrinsic form
+        # is one divide away, and this is the scale image-plane noise is flat on
+        out["s"] = rconv if rconv is not residual else residual.copy()
     return out
 
 

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -21,7 +21,7 @@ import xarray as xr
 from scipy.linalg import eigh
 
 from pfb_imaging.utils.fits import create_beams_table, save_fits, set_wcs
-from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam
+from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam, gauss_cov
 
 # CLI letter -> DataTree variable name. The B prefix follows the tree's
 # convention for beam-attenuated quantities (BDIRTY, BRESIDUAL); the C prefix on
@@ -73,9 +73,6 @@ def resolution_deficit(target, gausspars):
         target is sharper than some input along some direction, and each axis
         must grow by its square root. NaN where every input is NaN.
     """
-    # deferred: import cycle with utils.misc (see lowest_resolution)
-    from pfb_imaging.utils.misc import gauss_cov
-
     target = np.asarray(target, dtype=float)
     gausspars = np.asarray(gausspars, dtype=float)
     out = np.full(gausspars.shape[1], np.nan, dtype=float)
@@ -117,10 +114,6 @@ def lowest_resolution(gausspars):
         ``(ncorr, 3)``: a resolution at least as low as every input, in every
         direction. Rows are NaN where every input is NaN.
     """
-    # deferred: import cycle with utils.misc, which imports utils.fits, which
-    # this module also imports -- gauss_cov is only needed on this path
-    from pfb_imaging.utils.misc import gauss_cov
-
     gausspars = np.asarray(gausspars, dtype=float)
     out = np.full(gausspars.shape[1:], np.nan, dtype=float)
     for c in range(gausspars.shape[1]):

--- a/tests/test_convolve2gaussres.py
+++ b/tests/test_convolve2gaussres.py
@@ -331,3 +331,149 @@ def test_convolve2gaussres_gausspari_shared_triple_matches_per_plane():
     per_plane = convolve2gaussres(img, xx, yy, gaussparf, nthreads=1, pfrac=0.2, gausspari=gausspari_per_plane)
 
     np.testing.assert_allclose(shared, per_plane, rtol=0, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Resolution changes (gausspari given). Issue #312: these all passed vacuously
+# before, because every test above uses gausspari None, equal to gaussparf, or
+# a smooth centred Gaussian whose spectrum dies exactly where the old sampled
+# division went wrong.
+# ---------------------------------------------------------------------------
+
+
+@pmp("npix", [128, 512])
+def test_convolve2gaussres_preserves_position_when_deconvolving(npix):
+    """A delta must land where it started after a resolution change.
+
+    The old sampled division put it elsewhere entirely -- at npix=512 a source
+    at (170, 260) came out at (146, 260), displaced by twice its offset from
+    the image centre, with -0.81 of peak in ringing (issue #312).
+    """
+    y0, x0 = npix // 3, npix // 2 + 4
+    image = np.zeros((1, npix, npix))
+    image[0, y0, x0] = 1.0
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+
+    out = convolve2gaussres(
+        image,
+        xx,
+        yy,
+        np.array([[6.3, 4.2, 0.0]]),
+        nthreads=1,
+        gausspari=np.array([[6.0, 4.0, 0.0]]),
+        norm_kernel=False,
+        yx_order=True,
+    )[0]
+
+    assert np.unravel_index(np.argmax(out), out.shape) == (y0, x0)
+    # a small broadening of a delta is a near-identity: no deep negatives
+    assert out.min() > -0.05 * out.max()
+
+
+@pmp("norm_kernel", [False, True])
+def test_convolve2gaussres_conserves_flux_through_a_resolution_change(norm_kernel):
+    """Total flux scales by the ratio of the kernels' volumes, exactly.
+
+    With norm_kernel both kernels carry unit volume, so the gain is 1; without
+    it the gain is (emaj_f * emin_f) / (emaj_i * emin_i). The old sampled
+    division missed this by +6 percent at a 6 px beam and -25 percent at 12 px.
+    """
+    npix = 256
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 3, npix // 2 + 4] = 1.0
+    gausspari = np.array([5.0, 3.0, 0.4])
+    gaussparf = np.array([11.0, 7.0, 0.4])
+
+    out = convolve2gaussres(image, xx, yy, gaussparf, nthreads=1, gausspari=gausspari, norm_kernel=norm_kernel)
+
+    expected = 1.0 if norm_kernel else (gaussparf[0] * gaussparf[1]) / (gausspari[0] * gausspari[1])
+    assert out.sum() == pytest.approx(expected, rel=1e-6)
+
+
+@pmp("srf", [2.0, 3.0, 4.0])
+def test_convolve2gaussres_two_step_matches_direct_across_srf(srf):
+    """Going to gf via gi must equal going to gf directly.
+
+    The beam is 2 * srf pixels across and the sky is band limited to the uv
+    coverage that implies, so this is the invariant a restore run actually
+    depends on. The old sampled division broke it by 1.8e-3 and 1.4e-4 of peak
+    at srf 3 and 4, where the beam is well enough sampled that its transform
+    sinks into round-off before Nyquist and the quotient is noise over noise.
+    srf 2 is the one case it survived (4.0e-10): a 4 px FWHM aliases enough
+    that the transform never gets that small. The closed-form ratio is exact
+    at every srf, leaving only that aliasing floor (8.1e-10 at srf 2, 6e-16
+    above it).
+
+    The sky is windowed away from the frame edge and only the interior is
+    compared: the two-step path pads and unpads twice, and the flux that spills
+    into the pad is dropped at the first unpad. That edge artefact is real but
+    is not what this test is about, and it swamps everything at ~1e-1.
+    """
+    npix = 256
+    rng = np.random.default_rng(42)
+    # band limited to |k| <= 1 / (2 * srf) cycles/pixel, then tapered
+    k = np.fft.fftfreq(npix)
+    kr = np.sqrt(k[:, None] ** 2 + k[None, :] ** 2)
+    hat = np.fft.fft2(rng.standard_normal((npix, npix)))
+    hat[kr > 1.0 / (2 * srf)] = 0.0
+    sky = np.real(np.fft.ifft2(hat))
+    coord = -(npix // 2) + np.arange(npix)
+    radius = np.sqrt(coord[:, None] ** 2 + coord[None, :] ** 2)
+    sky = sky * np.exp(-0.5 * (radius / (npix / 8.0)) ** 2)
+    sky = (sky / np.abs(sky).max())[None]
+
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    fwhm = 2 * srf
+    gausspari = np.array([fwhm, 0.7 * fwhm, 0.0])
+    gaussparf = np.array([2 * fwhm, 1.4 * fwhm, 0.0])
+
+    im_i = convolve2gaussres(sky, xx, yy, gausspari, nthreads=1)
+    two_step = convolve2gaussres(im_i, xx, yy, gaussparf, nthreads=1, gausspari=gausspari)
+    direct = convolve2gaussres(sky, xx, yy, gaussparf, nthreads=1)
+
+    interior = slice(npix // 4, 3 * npix // 4)
+    err = np.abs(two_step[:, interior, interior] - direct[:, interior, interior]).max()
+    assert err < 1e-8 * np.abs(direct).max()
+
+
+@pmp(
+    "gausspari, gaussparf",
+    [
+        ((6.0, 4.0, 0.0), (5.0, 3.0, 0.0)),  # sharper on both axes
+        ((6.0, 4.0, 0.0), (7.0, 3.5, 0.0)),  # minor axis shrinks
+        ((10.0, 5.0, 0.0), (10.0, 5.0, 0.3)),  # same axes, rotated
+    ],
+)
+def test_convolve2gaussres_refuses_to_sharpen(gausspari, gaussparf):
+    """Sharpening is a deconvolution; say so instead of amplifying noise.
+
+    The rotated case is the one that catches callers by surprise:
+    restoration.lowest_resolution takes the max of each axis but the *mean* of
+    the position angles, so a band whose PA differs from the mean can land here
+    even though both its axes grew.
+    """
+    npix = 64
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 2, npix // 2] = 1.0
+
+    with pytest.raises(ValueError, match="deconvolution"):
+        convolve2gaussres(image, xx, yy, np.array(gaussparf), nthreads=1, gausspari=np.array(gausspari))
+
+
+def test_convolve2gaussres_allows_an_unchanged_resolution():
+    """gaussparf == gausspari must survive the positive semi-definite check."""
+    npix = 64
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 2 + 3, npix // 2 - 2] = 1.0
+    gausspar = np.array([6.0, 4.0, 0.7])
+
+    out = convolve2gaussres(image, xx, yy, gausspar, nthreads=1, gausspari=gausspar)
+
+    np.testing.assert_allclose(out, image, rtol=0, atol=1e-10)

--- a/tests/test_convolve2gaussres.py
+++ b/tests/test_convolve2gaussres.py
@@ -450,10 +450,10 @@ def test_convolve2gaussres_two_step_matches_direct_across_srf(srf):
 def test_convolve2gaussres_refuses_to_sharpen(gausspari, gaussparf):
     """Sharpening is a deconvolution; say so instead of amplifying noise.
 
-    The rotated case is the one that catches callers by surprise:
-    restoration.lowest_resolution takes the max of each axis but the *mean* of
-    the position angles, so a band whose PA differs from the mean can land here
-    even though both its axes grew.
+    The rotated case is the one that catches callers by surprise, and it is
+    what forced restoration.lowest_resolution to become a Loewner envelope
+    (D32): its old max-of-each-axis, mean-of-the-position-angles target landed
+    here routinely, with both axes grown.
     """
     npix = 64
     coord = -(npix // 2) + np.arange(npix)
@@ -463,6 +463,23 @@ def test_convolve2gaussres_refuses_to_sharpen(gausspari, gaussparf):
 
     with pytest.raises(ValueError, match="deconvolution"):
         convolve2gaussres(image, xx, yy, np.array(gaussparf), nthreads=1, gausspari=np.array(gausspari))
+
+
+def test_convolve2gaussres_rejects_xy_ordered_grids():
+    """The closed-form ratio reads the pixel size off xx/yy, so order matters.
+
+    np.meshgrid's *default* indexing is "xy", which transposes both grids and
+    makes the inferred spacings zero -- every frequency infinite and the whole
+    image NaN. Fail instead of returning that.
+    """
+    npix = 64
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord)  # note: no indexing="ij"
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 2, npix // 2] = 1.0
+
+    with pytest.raises(ValueError, match="indexing='ij'"):
+        convolve2gaussres(image, xx, yy, np.array([6.3, 4.2, 0.0]), nthreads=1, gausspari=np.array([6.0, 4.0, 0.0]))
 
 
 def test_convolve2gaussres_allows_an_unchanged_resolution():

--- a/tests/test_deconv.py
+++ b/tests/test_deconv.py
@@ -429,3 +429,68 @@ def test_deconv_requires_bdirty(tmp_path):
         deconv_core(
             output_filename, product="I", nthreads=1, fits_mfs=False, fits_cubes=False, log_directory=str(tmp_path)
         )
+
+
+@pytest.mark.slow
+def test_deconv_driver_runs_with_the_frequency_prior(tmp_path):
+    """End-to-end driver path with --gp-length-scale on (issue #307).
+
+    The unit tests stop at presets; this is the only coverage of the whole
+    chain -- core params -> geometry["freq_out"] -> _build_hess -> HessTreeRay
+    -> the cube-level CG that replaces the band-parallel one -> the exact
+    residual -> the hess_norm signature written back to the band attrs.
+    """
+    import xarray as xr
+
+    from pfb_imaging.core.deconv import _m_signature
+    from pfb_imaging.core.deconv import deconv as deconv_core
+
+    rng = np.random.default_rng(43)
+    nx = ny = 32
+    output_filename = str(tmp_path / "synthgp")
+    dt_name = f"{output_filename}_I.dt"
+    _write_synthetic_dt(dt_name, nx, ny, 64, 1, rng)
+
+    opts = dict(
+        product="I",
+        minor_cycle="sara",
+        opt_backend="primal-dual",
+        niter=1,
+        hess_norm=None,  # exercise the power method on the coupled operator
+        pd_maxit=20,
+        cg_maxit=20,
+        pm_maxit=20,
+        bases=["self"],
+        nlevels=1,
+        l1_reweight_from=100,
+        nthreads=2,
+        nworkers=1,
+        fits_mfs=False,
+        fits_cubes=False,
+        verbosity=0,
+        # the synthetic tree has a unit PSF, so at the default eta=1e-3 the data
+        # term swamps the prior and it moves the update by only ~3e-4. Raise eta
+        # so the test probes the regime the prior is for (eta a real share of M).
+        eta=0.1,
+    )
+    deconv_core(output_filename, gp_length_scale=0.5, gp_cap=10.0, **opts)
+
+    dt = xr.open_datatree(dt_name, engine="zarr", chunks=None)
+    band = dt["band0000_time0000"].ds
+    assert np.isfinite(band.MODEL.values).all()
+    assert np.isfinite(band.UPDATE.values).all()
+    assert band.attrs["niters"] == 1
+
+    # the cached norm must be labelled with the prior settings, so a later run
+    # without them re-estimates rather than reusing lambda_max of a different M
+    sig = band.attrs["hess_norm_opts"]
+    assert sig == _m_signature(dict(eta=0.1, eta_mode=None, eta_cap=100.0, gp_length_scale=0.5, gp_cap=10.0))
+    assert sig != _m_signature(dict(eta=0.1, eta_mode=None, eta_cap=100.0, gp_length_scale=None, gp_cap=10.0))
+
+    # the prior actually changed the update: same tree, same seed, prior off
+    out2 = str(tmp_path / "synthref")
+    _write_synthetic_dt(f"{out2}_I.dt", nx, ny, 64, 1, np.random.default_rng(43))
+    deconv_core(out2, gp_length_scale=None, **opts)
+    ref = xr.open_datatree(f"{out2}_I.dt", engine="zarr", chunks=None)["band0000_time0000"].ds
+    rel = np.linalg.norm(band.UPDATE.values - ref.UPDATE.values) / np.linalg.norm(ref.UPDATE.values)
+    assert rel > 1e-2, f"the prior left the update unchanged (rel={rel:.3e})"

--- a/tests/test_deconv_hess_norm_cache.py
+++ b/tests/test_deconv_hess_norm_cache.py
@@ -6,9 +6,10 @@ option that defines M must therefore take part in the cache key -- otherwise cha
 operator, and the primal-dual step sizes are set from it.
 """
 
+import inspect
 import json
 
-from pfb_imaging.core.deconv import _M_OPTS, _cached_hess_norm, _m_signature
+from pfb_imaging.core.deconv import _M_OPTS, _cached_hess_norm, _m_signature, deconv
 
 BASE = {
     "eta": 1e-3,
@@ -24,8 +25,29 @@ def _attrs(opts, value=1.68):
     return {"hess_norm": value, "hess_norm_opts": _m_signature(opts)}
 
 
-def test_every_m_defining_option_is_in_the_key():
+def test_the_m_option_set_is_pinned():
+    """Change-detector, not a proof.
+
+    Whether an option defines M is a fact about ``presets._build_hess``, which
+    no assertion here can read. This pins the set so that adding a knob to the
+    preconditioner has to touch this file, and the next reader has to decide
+    whether the new knob belongs in the key.
+    """
     assert set(_M_OPTS) == {"eta", "eta_mode", "eta_cap", "gp_length_scale", "gp_cap"}
+
+
+def test_every_key_name_is_a_real_deconv_option():
+    """A name that no longer exists keys on None for every run.
+
+    ``_m_signature`` reads the options with ``.get``, so renaming an option in
+    the CLI without renaming it here does not raise -- the entry silently
+    becomes None for everybody, the signature stops discriminating on it, and
+    the cache starts handing out a norm for a different M. That is the failure
+    mode the tautological version of this test could not see.
+    """
+    params = set(inspect.signature(deconv).parameters)
+    missing = [k for k in _M_OPTS if k not in params]
+    assert not missing, f"_M_OPTS names that are not deconv options: {missing}"
 
 
 def test_signature_ignores_options_that_do_not_define_m():

--- a/tests/test_deconv_hess_norm_cache.py
+++ b/tests/test_deconv_hess_norm_cache.py
@@ -1,0 +1,67 @@
+"""hess_norm is lambda_max(M), so its cache is only valid for the M that produced it.
+
+The .dt carries hess_norm in the band attrs and deconv reuses it across runs. Every
+option that defines M must therefore take part in the cache key -- otherwise changing
+--eta, --eta-mode or the frequency prior silently reuses a norm for a different
+operator, and the primal-dual step sizes are set from it.
+"""
+
+import json
+
+from pfb_imaging.core.deconv import _M_OPTS, _cached_hess_norm, _m_signature
+
+BASE = {
+    "eta": 1e-3,
+    "eta_mode": None,
+    "eta_cap": 100.0,
+    "gp_length_scale": None,
+    "gp_cap": 10.0,
+    "niter": 10,  # not an M option; must be ignored
+}
+
+
+def _attrs(opts, value=1.68):
+    return {"hess_norm": value, "hess_norm_opts": _m_signature(opts)}
+
+
+def test_every_m_defining_option_is_in_the_key():
+    assert set(_M_OPTS) == {"eta", "eta_mode", "eta_cap", "gp_length_scale", "gp_cap"}
+
+
+def test_signature_ignores_options_that_do_not_define_m():
+    assert _m_signature(BASE) == _m_signature({**BASE, "niter": 99})
+
+
+def test_signature_is_order_independent():
+    reversed_opts = dict(reversed(list(BASE.items())))
+    assert _m_signature(BASE) == _m_signature(reversed_opts)
+
+
+def test_matching_options_reuse_the_cached_value():
+    assert _cached_hess_norm(_attrs(BASE), BASE) == 1.68
+
+
+def test_missing_hess_norm_returns_none():
+    assert _cached_hess_norm({}, BASE) is None
+
+
+def test_a_tree_written_before_the_signature_existed_is_re_estimated():
+    """Re-estimating is the safe direction; reusing an unlabelled norm is not."""
+    assert _cached_hess_norm({"hess_norm": 1.68}, BASE) is None
+
+
+def test_changing_any_m_option_invalidates_the_cache():
+    attrs = _attrs(BASE)
+    for key, changed in (
+        ("eta", 1e-2),
+        ("eta_mode", "radial"),
+        ("eta_cap", 1000.0),
+        ("gp_length_scale", 0.5),
+        ("gp_cap", 100.0),
+    ):
+        assert _cached_hess_norm(attrs, {**BASE, key: changed}) is None, f"{key} did not invalidate"
+
+
+def test_the_signature_is_json_serialisable_for_zarr_attrs():
+    """Zarr attrs must round-trip through JSON; eta_mode is None on the default path."""
+    assert json.loads(_m_signature(BASE))["eta_mode"] is None

--- a/tests/test_eta_freq_mul.py
+++ b/tests/test_eta_freq_mul.py
@@ -1,0 +1,111 @@
+"""eta_freq_mul: the fused frequency congruence against its four-pass numpy form.
+
+The kernel is a candidate replacement for the driver-side coupling term in
+``HessTreeRay.dot`` (wiki D30) and is not wired in yet, so these tests hold it
+to the numpy expression it would replace.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from pfb_imaging.operators.gauss import eta_freq_mul
+
+pmp = pytest.mark.parametrize
+
+
+def _numpy_reference(out, dcinv, s, x):
+    """Exactly what HessTreeRay.dot does today."""
+    nband = dcinv.shape[0]
+    buf = x * s
+    buf2 = np.empty_like(x)
+    np.matmul(dcinv, buf.reshape(nband, -1), out=buf2.reshape(nband, -1))
+    return out + buf2 * s
+
+
+def _setup(nband, ny, nx, seed=0, profile=False):
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal((nband, ny, nx))
+    out = rng.standard_normal((nband, ny, nx))
+    # a symmetric coupling with the shape freq_precision produces
+    q = np.linalg.qr(rng.standard_normal((nband, nband)))[0]
+    dcinv = q @ np.diag(rng.uniform(0.1, 1.0, nband)) @ q.T - np.eye(nband)
+    s = rng.uniform(0.5, 2.0, (nband, ny, nx)) if profile else rng.uniform(0.5, 2.0, (nband, 1, 1))
+    return out, dcinv, s, x
+
+
+@pmp("nband", [1, 2, 3, 8])
+@pmp("nchunk", [1, 4])
+def test_matches_numpy_for_a_uniform_eta(nband, nchunk):
+    out, dcinv, s, x = _setup(nband, 12, 10)
+    want = _numpy_reference(out, dcinv, s, x)
+    got = eta_freq_mul(out.copy(), dcinv, s, x, nchunk=nchunk)
+    assert_allclose(got, want, rtol=1e-12, atol=1e-14)
+
+
+@pmp("nband", [1, 3, 8])
+@pmp("nchunk", [1, 4])
+def test_matches_numpy_for_a_spatially_varying_eta(nband, nchunk):
+    out, dcinv, s, x = _setup(nband, 12, 10, profile=True)
+    want = _numpy_reference(out, dcinv, s, x)
+    got = eta_freq_mul(out.copy(), dcinv, s, x, nchunk=nchunk)
+    assert_allclose(got, want, rtol=1e-12, atol=1e-14)
+
+
+def test_per_band_s_accepts_either_shape():
+    """(nband,) and (nband, 1, 1) are the same thing to the caller."""
+    out, dcinv, s, x = _setup(3, 12, 10)
+    flat = eta_freq_mul(out.copy(), dcinv, s.reshape(3), x)
+    cube = eta_freq_mul(out.copy(), dcinv, s, x)
+    assert_allclose(flat, cube, rtol=0, atol=0)
+
+
+def test_accumulates_in_place_and_returns_the_same_array():
+    out, dcinv, s, x = _setup(3, 12, 10)
+    before = out.copy()
+    got = eta_freq_mul(out, dcinv, s, x)
+    assert got is out
+    assert np.abs(out - before).max() > 0.0
+
+
+def test_result_is_independent_of_the_chunk_count():
+    """Chunking splits pixels, never bands, so the arithmetic per pixel is identical."""
+    out, dcinv, s, x = _setup(4, 31, 29, profile=True)  # sizes coprime with the tile
+    ref = eta_freq_mul(out.copy(), dcinv, s, x, nchunk=1)
+    for nchunk in (2, 3, 7, 64):
+        assert_allclose(eta_freq_mul(out.copy(), dcinv, s, x, nchunk=nchunk), ref, rtol=0, atol=0)
+
+
+def test_spans_more_than_one_tile():
+    """The tile loop must cover every pixel, including a ragged final tile."""
+    from pfb_imaging.operators.gauss import _ETA_FREQ_TILE
+
+    npix = 3 * _ETA_FREQ_TILE + 17
+    out, dcinv, s, x = _setup(2, 1, npix)
+    want = _numpy_reference(out, dcinv, s, x)
+    assert_allclose(eta_freq_mul(out.copy(), dcinv, s, x, nchunk=3), want, rtol=1e-12, atol=1e-14)
+
+
+def test_zero_coupling_is_a_no_op():
+    out, dcinv, s, x = _setup(3, 12, 10)
+    got = eta_freq_mul(out.copy(), np.zeros_like(dcinv), s, x)
+    assert_allclose(got, out, rtol=0, atol=0)
+
+
+def test_bad_shapes_are_rejected():
+    out, dcinv, s, x = _setup(3, 12, 10)
+    with pytest.raises(ValueError, match="square"):
+        eta_freq_mul(out.copy(), dcinv[:, :2], s, x)
+    with pytest.raises(ValueError, match="shape"):
+        eta_freq_mul(out[:2].copy(), dcinv, s, x)
+    with pytest.raises(ValueError, match="s must have"):
+        eta_freq_mul(out.copy(), dcinv, np.ones((2, 2)), x)
+
+
+def test_non_contiguous_arrays_are_rejected():
+    """reshape would silently copy, so the accumulation would be thrown away."""
+    out, dcinv, s, x = _setup(3, 12, 20)
+    with pytest.raises(ValueError, match="C-contiguous"):
+        eta_freq_mul(out[:, :, ::2].copy(order="F"), dcinv, s, x[:, :, ::2].copy())
+    with pytest.raises(ValueError, match="C-contiguous"):
+        eta_freq_mul(out.copy(), dcinv, s, np.asfortranarray(x))

--- a/tests/test_freq_precision.py
+++ b/tests/test_freq_precision.py
@@ -1,0 +1,95 @@
+"""Normalised frequency-precision matrix for the GP preconditioner prior (issue #307).
+
+The prior generalises ``--eta`` from a scalar to an ``nband x nband`` matrix. The
+invariants that make it a safe generalisation are the ones tested here:
+
+* the maximum precision is exactly 1, so ``lambda_max(M)`` -- hence ``hess_norm`` and
+  the primal-dual step sizes -- is unchanged;
+* ``length_scale -> 0`` gives exactly the identity, so a vanishing correlation length
+  degrades to today's uniform behaviour rather than to a uniform ``eta/cap``;
+* the spectrum never dips below ``1/cap``, bounding the erosion of the stable gamma;
+* the matrix stays symmetric positive definite, so CG still applies.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from pfb_imaging.operators.hessian import freq_correlation, freq_precision
+
+FREQ = np.linspace(0.86e9, 1.71e9, 8)  # MeerKAT L-band, 8 bands
+
+
+def test_disabled_when_length_scale_is_none():
+    assert freq_precision(FREQ, None) is None
+
+
+def test_disabled_for_a_single_band():
+    assert freq_precision(np.array([1.0e9]), 0.5) is None
+
+
+def test_disabled_when_every_band_shares_one_frequency():
+    """Zero span would divide by zero; the prior has nothing to correlate over."""
+    assert freq_precision(np.full(4, 1.0e9), 0.5) is None
+
+
+def test_correlation_is_unit_diagonal_and_symmetric():
+    corr = freq_correlation(FREQ, 0.5)
+    assert corr.shape == (FREQ.size, FREQ.size)
+    assert_allclose(np.diag(corr), 1.0, rtol=0, atol=1e-15)
+    assert_allclose(corr, corr.T, rtol=0, atol=1e-15)
+
+
+def test_correlation_decays_monotonically_with_frequency_separation():
+    corr = freq_correlation(FREQ, 0.5)
+    row = corr[0]
+    assert np.all(np.diff(row) < 0), f"row 0 is not monotone decreasing: {row}"
+
+
+@pytest.mark.parametrize("length_scale", [0.25, 0.5, 1.0])
+@pytest.mark.parametrize("cap", [3.0, 10.0, 100.0])
+def test_spectrum_is_bounded_with_the_maximum_attained_exactly(length_scale, cap):
+    """Max exactly 1 keeps lambda_max(M) fixed; the floor bounds the gamma erosion.
+
+    The minimum is 1/min(spread, cap) and only reaches 1/cap when the correlation
+    spectrum spans at least cap, so assert containment -- not an exact floor.
+    """
+    kinv = freq_precision(FREQ, length_scale, cap=cap)
+    lam = np.linalg.eigvalsh(kinv)
+    assert_allclose(lam.max(), 1.0, rtol=1e-12)
+    assert lam.min() >= 1.0 / cap - 1e-12, f"floor {lam.min():.3e} below 1/cap"
+    assert lam.min() > 0.0, "precision must stay positive definite"
+
+
+def test_short_length_scale_degrades_to_the_identity():
+    """The ell -> 0 limit must recover today's uniform eta, not a uniform eta/cap."""
+    kinv = freq_precision(FREQ, 1e-4, cap=10.0)
+    assert_allclose(kinv, np.eye(FREQ.size), rtol=0, atol=1e-9)
+
+
+def test_long_length_scale_relaxes_the_smoothest_mode_to_the_cap():
+    cap = 10.0
+    kinv = freq_precision(FREQ, 5.0, cap=cap)
+    lam = np.linalg.eigvalsh(kinv)
+    assert_allclose(lam.min(), 1.0 / cap, rtol=1e-9)
+
+
+def test_precision_is_symmetric():
+    kinv = freq_precision(FREQ, 0.5, cap=10.0)
+    assert_allclose(kinv, kinv.T, rtol=0, atol=1e-14)
+
+
+def test_uneven_and_unsorted_frequencies_are_handled_by_value():
+    """freq_out is data-dependent (wiki D28); nothing may assume even spacing."""
+    freq = np.array([1.0e9, 1.02e9, 1.5e9])
+    corr = freq_correlation(freq, 0.5)
+    assert corr[0, 1] > corr[0, 2], "near bands must correlate more than far ones"
+
+
+def test_bad_length_scale_and_cap_are_rejected():
+    with pytest.raises(ValueError, match="gp_length_scale"):
+        freq_precision(FREQ, 0.0)
+    with pytest.raises(ValueError, match="gp_length_scale"):
+        freq_precision(FREQ, -1.0)
+    with pytest.raises(ValueError, match="gp_cap"):
+        freq_precision(FREQ, 0.5, cap=0.5)

--- a/tests/test_hess_tree_ray.py
+++ b/tests/test_hess_tree_ray.py
@@ -225,3 +225,230 @@ def test_prior_stats_report_the_spectrum_and_its_contribution_to_m():
     # the prior's top contribution to M equals eta: lambda_max(M) is unchanged
     assert_allclose(stats["lam_max"], eta, rtol=1e-12)
     assert_allclose(stats["lam_min"], stats["prec_min"] * eta, rtol=1e-12)
+
+
+# --- what the prior does to M's spectrum, and why CG gets slower (issue #307) ---
+
+
+def _shared_parts(rng, nband, nx, ny, uv_hole=False):
+    """One partition shared by every band, so ``M_data = I_nband (x) A``.
+
+    With the same ``A`` in every band the data term and the prior commute and
+    the coupled operator's whole spectrum is available in closed form.
+    ``uv_hole`` zeroes three quarters of ``psfhat`` -- unsampled uv cells, where
+    the data term has NO curvature at all (``lambda_min(A) == 0`` to roundoff)
+    and ``eta`` is the only thing holding ``M`` up. Real data lives in that
+    regime over much of the uv plane: ``scripts/max_gamma.py`` reports 25-30% of
+    Fourier modes below ``eta`` on ``subset_withbeam_I.dt``.
+    """
+    psf = rng.uniform(0.0, 1.0, size=(2 * nx, 2 * ny))
+    psfhat = np.abs(r2c(psf, axes=(0, 1), forward=True, inorm=0))[None]
+    if uv_hole:
+        psfhat[:, nx // 2 :, :] = 0.0
+    part = {"psfhat": psfhat, "beam": np.ones((1, nx, ny)), "wsum": np.array([1.0])}
+    return part, [[part] for _ in range(nband)]
+
+
+def _pair(parts, nx, ny, eta, kinv, **kw):
+    """``(uncoupled, coupled)`` facades over ONE shared worker pool.
+
+    Both constructors call ``init_hess`` with identical arguments, so the
+    worker-side operator is the same for both and only the driver-side coupling
+    differs -- which is also what the deconv driver does, and halves the Ray
+    actor startup these tests would otherwise pay twice over.
+    """
+    from pfb_imaging.operators.band_worker import BandWorkerPool
+
+    common = dict(etas=eta, workers=BandWorkerPool(len(parts), 1), **kw)
+    off = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, **common)
+    on = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, freq_prec=kinv, **common)
+    return off, on
+
+
+def _dense(op, shape):
+    """Materialise a cube operator as a matrix, column by column."""
+    n = int(np.prod(shape))
+    out = np.zeros((n, n))
+    for i in range(n):
+        e = np.zeros(n)
+        e[i] = 1.0
+        out[:, i] = np.asarray(op(e.reshape(shape))).ravel()
+    return out
+
+
+def test_prior_couples_bands_and_never_pixels():
+    """The coupling is exactly ``eta*(Cinv - I)`` down the band axis, pixel by pixel.
+
+    ``dot`` applies it as ``(nband, nband) @ (nband, npix)`` over a
+    ``reshape(nband, -1)`` view, so an axis mix-up would smear one pixel across
+    its neighbours -- checked directly with a single-pixel delta, whose response
+    must stay in that pixel.
+    """
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(15)
+    nband, nx, ny = 3, 6, 6
+    eta = 1e-2
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=10.0)
+    off, on = _pair(parts, nx, ny, eta, kinv)
+    dprec = kinv - np.eye(nband)
+
+    x = rng.standard_normal((nband, nx, ny))
+    assert_allclose(on.dot(x) - off.dot(x), eta * np.einsum("bc,cyx->byx", dprec, x), rtol=1e-10, atol=1e-14)
+
+    d = np.zeros((nband, nx, ny))
+    d[0, 2, 3] = 1.0
+    resp = on.dot(d) - off.dot(d)
+    elsewhere = np.ones((nx, ny), dtype=bool)
+    elsewhere[2, 3] = False
+    assert_allclose(resp[:, elsewhere], 0.0, atol=1e-15)
+    assert_allclose(resp[:, 2, 3], eta * dprec[:, 0], rtol=1e-10)
+
+
+def test_prior_congruence_with_a_spatially_varying_eta():
+    """The ``eta_mode`` branch of ``_s``: D is a per-band, per-pixel profile, not a scalar.
+
+    ``test_prior_term_matches_the_dense_congruence`` covers only uniform eta,
+    where ``D^.5 Cinv D^.5`` collapses to ``eta*Cinv``. Under ``--eta-mode`` the
+    congruence is the whole point and ``_s`` is an ``(nband, ny, nx)`` cube
+    fetched back from the workers, so a band or axis mix-up is possible in a way
+    it is not for a scalar. Per-band beams make the profiles differ, so reusing
+    one band's profile for all of them fails here.
+    """
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(16)
+    nband, nx, ny = 3, 6, 6
+    eta, eta_mode, eta_cap = 1e-2, "invbeam", 20.0
+    parts = []
+    for _ in range(nband):
+        p = _rand_part(rng, nx, ny, 2 * nx, 2 * ny)
+        p["beam"] = rng.uniform(0.2, 1.0, size=(1, nx, ny))
+        parts.append([p])
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=10.0)
+    _, on = _pair(parts, nx, ny, eta, kinv, eta_mode=eta_mode, eta_cap=eta_cap)
+
+    x = rng.standard_normal((nband, nx, ny))
+    base = np.zeros_like(x)
+    s = np.zeros_like(x)
+    for b in range(nband):
+        local = HessianTree(parts[b], nx, ny, 2 * nx, 2 * ny, eta=eta, eta_mode=eta_mode, eta_cap=eta_cap)
+        base[b] = local.dot(x[b])[0]
+        s[b] = np.sqrt(np.asarray(local.eta).reshape(-1, ny, nx)[0])
+    assert s.std(axis=(1, 2)).min() > 0.0, "the profiles must vary spatially or this tests nothing"
+    assert np.abs(np.diff(s, axis=0)).max() > 0.0, "the profiles must differ between bands"
+
+    want = base + s * np.einsum("bc,cyx->byx", kinv - np.eye(nband), s * x)
+    assert_allclose(on.dot(x), want, rtol=1e-10, atol=1e-14)
+
+
+@pytest.mark.slow
+def test_prior_matches_the_kronecker_spectrum():
+    """M_gp's entire spectrum is ``alpha_k + eta*p_j`` -- data eigenvalue plus prior eigenvalue.
+
+    Every band shares one partition, so ``M_data = I_nband (x) A`` and
+    ``P = eta*Cinv_n (x) I`` commute and their eigenvalues add pairwise. Checking
+    the whole sorted spectrum against that closed form pins the driver-side term
+    far harder than one dot product can: a sign flip, a transposed apply, a
+    band/pixel mix-up, or the wrong normalisation each break it, and none of them
+    are visible to the fixed-point test (wiki D22).
+    """
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(12)
+    nband, nx, ny = 3, 6, 6
+    eta, cap = 1e-2, 10.0
+    part, parts = _shared_parts(rng, nband, nx, ny, uv_hole=True)
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=cap)
+
+    _, on = _pair(parts, nx, ny, eta, kinv)
+    got = np.linalg.eigvalsh(_dense(on.dot, (nband, nx, ny)))
+
+    a = _dense(lambda z: HessianTree([part], nx, ny, 2 * nx, 2 * ny, eta=0.0).dot(z)[0], (nx, ny))
+    want = np.sort(np.add.outer(np.linalg.eigvalsh(a), eta * np.linalg.eigvalsh(kinv)).ravel())
+    assert_allclose(got, want, rtol=1e-9, atol=1e-12)
+
+
+@pytest.mark.slow
+@pmp("uv_hole", [True, False])
+def test_prior_lowers_lambda_min_only_where_the_data_lacks_curvature(uv_hole):
+    """``lambda_max`` is untouched; ``lambda_min`` drops by the precision's smallest eigenvalue.
+
+    This is the designed trade, not a defect. The precision is normalised so the
+    ROUGHEST frequency mode sits at exactly 1 and smoother ones are *relaxed*
+    down to ``1/cap`` (wiki D30), so the prior only ever removes curvature from
+    ``M``. Where the data term has curvature of its own the removal is invisible;
+    where it has none, ``lambda_min(M)`` falls by the full factor and
+    ``cond(M)`` rises by it. Contrast ``eta_profile``, whose modes are normalised
+    so that ``lambda_min(M)`` cannot degrade -- these two knobs pull opposite ways
+    on the CG iteration count, by design.
+    """
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(13)
+    nband, nx, ny = 3, 6, 6
+    eta, cap = 1e-2, 10.0
+    _, parts = _shared_parts(rng, nband, nx, ny, uv_hole=uv_hole)
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=cap)
+    p_min = float(np.linalg.eigvalsh(kinv).min())
+
+    shape = (nband, nx, ny)
+    off, on = _pair(parts, nx, ny, eta, kinv)
+    w_off = np.linalg.eigvalsh(_dense(off.dot, shape))
+    w_on = np.linalg.eigvalsh(_dense(on.dot, shape))
+
+    # the prec.max() == 1 normalisation, read off the operator rather than the
+    # matrix: lambda_max(M) -- hence hess_norm and the PD step sizes -- is fixed
+    assert_allclose(w_on.max(), w_off.max(), rtol=1e-10)
+    assert w_on.min() <= w_off.min() * (1.0 + 1e-10), "the prior may only remove curvature from M"
+    if uv_hole:
+        # lambda_min(A) == 0 there, so lambda_min(M) is eta and eta*p_min exactly
+        assert_allclose(w_off.min(), eta, rtol=1e-6)
+        assert_allclose(w_on.min() / w_off.min(), p_min, rtol=1e-6)
+    else:
+        # the data term dominates eta everywhere, so the prior is nearly free
+        assert w_on.min() / w_off.min() > 0.9
+
+
+@pytest.mark.slow
+def test_prior_needs_more_cg_iterations_and_that_is_expected():
+    """CG gets SLOWER with the prior on. Pinned here so it is not read as a regression.
+
+    ``lambda_min(M)`` drops by up to ``gp_cap`` (previous test) while
+    ``lambda_max(M)`` is fixed, so ``cond(M)`` rises by up to ``gp_cap`` and CG
+    needs of order ``sqrt(gp_cap)`` more iterations. Measured on real data:
+    95 -> >150 applications for one forward solve
+    (``scripts/profile_freq_correlated_hessian.py``). Expecting a prior to *help*
+    CG is reading it as added regularisation; this one is a relaxation.
+    """
+    from pfb_imaging.operators.hessian import freq_precision
+    from pfb_imaging.opt.pcg import pcg_numba
+
+    rng = np.random.default_rng(14)
+    nband, nx, ny = 3, 6, 6
+    eta, cap = 1e-2, 10.0
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=cap)
+    rhs = rng.standard_normal((nband, nx, ny))
+
+    def applications(op):
+        n = [0]
+
+        def counted(z):
+            n[0] += 1
+            return op.dot(z)
+
+        pcg_numba(counted, rhs.copy(), tol=1e-8, maxit=5000, minit=1, verbosity=0)
+        return n[0]
+
+    _, holed = _shared_parts(rng, nband, nx, ny, uv_hole=True)
+    off, on = _pair(holed, nx, ny, eta, kinv)
+    it_off, it_on = applications(off), applications(on)
+    assert it_on > 1.5 * it_off, f"expected the prior to cost iterations, got {it_off} -> {it_on}"
+
+    # where eta is not load-bearing the same prior is nearly free: the cost
+    # tracks how much of M's spectrum eta is holding up, not the prior itself
+    _, full = _shared_parts(rng, nband, nx, ny, uv_hole=False)
+    off_f, on_f = _pair(full, nx, ny, eta, kinv)
+    it_full, it_full_gp = applications(off_f), applications(on_f)
+    assert it_full_gp < 1.3 * it_full, f"expected the prior to be nearly free here, got {it_full} -> {it_full_gp}"

--- a/tests/test_hess_tree_ray.py
+++ b/tests/test_hess_tree_ray.py
@@ -193,3 +193,30 @@ def test_cg_with_the_prior_bypasses_the_band_parallel_pool_path():
 
     gp._pool.hess_cg = boom
     gp.cg(rng.standard_normal((nband, nx, ny)))
+
+
+def test_prior_stats_are_none_when_the_prior_is_off():
+    rng = np.random.default_rng(10)
+    nband, nx, ny = 2, 8, 8
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    hess = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-2)
+    assert hess.get_freq_prior_stats() is None
+
+
+def test_prior_stats_report_the_spectrum_and_its_contribution_to_m():
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(11)
+    nband, nx, ny = 3, 8, 8
+    eta, cap = 1e-2, 10.0
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 1.0, cap=cap)
+    gp = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=eta, freq_prec=kinv)
+
+    stats = gp.get_freq_prior_stats()
+    assert_allclose(stats["prec_max"], 1.0, rtol=1e-12)
+    assert stats["prec_min"] >= 1.0 / cap - 1e-12
+    assert_allclose(stats["eta_max"], eta, rtol=1e-12)
+    # the prior's top contribution to M equals eta: lambda_max(M) is unchanged
+    assert_allclose(stats["lam_max"], eta, rtol=1e-12)
+    assert_allclose(stats["lam_min"], stats["prec_min"] * eta, rtol=1e-12)

--- a/tests/test_hess_tree_ray.py
+++ b/tests/test_hess_tree_ray.py
@@ -94,11 +94,16 @@ def test_prior_term_matches_the_dense_congruence():
     parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
     kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=10.0)
 
-    base = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=eta)
     gp = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=eta, freq_prec=kinv)
 
     x = rng.standard_normal((nband, nx, ny))
-    want = base.dot(x) - eta * x + eta * np.einsum("bc,cyx->byx", kinv, x)
+    # the M_data + eta*I reference is built with local HessianTrees rather than a
+    # second HessTreeRay: it halves the Ray actor count and keeps this test -- the
+    # one that pins the prior term's sign and value -- inside the fast loop
+    base_dot = np.zeros_like(x)
+    for b in range(nband):
+        base_dot[b] = HessianTree(parts[b], nx, ny, 2 * nx, 2 * ny, eta=eta).dot(x[b])[0]
+    want = base_dot - eta * x + eta * np.einsum("bc,cyx->byx", kinv, x)
     assert_allclose(gp.dot(x), want, rtol=1e-11, atol=1e-13)
 
 

--- a/tests/test_hess_tree_ray.py
+++ b/tests/test_hess_tree_ray.py
@@ -141,3 +141,55 @@ def test_wrong_freq_prec_shape_is_rejected():
     kinv = freq_precision(np.linspace(1.0e9, 1.4e9, 4), 0.5)  # 4 bands, not 3
     with pytest.raises(ValueError, match="freq_prec"):
         HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-2, freq_prec=kinv)
+
+
+def test_cg_solves_the_coupled_system_when_the_prior_is_on():
+    """The real contract: whichever branch runs, cg must invert the operator dot applies."""
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(7)
+    nband, nx, ny = 3, 8, 8
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=10.0)
+    gp = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-1, freq_prec=kinv, cg_tol=1e-10, cg_maxit=500)
+
+    rhs = rng.standard_normal((nband, nx, ny))
+    u = gp.cg(rhs)
+    assert_allclose(gp.dot(u), rhs, rtol=1e-5, atol=1e-7)
+
+
+def test_cg_without_the_prior_still_uses_the_band_parallel_pool_path():
+    """The in-worker fast path is one Ray dispatch per solve; do not lose it."""
+    rng = np.random.default_rng(8)
+    nband, nx, ny = 2, 8, 8
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    hess = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-1)
+
+    calls = []
+    original = hess._pool.hess_cg
+
+    def spy(*args, **kwargs):
+        calls.append(1)
+        return original(*args, **kwargs)
+
+    hess._pool.hess_cg = spy
+    u = hess.cg(rng.standard_normal((nband, nx, ny)))
+    assert calls == [1], "the band-parallel pool path was bypassed"
+    assert u.shape == (nband, nx, ny)
+
+
+def test_cg_with_the_prior_bypasses_the_band_parallel_pool_path():
+    """Band-parallel CG cannot solve a band-coupled operator."""
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(9)
+    nband, nx, ny = 3, 8, 8
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=10.0)
+    gp = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-1, freq_prec=kinv)
+
+    def boom(*args, **kwargs):
+        raise AssertionError("hess_cg must not be called when bands are coupled")
+
+    gp._pool.hess_cg = boom
+    gp.cg(rng.standard_normal((nband, nx, ny)))

--- a/tests/test_hess_tree_ray.py
+++ b/tests/test_hess_tree_ray.py
@@ -78,3 +78,66 @@ def test_cg_matches_local_pcg(nband):
         local = HessianTree(parts[b], nx, ny, 2 * nx, 2 * ny, eta=0.5)
         want_b = pcg_numba(lambda z: local.dot(z)[0], rhs[b], tol=1e-8, maxit=200, minit=1, verbosity=0)
         assert_allclose(got[b], want_b, rtol=1e-6, atol=1e-9)
+
+
+def test_prior_term_matches_the_dense_congruence():
+    """M_gp x == M_data x + eta * (Cinv @ x) when eta is uniform.
+
+    With eta_mode unset the congruence D^.5 Cinv D^.5 collapses to eta*Cinv, so
+    the driver-side term is exactly eta*(Cinv - I) applied over the band axis.
+    """
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(3)
+    nband, nx, ny = 3, 8, 8
+    eta = 1e-2
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=10.0)
+
+    base = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=eta)
+    gp = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=eta, freq_prec=kinv)
+
+    x = rng.standard_normal((nband, nx, ny))
+    want = base.dot(x) - eta * x + eta * np.einsum("bc,cyx->byx", kinv, x)
+    assert_allclose(gp.dot(x), want, rtol=1e-11, atol=1e-13)
+
+
+def test_prior_is_a_no_op_when_freq_prec_is_none():
+    """The default path must be bit-identical to today (regression guard)."""
+    rng = np.random.default_rng(4)
+    nband, nx, ny = 2, 8, 8
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    hess = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-2, freq_prec=None)
+    x = rng.standard_normal((nband, nx, ny))
+    want = np.zeros_like(x)
+    for b in range(nband):
+        want[b] = HessianTree(parts[b], nx, ny, 2 * nx, 2 * ny, eta=1e-2).dot(x[b])[0]
+    assert_allclose(hess.dot(x), want, rtol=0, atol=0)
+
+
+def test_prior_hessian_stays_symmetric_and_positive_definite():
+    """CG requires both; the driver-side correction alone is only NSD."""
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(5)
+    nband, nx, ny = 3, 8, 8
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 1.0, cap=50.0)
+    gp = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-2, freq_prec=kinv)
+
+    for _ in range(10):
+        u = rng.standard_normal((nband, nx, ny))
+        v = rng.standard_normal((nband, nx, ny))
+        assert_allclose(np.vdot(u, gp.dot(v)), np.vdot(gp.dot(u), v), rtol=1e-10)
+        assert np.vdot(u, gp.dot(u)) > 0.0
+
+
+def test_wrong_freq_prec_shape_is_rejected():
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(6)
+    nband, nx, ny = 3, 8, 8
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, 4), 0.5)  # 4 bands, not 3
+    with pytest.raises(ValueError, match="freq_prec"):
+        HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-2, freq_prec=kinv)

--- a/tests/test_pfb_solver.py
+++ b/tests/test_pfb_solver.py
@@ -395,3 +395,71 @@ def test_build_hess_eta_is_fraction_of_total_wsum(monkeypatch):
     presets._build_hess(parts, {"nx": 8, "ny": 8, "nx_psf": 16, "ny_psf": 16}, opts)
     assert_allclose(captured["etas"], 0.01)  # uniform, NOT scaled by wsum_b/wsum_tot
     assert np.isclose(captured["wsums"], 4.0)
+
+
+def _gp_opts(**overrides):
+    """Minimal make_sara opts; see test_make_sara_opt_backend_selects_solver."""
+    opts = dict(
+        bases=["self"],
+        nlevels=1,
+        rmsfactor=1.0,
+        alpha=2.0,
+        gamma=1.0,
+        positivity=0,
+        eta=0.5,
+        l1_reweight_from=-1,
+        hess_norm=1.0,
+        opt_backend="primal-dual",
+        acceleration=True,
+        nthreads=1,
+        verbosity=0,
+        pd_tol=1e-6,
+        pd_maxit=10,
+        pd_verbose=0,
+        pd_report_freq=100,
+        fb_tol=1e-6,
+        fb_maxit=10,
+        fb_verbose=0,
+        fb_report_freq=100,
+        cg_tol=1e-6,
+        cg_maxit=10,
+        cg_verbose=0,
+        cg_report_freq=100,
+        pm_tol=1e-3,
+        pm_maxit=10,
+        pm_verbose=0,
+        pm_report_freq=100,
+    )
+    opts.update(overrides)
+    return opts
+
+
+def test_build_hess_omits_the_frequency_prior_by_default():
+    """Callers that never ask for the prior must not have to supply freq_out."""
+    from pfb_imaging.deconv.presets import make_sara
+
+    geometry = {"nx": 16, "ny": 16, "nx_psf": 32, "ny_psf": 32}  # no freq_out
+    solver = make_sara(_delta_partitions(2, 16, 16), geometry, np.zeros((2, 16, 16)), np.zeros((2, 16, 16)), _gp_opts())
+    assert solver.hess._dC is None
+
+
+def test_build_hess_wires_the_frequency_prior_when_requested():
+    """gp_length_scale must reach HessTreeRay, not be silently dropped."""
+    from pfb_imaging.deconv.presets import make_sara
+
+    nband = 3
+    geometry = {
+        "nx": 16,
+        "ny": 16,
+        "nx_psf": 32,
+        "ny_psf": 32,
+        "freq_out": np.linspace(1.0e9, 1.4e9, nband),
+    }
+    opts = _gp_opts(gp_length_scale=0.5, gp_cap=10.0)
+    solver = make_sara(
+        _delta_partitions(nband, 16, 16), geometry, np.zeros((nband, 16, 16)), np.zeros((nband, 16, 16)), opts
+    )
+    assert solver.hess._dC is not None
+    assert solver.hess._dC.shape == (nband, nband)
+    # the remainder is not trivial: a zero dC would mean the kernel collapsed to I
+    assert np.abs(solver.hess._dC).max() > 1e-6

--- a/tests/test_pfb_solver.py
+++ b/tests/test_pfb_solver.py
@@ -465,3 +465,27 @@ def test_build_hess_wires_the_frequency_prior_when_requested():
     assert solver.hess._dC.shape == (nband, nband)
     # the remainder is not trivial: a zero dC would mean the kernel collapsed to I
     assert np.abs(solver.hess._dC).max() > 1e-6
+
+
+@pytest.mark.slow
+def test_build_hess_warns_when_the_prior_is_requested_but_undefinable(monkeypatch):
+    """A single band has nothing to correlate; do not accept the flag in silence.
+
+    freq_precision returns None there, so the run proceeds with an uncorrelated
+    eta -- correct, but indistinguishable from the option being unset unless it
+    is said out loud. Captured off the module logger rather than caplog: the
+    pfb root logger sets propagate = False, so caplog sees nothing.
+    """
+    from pfb_imaging.deconv import presets
+
+    warnings = []
+    monkeypatch.setattr(presets.log, "warning", lambda msg, *a, **k: warnings.append(str(msg)))
+
+    geometry = {"nx": 16, "ny": 16, "nx_psf": 32, "ny_psf": 32, "freq_out": np.array([1.0e9])}
+    opts = _gp_opts(gp_length_scale=0.5)
+    solver = presets.make_sara(
+        _delta_partitions(1, 16, 16), geometry, np.zeros((1, 16, 16)), np.zeros((1, 16, 16)), opts
+    )
+
+    assert solver.hess._dC is None  # genuinely off, as freq_precision decided
+    assert any("nothing to correlate" in w for w in warnings), warnings

--- a/tests/test_pfb_solver.py
+++ b/tests/test_pfb_solver.py
@@ -434,6 +434,7 @@ def _gp_opts(**overrides):
     return opts
 
 
+@pytest.mark.slow
 def test_build_hess_omits_the_frequency_prior_by_default():
     """Callers that never ask for the prior must not have to supply freq_out."""
     from pfb_imaging.deconv.presets import make_sara
@@ -443,6 +444,7 @@ def test_build_hess_omits_the_frequency_prior_by_default():
     assert solver.hess._dC is None
 
 
+@pytest.mark.slow
 def test_build_hess_wires_the_frequency_prior_when_requested():
     """gp_length_scale must reach HessTreeRay, not be silently dropped."""
     from pfb_imaging.deconv.presets import make_sara

--- a/tests/test_preconditioner_consistency.py
+++ b/tests/test_preconditioner_consistency.py
@@ -352,3 +352,101 @@ def test_deconv_unregularised_residual_keeps_descending(sky_truth, ms_name, tmp_
     min_flux = sky_truth.ref_flux.min()
     assert resid1 < 0.02 * min_flux, f"segment 1 residual peak {resid1:.3e} too high"
     assert resid2 < 0.7 * resid1, f"residual plateaued: resid2 {resid2:.3e} vs resid1 {resid1:.3e}"
+
+
+@pytest.mark.slow
+def test_frequency_prior_does_not_move_the_fixed_point():
+    """A GP prior over frequency reshapes each update but not the solution.
+
+    Preconditioned Richardson converges to ``A^-1 b`` for ANY nonsingular ``M``
+    (wiki D22), so coupling bands through ``M`` must reach the same fixed point
+    as the band-diagonal preconditioner -- only the path and the rate change.
+    The beams narrow with frequency, reproducing the tapering of issue #307.
+
+    What this does NOT guard, by construction: the *sign* or the exact value of
+    the prior term. Flipping ``dot``'s ``out += self._buf2`` to ``-=`` yields
+    ``M_data + D + D^.5 (I - Cinv) D^.5``, which is still symmetric positive
+    definite, so the theorem says it reaches the same fixed point -- and this
+    test passes (verified). That is the theorem working, not a gap. The prior
+    term's actual value is pinned against an explicit dense formula by
+    ``test_hess_tree_ray.py::test_prior_term_matches_the_dense_congruence``,
+    which does fail under that mutation.
+    """
+    from pfb_imaging.operators.hessian import HessTreeRay, freq_precision
+
+    nband, nx, ny = 3, 8, 8
+    # eta is a large share of M here (measured: the prior moves ||M|| by 23%,
+    # against 3% at eta=1e-2). That is the regime the prior targets -- the field
+    # edge, where the beam kills M_data and eta is what is left -- and it keeps
+    # the vacuity guard below meaningful.
+    eta = 1e-1
+    cell = np.deg2rad(3.0) / nx
+    rng = np.random.default_rng(31)
+
+    beams = [_gaussian_beam(nx, ny, cell, fwhm_deg=3.0 - 0.6 * b, cx=1.0, cy=-0.5) for b in range(nband)]
+    parts = [[_make_partition(rng, cell, nx, ny, beams[b])] for b in range(nband)]
+    wsum = sum(p["wsum"] for plist in parts for p in plist)
+
+    def aop(m):
+        """Exact block-diagonal Hessian: the data term never couples bands."""
+        out = np.zeros_like(m)
+        for b, plist in enumerate(parts):
+            for p in plist:
+                beam = p["beam"]
+                out[b] += beam * _gtwg(beam * m[b], p["uvw"], p["wgt"], cell)
+        return out / wsum + eta * m
+
+    hess_parts = [
+        [{"psfhat": p["psfhat"], "beam": p["beam"][None], "wsum": np.array([p["wsum"]])} for p in plist]
+        for plist in parts
+    ]
+    kinv = freq_precision(np.linspace(0.9e9, 1.7e9, nband), 0.5, cap=10.0)
+    base = HessTreeRay(hess_parts, nx, ny, 2 * nx, 2 * ny, etas=eta, wsums=wsum, nthreads=NTHREADS)
+    gp = HessTreeRay(hess_parts, nx, ny, 2 * nx, 2 * ny, etas=eta, wsums=wsum, nthreads=NTHREADS, freq_prec=kinv)
+
+    ndof = nband * ny * nx
+
+    def _dense(apply_fn):
+        out = np.zeros((ndof, ndof))
+        e = np.zeros((nband, ny, nx))
+        for i in range(ndof):
+            e.flat[i] = 1.0
+            out[:, i] = apply_fn(e).ravel()
+            e.flat[i] = 0.0
+        return out
+
+    a_dense = _dense(aop)
+    m_base = _dense(base.dot)
+    m_gp = _dense(gp.dot)
+
+    # the test is only meaningful if the two preconditioners really differ
+    gap = np.linalg.norm(m_gp - m_base) / np.linalg.norm(m_base)
+    assert gap > 0.05, f"the prior barely changed M ({gap:.3e}); the test would be vacuous"
+
+    # a smooth source with a spectral gradient, brightest where the beams differ most
+    yyp, xxp = np.mgrid[0:ny, 0:nx]
+    blob = np.exp(-0.5 * ((xxp - nx / 2 - 1) ** 2 + (yyp - ny / 2 + 1) ** 2) / (nx / 6) ** 2)
+    m_true = np.stack([blob * (1.0 + 0.4 * b) for b in range(nband)])
+    b_rhs = aop(m_true)
+
+    x_full = np.linalg.solve(a_dense, b_rhs.ravel()).reshape(nband, ny, nx)
+
+    def _richardson(mop, m_dense):
+        evals = np.linalg.eigvals(np.linalg.solve(m_dense, a_dense)).real
+        gamma = 2.0 / (evals.min() + evals.max())
+        m = np.zeros((nband, ny, nx))
+        rel = np.inf
+        for _ in range(400):
+            grad = b_rhs - aop(m)
+            m = m + gamma * pcg_numba(mop.dot, grad, tol=1e-10, maxit=300, minit=1, verbosity=0)
+            rel = np.linalg.norm(m - x_full) / np.linalg.norm(x_full)
+            if rel < 1e-5:
+                break
+        return m, rel
+
+    m_base_sol, rel_base = _richardson(base, m_base)
+    m_gp_sol, rel_gp = _richardson(gp, m_gp)
+
+    assert rel_base < 1e-5, f"band-diagonal preconditioner did not converge (rel={rel_base:.3e})"
+    assert rel_gp < 1e-5, f"frequency-coupled preconditioner did not converge (rel={rel_gp:.3e})"
+    np.testing.assert_allclose(m_gp_sol, m_base_sol, rtol=0, atol=1e-4 * np.abs(x_full).max())

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -398,6 +398,67 @@ def test_restore_zero_gausspar_selects_lowest_resolution(tmp_path):
         np.testing.assert_allclose(pf[2], 0.3, rtol=1e-6)  # mean pa
 
 
+def test_restore_cresidual_completes_the_restored_image(tmp_path):
+    """CRESIDUAL is exactly the term KIMAGE adds to the convolved model.
+
+    That is the whole point of storing it: the resolution change applied to the
+    residual is otherwise unrecoverable from the tree, so nothing records what
+    it did (issue #312).
+    """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kKsS", gausspar=(0.0, 0.0, 0.0))
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    for b in range(2):
+        ds = dt[f"band{b:04d}_time0000"].ds
+        assert "CRESIDUAL" in ds
+        model = ds.MODEL.values
+        _, ny, nx = model.shape
+        x = -(nx // 2) + np.arange(nx)
+        y = -(ny // 2) + np.arange(ny)
+        xx, yy = np.meshgrid(x, y, indexing="ij")
+        mconv = convolve2gaussres(
+            model, xx, yy, ds.PSFPARSF.values, nthreads=1, pfrac=0.2, norm_kernel=False, yx_order=True
+        )
+        np.testing.assert_allclose(mconv + ds.CRESIDUAL.values, ds.KIMAGE.values, rtol=0, atol=1e-5)
+
+
+def test_restore_cresidual_is_apparent_and_not_the_raw_residual(tmp_path):
+    """It is pre-beam-division, and it is not RESIDUAL untouched.
+
+    Apparent because that is the scale image-plane noise is flat on and BEAM is
+    already on the node; not RESIDUAL because the whole point is the resolution
+    change. RESIDUAL itself must survive unmodified.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+    before = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds.RESIDUAL.values.copy()
+
+    _run_restore(tmp_path, outputs="iIsS", gausspar=(0.0, 0.0, 0.0))
+
+    ds = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds
+    np.testing.assert_array_equal(ds.RESIDUAL.values, before)
+    raw = ds.RESIDUAL.values / ds.WSUM.values[:, None, None]
+    # band 0 is the narrow band, so it is genuinely broadened to reach the target
+    assert not np.allclose(ds.CRESIDUAL.values, raw, atol=1e-8)
+    # apparent: IMAGE divides it by the beam, CRESIDUAL does not
+    assert np.nanmax(np.abs(ds.CRESIDUAL.values)) < np.nanmax(np.abs(ds.CRESIDUAL.values / ds.BEAM.values)) * 1.001
+
+
+def test_restore_without_s_writes_no_cresidual(tmp_path):
+    """It is opt-in: a default run must not pay for another cube per band."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kK")
+
+    assert "CRESIDUAL" not in xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds
+
+
 def test_restore_zero_gausspar_handles_bands_at_different_angles(tmp_path):
     """The real --gausspar 0 0 0 hazard: bands whose position angles differ.
 

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -434,6 +434,8 @@ def test_restore_cresidual_is_apparent_and_not_the_raw_residual(tmp_path):
     already on the node; not RESIDUAL because the whole point is the resolution
     change. RESIDUAL itself must survive unmodified.
     """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
     store = str(tmp_path / "rt_I.dt")
     _write_restore_dt(store)
     before = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds.RESIDUAL.values.copy()
@@ -445,8 +447,20 @@ def test_restore_cresidual_is_apparent_and_not_the_raw_residual(tmp_path):
     raw = ds.RESIDUAL.values / ds.WSUM.values[:, None, None]
     # band 0 is the narrow band, so it is genuinely broadened to reach the target
     assert not np.allclose(ds.CRESIDUAL.values, raw, atol=1e-8)
-    # apparent: IMAGE divides it by the beam, CRESIDUAL does not
-    assert np.nanmax(np.abs(ds.CRESIDUAL.values)) < np.nanmax(np.abs(ds.CRESIDUAL.values / ds.BEAM.values)) * 1.001
+
+    # apparent: the beam divide happens in IMAGE, not in CRESIDUAL, so what
+    # IMAGE adds to the convolved model is CRESIDUAL / BEAM and not CRESIDUAL.
+    # Band 1 carries the sub-unit beam, so it is the one where that differs.
+    ds1 = xr.open_datatree(store, engine="zarr", chunks=None)["band0001_time0000"].ds
+    beam = ds1.BEAM.values
+    assert beam.max() < 0.9, "a unit beam would make this vacuous"
+    _, ny, nx = ds1.MODEL.shape
+    xx, yy = np.meshgrid(-(nx // 2) + np.arange(nx), -(ny // 2) + np.arange(ny), indexing="ij")
+    mconv = convolve2gaussres(
+        ds1.MODEL.values, xx, yy, ds1.PSFPARSF.values, nthreads=1, pfrac=0.2, norm_kernel=False, yx_order=True
+    )
+    keep = beam > 0.1  # the pb_min core/restore.py defaults to
+    np.testing.assert_allclose((ds1.IMAGE.values - mconv)[keep], (ds1.CRESIDUAL.values / beam)[keep], rtol=0, atol=1e-5)
 
 
 def test_restore_without_s_writes_no_cresidual(tmp_path):

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -147,11 +147,85 @@ def test_clean_beam_zero_wsum_is_nan_not_a_crash():
     assert np.isnan(out).all()
 
 
-def test_lowest_resolution_takes_max_axes_and_mean_pa():
+def test_lowest_resolution_takes_max_axes_when_the_angles_agree():
+    """Aligned inputs: the answer is still just the max of each axis."""
     from pfb_imaging.utils.restoration import lowest_resolution
 
-    gp = np.array([[[6.0, 3.0, 0.2]], [[4.0, 5.0, 0.6]]])
-    np.testing.assert_allclose(lowest_resolution(gp), np.array([[6.0, 5.0, 0.4]]))
+    gp = np.array([[[6.0, 3.0, 0.2]], [[5.0, 4.0, 0.2]]])
+    np.testing.assert_allclose(lowest_resolution(gp), np.array([[6.0, 4.0, 0.2]]), rtol=1e-5)
+
+
+LOWEST_RESOLUTION_CASES = [
+    ([(10.0, 5.0, 0.3), (11.0, 5.4, 0.3), (12.0, 6.0, 0.3)], "aligned"),
+    ([(10.0, 5.0, 0.0), (10.2, 5.1, 0.15), (10.4, 5.2, -0.1)], "small pa spread"),
+    ([(10.0, 5.0, 0.0), (10.2, 5.1, 0.8), (9.8, 4.9, -0.7)], "large pa spread"),
+    ([(10.0, 5.0, 0.05), (10.1, 5.05, np.pi - 0.05)], "across the mod-pi seam"),
+    ([(20.0, 12.0, 0.4), (8.0, 4.0, -0.9), (7.0, 3.5, 1.2)], "one dominant band"),
+    ([(9.0, 8.9, 0.2), (9.1, 8.8, 1.3)], "near circular"),
+]
+
+
+@pytest.mark.parametrize("rows, label", LOWEST_RESOLUTION_CASES)
+def test_lowest_resolution_dominates_every_input(rows, label):
+    """Every input must be convolvable to the result.
+
+    Taking the max of each axis and the mean of the angles does not give this:
+    a rotated ellipse pokes out diagonally, so the difference of covariances is
+    indefinite and the "convolution" is a deconvolution along some direction.
+    Only one of these six cases passed under that heuristic (issue #312, D31).
+    """
+    from pfb_imaging.utils.misc import convolve2gaussres
+    from pfb_imaging.utils.restoration import lowest_resolution, resolution_deficit
+
+    gausspars = np.array(rows)[:, None, :]  # (n, ncorr=1, 3)
+    target = lowest_resolution(gausspars)
+
+    assert resolution_deficit(target, gausspars)[0] <= 1.0
+
+    # and end to end: convolve2gaussres must accept every one of them
+    npix = 128
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 2 + 3, npix // 2 - 2] = 1.0
+    for row in rows:
+        convolve2gaussres(image, xx, yy, target[0], nthreads=1, gausspari=np.array(row))
+
+
+def test_lowest_resolution_averages_position_angles_modulo_pi():
+    """PA is defined mod pi, so 0.05 and pi - 0.05 are nearly the same angle.
+
+    np.mean puts them at pi/2, orthogonal to both, which then needs a hugely
+    inflated beam to still dominate. The circular mean keeps them together.
+    """
+    from pfb_imaging.utils.restoration import lowest_resolution
+
+    gp = np.array([[[10.0, 5.0, 0.05]], [[10.0, 5.0, np.pi - 0.05]]])
+    target = lowest_resolution(gp)[0]
+
+    assert abs(target[2]) < 0.1 or abs(abs(target[2]) - np.pi) < 0.1
+    # near-aligned inputs need only a slight inflation, not a near-circular beam
+    assert target[0] / target[1] > 1.8
+
+
+def test_lowest_resolution_skips_nan_rows():
+    """Fully flagged bands come through as NaN and must not poison the result."""
+    from pfb_imaging.utils.restoration import lowest_resolution
+
+    gp = np.array([[[10.0, 5.0, 0.2]], [[np.nan] * 3], [[11.0, 5.5, 0.2]]])
+    np.testing.assert_allclose(lowest_resolution(gp), np.array([[11.0, 5.5, 0.2]]), rtol=1e-5)
+
+    assert np.isnan(lowest_resolution(np.array([[[np.nan] * 3]]))).all()
+
+
+def test_resolution_deficit_flags_a_target_that_is_too_sharp():
+    """The guard the --gausspar branch uses to fail early with a useful message."""
+    from pfb_imaging.utils.restoration import resolution_deficit
+
+    gausspars = np.array([[[10.0, 5.0, 0.0]], [[10.0, 5.0, 0.6]]])
+
+    assert resolution_deficit(np.array([[10.0, 5.0, 0.0]]), gausspars)[0] > 1.0
+    assert resolution_deficit(np.array([[20.0, 20.0, 0.0]]), gausspars)[0] <= 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -322,6 +396,46 @@ def test_restore_zero_gausspar_selects_lowest_resolution(tmp_path):
         np.testing.assert_allclose(pf[0], 10.0, rtol=1e-6)  # max emaj over bands
         np.testing.assert_allclose(pf[1], 6.0, rtol=1e-6)  # max emin over bands
         np.testing.assert_allclose(pf[2], 0.3, rtol=1e-6)  # mean pa
+
+
+def test_restore_zero_gausspar_handles_bands_at_different_angles(tmp_path):
+    """The real --gausspar 0 0 0 hazard: bands whose position angles differ.
+
+    Max-of-each-axis with the mean angle is not wide enough to contain a
+    rotated ellipse, so restoring to it is a deconvolution along some direction
+    (issue #312). The envelope must both complete and dominate every band.
+    """
+    from pfb_imaging.utils.restoration import resolution_deficit
+
+    store = str(tmp_path / "rt_I.dt")
+    gpars = ((10.0, 5.0, 0.0), (10.4, 5.2, 0.7))
+    _write_restore_dt(store, gpars=gpars)
+
+    _run_restore(tmp_path, outputs="kK", gausspar=(0.0, 0.0, 0.0))
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    target = dt["band0000_time0000"].ds.PSFPARSF.values  # (ncorr, 3)
+    # every band shares the target, and the target contains every band
+    for b in range(2):
+        np.testing.assert_allclose(dt[f"band{b:04d}_time0000"].ds.PSFPARSF.values, target, rtol=1e-12)
+    assert resolution_deficit(target, np.array(gpars)[:, None, :])[0] <= 1.0
+    # the old max-axis, mean-pa answer would not have contained them
+    old = np.array([[10.4, 5.2, 0.35]])
+    assert resolution_deficit(old, np.array(gpars)[:, None, :])[0] > 1.0
+
+
+def test_restore_gausspar_sharper_than_the_data_raises(tmp_path):
+    """An impossible --gausspar must say so, not ring the image.
+
+    The old code divided by a near-zero transform and returned noise; the error
+    names the factor short and the resolution that would work.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+    cell_deg = np.rad2deg(1.0e-6)
+
+    with pytest.raises(ValueError, match="deconvolution"):
+        _run_restore(tmp_path, outputs="kK", gausspar=(4.0 * cell_deg, 2.0 * cell_deg, 0.3))
 
 
 def test_restore_skips_zero_wsum_bands(tmp_path):


### PR DESCRIPTION
Closes #307. Also carries #312 (merged in via #317), so this is four design decisions, not one: **D30** frequency-correlated preconditioner, **D31** closed-form Gaussian transform ratio, **D32** Loewner-envelope restoring beam, **D33** `CRESIDUAL`.

## D30 — `--gp-length-scale`: the preconditioner's frequency prior

On a wide-field mosaic the primary beam tapers the *forward update* at the field edges, worst at the top of the band, and structure visible in the residual never reaches the model. The forward step already solves `B†HB + K⁻¹` with `K⁻¹ = η·I`, so exploiting frequency smoothness means replacing that scalar with a matrix — not a new mechanism.

`M x = M_data x + D^½ C⁻¹ₙ D^½ x`, with `D` the existing `eta`/`eta_mode` profile and `C⁻¹ₙ` a normalised `nband×nband` precision (squared exponential, linear frequency metric, length scale as a fraction of the band span). Applied through `D^½C⁻¹ₙD^½ = D + D^½(C⁻¹ₙ − I)D^½`, so **the band workers are untouched** and the driver adds only the remainder.

**The normalisation is the load-bearing part:** `prec = min(λmax/λ, cap)` then `prec /= prec.max()`, anchoring `η` to the *roughest* frequency mode present and relaxing smoother ones by up to `cap`. Three alternatives were tried and rejected — a uniform coupling on top of `diag(e)` (10× more white than correlated exactly at the corners where it is needed), "tighten" (makes the field-edge update *smaller*, i.e. the wrong direction, plus a 50× `hess_norm` inflation), and dividing by `cap` (a white kernel returns `I/cap`, silently weakening `eta` everywhere instead of degrading to today's behaviour). A log-frequency metric was also rejected: linear *is* its first-order expansion, differing 4% over a full 2:1 band.

**Cost when enabled is real and measured** (`scripts/profile_freq_correlated_hessian.py`): one forward solve **5.8 s → 20.0 s**, then **6.3 s → 12.7 s (2.03×)** once the coupling moved to a fused numba kernel. Three effects, not one — the band-parallel fast path is lost (+1.4 s), conditioning (+3.8 s, `λmin(M)` drops by up to `gp_cap` so CG needs ~`√gp_cap` more iterations — **designed behaviour**, and the opposite of `eta_profile`, which is normalised so `λmin` cannot degrade), and costlier dots. That last one was mostly **BLAS spin**: `np.matmul` with `k = nband` tiny and `n = npix` huge is memory-bound, but OpenBLAS spread it over every core and those threads busy-polled ~100 ms straight through the *next* `ray.get` while the workers needed the cores. `gauss.eta_freq_mul` replaces it — band-major inside a 2048-pixel tile, no scratch cubes (the numpy form held 7.6 GB at 8 × 8000²).

**At production size the binding cost is transfer, not arithmetic:** at 8 × 8000² one cube-level round trip is 1.63 s, so a 150-iteration forward solve moves 1.12 TB through the object store and `pcg_numba` holds 26.7 GB on the driver. All in D30.

## D31/D32/D33 — see #317

`convolve2gaussres` displaced sources through any resolution change (delta at (170, 260) → (146, 260), −0.81 of peak in ringing). Two independent causes; the closed-form transform ratio kills both and conserves flux exactly. That check then exposed `lowest_resolution` producing invalid targets all along — of six representative band sets, only the perfectly-aligned one gave a target every band could be convolved to. Plus `--outputs s`/`S` → `CRESIDUAL`.

## The invariant this PR is judged on: nothing changes when the prior is off

`--gp-length-scale` defaults to `None`, and the off path is **bit-identical to `dev-0.1.0`**, verified against a `dev-0.1.0` worktree with a fixed-seed 3-band `HessTreeRay` over real Ray actors:

```
dot   bit-identical: True   max|diff| = 0.000e+00
cg    bit-identical: True   max|diff| = 0.000e+00
eta   bit-identical: True   max|diff| = 0.000e+00
```

That holds structurally: `class HessianTree`'s body is untouched, `dot` gains one `is not None` check, and `cg` returns `self._pool.hess_cg(...)` unchanged. Pinned by `test_prior_is_a_no_op_when_freq_prec_is_none` (`rtol=0, atol=0`) and `test_cg_without_the_prior_still_uses_the_band_parallel_pool_path`.

**Import cost is flat too**, which was not free: `operators.hessian` now imports `operators.gauss`, which used to pull `africanus.gps.kernels` at module scope. Deferring that into `Gauss.__init__` pays for the new import — 0.926 s vs 0.926 s, `africanus` loaded on neither.

## Review pass

Four gaps found re-reading this before merge, all fixed in `f85119f`, none behaviour-changing with the prior off (re-verified bit-identical after):

- `hess_dot`'s `np.empty_like` made "every band is overwritten" load-bearing rather than merely true — `_map`'s local branch returns one result whatever `nband` is, and its Ray branch zips against `self.actors`. Both counts now checked.
- `test_every_m_defining_option_is_in_the_key` asserted `_M_OPTS` equals its own contents, so it could never fail for the reason its docstring gave. Renamed to say it is a change-detector, and added a test that every key name is a real `deconv` option — the failure mode that does bite, since `_m_signature` reads with `.get` and a renamed option silently keys on `None` for every run.
- `--gp-length-scale` on a single band was discarded in silence while the `nband > 1` path logs a whole correlation row. Now warns with the band count and span.
- `get_freq_prior_stats` claimed `lam_max == eta_max` keeps `λmax(M)` *unchanged*. `C⁻¹ ⪯ I` gives `M_gp ⪯ M`, so `λmax` can only fall — and does, since the eigenvectors do not align and `M`'s top mode is frequency-flat, the one relaxed to `1/cap`. Bounded by `η(1 − 1/cap)` ≈ 9e-4 against `λmax(M) ≈ 1.98`, and reusing the larger norm errs toward smaller steps. An upper bound, not an equality; corrected in the docstring and D30.

`HessTreeRay.cg`'s two branches have opposite `x0` aliasing (uncoupled allocates, coupled mutates in place). `PFBSolver.forward` is safe, but only by accident. Recorded as **Known debt** with the preferred fix; left out of this PR because it changes the contract around a frozen oracle and wants its own test.

## Expect once per existing tree

`hess_norm` is now cache-keyed on the M-defining options, fixing a **pre-existing bug** — changing `--eta` between runs on the same `.dt` silently reused a stale norm. Trees written before the key existed carry no `hess_norm_opts` and re-estimate on their first run, logged as "Preconditioner options changed since the cached hess_norm was written; re-estimating". One-off, not a per-run regression.

## Verification

```
uv run pytest tests/ -m ""   →  671 passed in 486s
uv run ruff format --check . →  clean
uv run ruff check .          →  All checks passed
hip-cargo generate-cabs      →  clean diff
```

Note `ci.yml`'s `pull_request` trigger is scoped to `branches: [main]`, so neither this PR nor #317 ran CI — that local run is the gate. CI fires for the first time on #297 (`dev-0.1.0 → main`) once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
