### PR TITLE
fix(restore): closed-form Gaussian transform ratio, Loewner-envelope restoring beam

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -139,7 +139,9 @@ scratch beam `("corr", "m_beam", "l_beam")`; ducc's x-major world exists only be
 `.T` views at the wgridder call sites (wiki design-decisions D19/D20).
 `MODEL`/`RESIDUAL`/`NOISE` are added later by the `deconv` consumer, and
 `IMAGE`/`BIMAGE`/`KIMAGE` plus `PSFPARSF` by the `restore` consumer (the intrinsic,
-apparent and mixed flux scales — wiki D29).
+apparent and mixed flux scales — wiki D29), and optionally `CRESIDUAL` (`--outputs s`/`S`),
+the residual convolved to the restoring resolution — apparent, pre-beam-division, and the
+only record of what the resolution change did to the residual (wiki D33).
 
 **Access layer — native DataTree only.** Use `xr.open_datatree(store)`,
 `ds.to_zarr(store, group="band…/part…", mode="a")`, and `dt.children` directly. Do **not** add

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,17 @@ rediscovery:
   stats `R GB` column shows ~0); only compare wall times at matching cache state.
 * **One mechanism per commit,** with the measured before/after in the commit message. It keeps
   cluster-run bisection possible when a change must be re-litigated.
+* **`gh issue view` and `gh pr edit` are broken on this machine — use `gh api` instead.** The
+  system `gh` is Ubuntu's 2.46.0, which asks GraphQL for the Projects-classic `projectCards`
+  field; the API has hard-errored on that since the May 2024 sunset, so both commands die with
+  `GraphQL: Projects (classic) is being deprecated … (repository.pullRequest.projectCards)`.
+  Upstream feature-detects v1 projects from **2.71.0** (`issue view`) and **2.73.0** (`pr edit`),
+  but the machine deliberately stays on the distro package, so treat this as permanent. It is
+  the client, not the repo — it reproduces against `cli/cli`. Reach for REST:
+  `gh api repos/ratt-ru/pfb-imaging/issues/<n> --jq '{title,state,body}'` to read an issue, and
+  `gh api -X PATCH repos/ratt-ru/pfb-imaging/pulls/<n> --input body.json` (a `{"body": …}` file,
+  so markdown survives shell quoting) to edit a PR. `gh pr view`/`list`/`checks`/`create`/`merge`
+  and every `gh api` call are unaffected, as is CI — both workflow uses are already `gh api`.
 
 ## Project Structure
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-12T17:05:00Z
-last_verified_commit: a07eb8a
+timestamp: 2026-08-15T12:00:00Z
+last_verified_commit: eb1bc6d
 ---
 
 # Design decisions, known debt and recurring gotchas
@@ -1021,6 +1021,52 @@ update it (and this page's `last_verified_commit`) in the same session.
   `scripts/profile_freq_correlated_hessian.py` (the cost decomposition above);
   `src/pfb_imaging/operators/gauss.py` (`eta_freq_mul`), `tests/test_eta_freq_mul.py`.
 
+### D31 — Resolution changes use the closed-form Gaussian transform ratio, never a sampled division
+
+- **Context:** `convolve2gaussres` took an image from resolution `gausspari` to `gaussparf`
+  by FFT-ing both sampled `gaussian2d` kernels and dividing (`convkernhat[msk] =
+  gausskernhat[msk] / thiskernhat[msk]`, masked only by `> 0.0`). Issue #312 found this
+  displacing sources: a delta at (170, 260) restored to (146, 260), with −0.81 of peak in
+  ringing. It reaches users through `restore_products` whenever a restoring resolution is
+  asked for — `pfb restore --gausspar` and the lowest-resolution mode.
+- **Decision:** the ratio of two Gaussian transforms is itself a Gaussian, so write it
+  down: `Kf(k)/Ki(k) = sqrt(|Σf|/|Σi|)·exp(−2π²·kᵀ(Σf−Σi)k)`, evaluated directly on the
+  padded rfft grid (`gauss_cov`, `gauss_ratio_hat`). `gaussian2d`'s support returns to
+  `nfwhm` major-axis FWHMs, and the parameter is renamed from `nsigma` to say so. A
+  non-positive-semi-definite `Σf − Σi` now raises `ValueError` instead of being applied.
+  The `gausspari=None` path (a plain convolution by the sampled kernel) is untouched.
+- **Rationale:** there were two independent error sources and the support width only fixes
+  one. (1) Truncating at 5 σ leaves a step of `exp(−12.5) = 3.7e-6` of peak, whose spectral
+  ripple dwarfs the transform's own ~1e-14 floor near Nyquist; at 5 FWHM (11.8 σ) the step
+  is ~4e-31 and the ripple is gone. This is the half issue #312 diagnosed, and the half
+  spimple fixed (`landmanbester/spimple@27a4bc8`). (2) A *sampled* Gaussian's DFT sinks
+  into FFT round-off before Nyquist regardless of support, so past that point the quotient
+  is noise over noise — and unbounded, since pfb's mask is `> 0.0`, not spimple's `> 1e-10`.
+  Source (2) gets *worse* as the beam is better sampled: measured on a band-limited sky at
+  `--super-resolution-factor` 2/3/4 with a matched 2·srf px beam, the two-step invariant
+  (`sky→gi→gf` vs `sky→gf`) broke by 4.0e-10, 1.8e-3 and 1.4e-4 of peak. The closed-form
+  ratio has neither problem (8.1e-10 at srf 2, ~6e-16 above — a kernel-aliasing floor),
+  conserves flux exactly (the sampled division was off by +6% at a 6 px beam and −25% at
+  12 px), and costs two FFTs less per plane.
+- **Consequences:** the support width no longer carries correctness for the deconvolution
+  path — the remaining `gaussian2d` callers only ever *multiply*, where a 3.7e-6 truncation
+  step is harmless — but it is kept wide for spimple parity and because nothing gains from
+  narrowing it. **`restore` can now raise where it used to return garbage:**
+  `restoration.lowest_resolution` takes the max of each axis but the **mean** of the
+  position angles, so a band whose PA differs from the mean can give an indefinite
+  `Σf − Σi` even though both its axes grew. That is a real defect the old code hid by
+  silently amplifying instead of refusing; if it fires in practice the fix belongs in
+  `lowest_resolution` (a PA-aware envelope), not in loosening the check. `nsigma` survives
+  in `fitcleanbeam`, where it does mean standard deviations.
+- **Source:** issue #312; landmanbester/spimple#50 and `landmanbester/spimple@27a4bc8`
+  (where the same regression was found first); the `gaussian2d` regression entered in
+  `1bde45d` (#218), which fixed a genuine width bug and narrowed the support in passing;
+  `src/pfb_imaging/utils/misc.py` (`gauss_cov`, `gauss_ratio_hat`, `convolve2gaussres`,
+  `gaussian2d`); `src/pfb_imaging/utils/restoration.py`;
+  `tests/test_convolve2gaussres.py::test_convolve2gaussres_preserves_position_when_deconvolving`,
+  `…_conserves_flux_through_a_resolution_change`, `…_two_step_matches_direct_across_srf`,
+  `…_refuses_to_sharpen`.
+
 ## Known debt
 
 - `opt/primal_dual.py::primal_dual_numba` contains two `pdb.set_trace()` breakpoints
@@ -1095,6 +1141,12 @@ update it (and this page's `last_verified_commit`) in the same session.
   RA = 0 reads as ~2pi apart when it is 2e-9. Wrap first, then take magnitudes:
   `np.abs((a - b + np.pi) % (2 * np.pi) - np.pi)`. Dec never wraps, so applying it
   elementwise to the (ra, dec) pair is safe.
+- **Never divide two sampled kernels' FFTs.** A sampled Gaussian's DFT sinks into
+  round-off before Nyquist, so the quotient is noise over noise there — and the
+  error grows as the kernel is *better* sampled, which is the opposite of the
+  intuition. When the quotient has a closed form (Gaussians do), evaluate it; see
+  D31. The same reasoning applies to any "divide by the transform of a model
+  kernel" step, and widening the kernel's support only fixes the truncation half.
 - **Warm-cache timing:** back-to-back runs on the same MS read from page cache
   (stimela stats `R GB` ≈ 0); only compare wall times at matching cache state.
 - **stimela deconv memory stats are dominated by fixed Ray overhead** on small tests

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1113,7 +1113,7 @@ update it (and this page's `last_verified_commit`) in the same session.
   second term is computed inside `restore_products` and discarded. Nothing in the tree
   records it, so "what did homogenisation do to the residual" could only be answered by
   redoing the convolution with the exact `G` and `PSFPARSN_b` of that run — which is what
-  `scripts/test_spi_ripples.py` has to do, and why it needs a rebuild-vs-`IMAGE` check at
+  `scripts/check_spi_ripples.py` has to do, and why it needs a rebuild-vs-`IMAGE` check at
   all. The question matters because that term is the leading suspect for the ripples left in
   a per-pixel spectral index fit (#312).
 - **Decision:** `--outputs s`/`S` stores it as band variable `CRESIDUAL`, **apparent**
@@ -1138,7 +1138,7 @@ update it (and this page's `last_verified_commit`) in the same session.
   residual — correct, since the restoring resolution *is* native there.
 - **Source:** issue #312; `src/pfb_imaging/utils/restoration.py` (`PRODUCT_VARS`,
   `restore_products`); `src/pfb_imaging/core/restore.py`; `src/pfb_imaging/cli/restore.py`;
-  `scripts/test_spi_ripples.py`; `tests/test_restore.py::test_restore_cresidual_completes_the_restored_image`,
+  `scripts/check_spi_ripples.py`; `tests/test_restore.py::test_restore_cresidual_completes_the_restored_image`,
   `…_is_apparent_and_not_the_raw_residual`, `test_restore_without_s_writes_no_cresidual`.
 
 ## Known debt

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1051,12 +1051,8 @@ update it (and this page's `last_verified_commit`) in the same session.
 - **Consequences:** the support width no longer carries correctness for the deconvolution
   path — the remaining `gaussian2d` callers only ever *multiply*, where a 3.7e-6 truncation
   step is harmless — but it is kept wide for spimple parity and because nothing gains from
-  narrowing it. **`restore` can now raise where it used to return garbage:**
-  `restoration.lowest_resolution` takes the max of each axis but the **mean** of the
-  position angles, so a band whose PA differs from the mean can give an indefinite
-  `Σf − Σi` even though both its axes grew. That is a real defect the old code hid by
-  silently amplifying instead of refusing; if it fires in practice the fix belongs in
-  `lowest_resolution` (a PA-aware envelope), not in loosening the check. `nsigma` survives
+  narrowing it. The new check immediately exposed that `restoration.lowest_resolution`
+  had been producing invalid targets all along — rewritten in D32. `nsigma` survives
   in `fitcleanbeam`, where it does mean standard deviations.
 - **Source:** issue #312; landmanbester/spimple#50 and `landmanbester/spimple@27a4bc8`
   (where the same regression was found first); the `gaussian2d` regression entered in
@@ -1066,6 +1062,50 @@ update it (and this page's `last_verified_commit`) in the same session.
   `tests/test_convolve2gaussres.py::test_convolve2gaussres_preserves_position_when_deconvolving`,
   `…_conserves_flux_through_a_resolution_change`, `…_two_step_matches_direct_across_srf`,
   `…_refuses_to_sharpen`.
+
+### D32 — The common restoring resolution is a Loewner envelope, not a max of axes
+
+- **Context:** `--gausspar 0 0 0` homogenises every band to a common resolution — the
+  input a spectral-index fit needs (spimple). `restoration.lowest_resolution` built that
+  target as `nanmax(emaj)`, `nanmax(emin)`, `nanmean(pa)`. D31's semi-definiteness check
+  turned what had been silent corruption into a visible failure, and it fires on real
+  data: of six representative band sets, only the one with perfectly aligned position
+  angles produced a valid target.
+- **Decision:** the target is the smallest ellipse that dominates every input in the
+  **Loewner order** (`Σf − Σj ⪰ 0` for every input `j`), which is the exact condition for
+  `convolve2gaussres` to be a convolution from all of them. Candidate shapes are formed
+  from the max axes at each of several orientations (the circular mean of the input PAs,
+  plus each input's own PA) crossed with five axis ratios from the widest input's to
+  circular; each is inflated by the smallest scalar that makes it dominate — the largest
+  generalised eigenvalue of the pencil `(Σj, shape)`, closed form for 2×2 — and the
+  smallest resulting ellipse wins. `resolution_deficit` exposes the same quantity so the
+  explicit `--gausspar` branch can fail early with the viable floor instead of failing
+  inside an FFT. The MFS native beam is now part of the input set.
+- **Rationale:** "at least as wide as every input" is a statement about covariances, not
+  about the axes separately — a rotated ellipse pokes out diagonally, so matching axis by
+  axis is necessary but **not sufficient**. (Concretely: eigenvalues 4 and 1 at 45° project
+  to 2.5 on both coordinate axes, and `2.5·I` does not dominate it.) Three separate
+  defects were in that one line. (1) Rotation, above. (2) `nanmean` on position angles,
+  which are defined mod π: PAs of 0.05 and π − 0.05 are near-identical orientations that
+  average to π/2, orthogonal to both — the circular mean on the doubled angle fixes it.
+  (3) The MFS beam is `fitcleanbeam(Σ_b PSF_b)`, a fit to the summed PSF and not an
+  average of the band fits (D29), so nothing bounds it by the per-band envelope, yet it is
+  reconvolved to the same target. The candidate sweep matters because neither extreme is
+  right alone: with aligned PAs the max-axis ellipse is exactly optimal (bit-identical to
+  the old answer, area ratio 1.000), while over a ~1.5 rad PA spread a *circular* beam is
+  tighter than any scaling of the elongated one (2.00× the old area rather than 2.79×).
+- **Consequences:** with aligned PAs nothing changes. Otherwise the restoring beam grows —
+  measured at 1.02× to 2.0× in area over the six cases — which is a real resolution cost
+  and the honest price of a target every band can actually reach. A `1 + 1e-6` margin on
+  the scale keeps the binding input inside D31's tolerance. The search is
+  `(n + 1) × 5 × n` 2×2 eigenproblems per correlation, microseconds. `--gausspar` with an
+  impossible value now raises before any FFT, naming the shortfall factor and the floor.
+- **Source:** issue #312; `src/pfb_imaging/utils/restoration.py` (`lowest_resolution`,
+  `resolution_deficit`, `_mean_pa`); `src/pfb_imaging/core/restore.py`;
+  `tests/test_restore.py::test_lowest_resolution_dominates_every_input` (the six cases),
+  `…_averages_position_angles_modulo_pi`, `…_takes_max_axes_when_the_angles_agree`,
+  `test_restore_zero_gausspar_handles_bands_at_different_angles`,
+  `test_restore_gausspar_sharper_than_the_data_raises`.
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-08-15T12:00:00Z
-last_verified_commit: eb1bc6d
+timestamp: 2026-09-07T12:00:00Z
+last_verified_commit: 3699b79
 ---
 
 # Design decisions, known debt and recurring gotchas

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1061,7 +1061,7 @@ update it (and this page's `last_verified_commit`) in the same session.
   `gaussian2d`); `src/pfb_imaging/utils/restoration.py`;
   `tests/test_convolve2gaussres.py::test_convolve2gaussres_preserves_position_when_deconvolving`,
   `…_conserves_flux_through_a_resolution_change`, `…_two_step_matches_direct_across_srf`,
-  `…_refuses_to_sharpen`.
+  `…_refuses_to_sharpen`, `…_rejects_xy_ordered_grids`.
 
 ### D32 — The common restoring resolution is a Loewner envelope, not a max of axes
 
@@ -1215,6 +1215,11 @@ update it (and this page's `last_verified_commit`) in the same session.
   RA = 0 reads as ~2pi apart when it is 2e-9. Wrap first, then take magnitudes:
   `np.abs((a - b + np.pi) % (2 * np.pi) - np.pi)`. Dec never wraps, so applying it
   elementwise to the (ra, dec) pair is safe.
+- **`convolve2gaussres` reads the pixel size off `xx`/`yy` on the `gausspari` path,**
+  so the grids must be `np.meshgrid(x, y, indexing="ij")`. numpy's *default* is
+  `indexing="xy"`, which transposes both, makes the inferred spacings zero and every
+  frequency infinite — an all-NaN image. It now raises instead; before the closed form
+  (D31) the kernel was evaluated on the grids themselves and the mistake was invisible.
 - **Never divide two sampled kernels' FFTs.** A sampled Gaussian's DFT sinks into
   round-off before Nyquist, so the quotient is noise over noise there — and the
   error grows as the kernel is *better* sampled, which is the opposite of the

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1107,6 +1107,40 @@ update it (and this page's `last_verified_commit`) in the same session.
   `test_restore_zero_gausspar_handles_bands_at_different_angles`,
   `test_restore_gausspar_sharper_than_the_data_raises`.
 
+### D33 — `CRESIDUAL` records what the resolution change did to the residual
+
+- **Context:** the restored image is `MODEL ⊗ G + (RESIDUAL/WSUM) ⊗ [G/PSFPARSN_b]`, and the
+  second term is computed inside `restore_products` and discarded. Nothing in the tree
+  records it, so "what did homogenisation do to the residual" could only be answered by
+  redoing the convolution with the exact `G` and `PSFPARSN_b` of that run — which is what
+  `scripts/test_spi_ripples.py` has to do, and why it needs a rebuild-vs-`IMAGE` check at
+  all. The question matters because that term is the leading suspect for the ripples left in
+  a per-pixel spectral index fit (#312).
+- **Decision:** `--outputs s`/`S` stores it as band variable `CRESIDUAL`, **apparent**
+  (pre-beam-division) and at the restoring resolution. Off by default — it is another cube
+  per band. The `C` prefix means convolved, alongside the tree's existing `B` for
+  beam-attenuated.
+- **Rationale:** apparent because image-plane noise is flat on that scale and `BEAM` is
+  already on the node, so the intrinsic form is one divide away; the reverse is not true
+  where the beam is small. Storing it makes the tree self-describing: `MODEL ⊗ G + CRESIDUAL`
+  reproduces `KIMAGE` exactly, which is the property the tests pin. It also gives
+  `spifit` the array its SNR cut is actually applied to — the rms currently comes from
+  `std(RESIDUAL/WSUM)`, the *raw* residual, while the image being thresholded contains the
+  convolved one, whose rms differs by a band-dependent factor because the broadening needed
+  to reach `G` does. That is tidiness rather than a ripple source: the mask is a single
+  min-over-bands cut, so it shifts which pixels are fitted, not their spectra.
+- **Consequences:** `restore` still never writes `RESIDUAL` — only `PSFPARSF` and the
+  `PRODUCT_VARS` entries, so the raw residual survives untouched and `--outputs F` keeps
+  FFT-ing the raw array. The MFS `CRESIDUAL` FITS is written from the direct MFS path, not
+  by summing bands, for the same reason the restored MFS image is (D29): with no
+  homogenisation the per-band `CRESIDUAL` sit at different resolutions. When `gaussparf`
+  equals a band's own resolution the convolution is skipped and `CRESIDUAL` is that band's
+  residual — correct, since the restoring resolution *is* native there.
+- **Source:** issue #312; `src/pfb_imaging/utils/restoration.py` (`PRODUCT_VARS`,
+  `restore_products`); `src/pfb_imaging/core/restore.py`; `src/pfb_imaging/cli/restore.py`;
+  `scripts/test_spi_ripples.py`; `tests/test_restore.py::test_restore_cresidual_completes_the_restored_image`,
+  `…_is_apparent_and_not_the_raw_residual`, `test_restore_without_s_writes_no_cresidual`.
+
 ## Known debt
 
 - `opt/primal_dual.py::primal_dual_numba` contains two `pdb.set_trace()` breakpoints

--- a/scripts/check_spi_ripples.py
+++ b/scripts/check_spi_ripples.py
@@ -57,7 +57,7 @@ Seven diagnostics, in decreasing order of how decisive they are:
 
 Run (from the repo root, on the box holding the tree)::
 
-    uv run python scripts/test_spi_ripples.py /path/to/out_I.dt --nthreads 16
+    uv run python scripts/check_spi_ripples.py /path/to/out_I.dt --nthreads 16
 
 Writes ``<outdir>/spi_ripples_report.txt`` (read this first),
 ``spi_ripples_diagnostics.npz`` and ``spi_ripples_summary.png``.  Default

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -426,18 +426,27 @@ def uv_diagnostics(resids, psfs, psfparsn, gcommon, freqs, cell_rad, say):
     gx, gy = grids(npy, npx)
     fake = np.stack([gaussian2d(gx, gy, p, normalise=False).T for p in psfparsn])
     fhat = np.stack([np.abs(np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(p)))) for p in fake])
-    checks = []
+    # Check the statistic actually reported -- the residual-power-weighted mean --
+    # not the worst radial bin. The bin straddling the ghat cut is a numerical
+    # edge and deviates ~1e-3 on real beams while the mean is exact to 1e-5, so
+    # testing the max just cries wolf.
+    checks, worst_bin = [], 0.0
     for b in range(nband):
         tb = transfer((npy, npx), gauss_cov(psfparsn[b]), cov_g)
         with np.errstate(invalid="ignore", divide="ignore"):
             e = np.where(ghat > gcut, fhat[b] * tb / np.maximum(ghat, 1e-30), np.nan)
-        checks.append(float(np.nanmax(np.abs(radial_profile(e, nbins=140)[1] - 1.0))))
-    worst = max(checks)
+        w = np.nan_to_num(radial_profile(rhat[b] ** 2, nbins=140)[1])
+        ep = radial_profile(e, nbins=140)[1]
+        ok = np.isfinite(ep) & (w > 0)
+        checks.append(abs(float(np.sum(ep[ok] * w[ok]) / max(np.sum(w[ok]), 1e-30)) - 1.0) if ok.any() else np.nan)
+        worst_bin = max(worst_bin, float(np.nanmax(np.abs(ep - 1.0))))
+    worst = np.nanmax(checks)
     if worst > 1e-3:
-        say(f"  SELF-CHECK FAILED: E is {worst:.3e} from 1 for exactly Gaussian PSFs.")
+        say(f"  SELF-CHECK FAILED: <E_b> is {worst:.3e} from 1 for exactly Gaussian PSFs.")
         say("  The numbers below are measuring a convention error, not the data. Stop here.")
     else:
-        say(f"  (self-check: E = 1 to {worst:.1e} when the PSFs are exactly Gaussian)")
+        say(f"  (self-check: <E_b> = 1 to {worst:.1e} on exactly Gaussian PSFs; worst single")
+        say(f"  radial bin {worst_bin:.1e}, which is the numerical edge at the Ghat cut)")
 
     say("DIAGNOSTIC 0 -- the uv plane (this is what restore --outputs F writes).")
     say("  Support and hole are read off the sampling function FFT(PSF/WSUM); the residual")

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -19,8 +19,21 @@ law, and a per-pixel fit reads that as spectral index: coherent, spatially
 periodic ripples, strongest where the residual carries a large fraction of the
 flux (the diffuse emission), weakest on the bright deconvolved structure.
 
-Six diagnostics, in decreasing order of how decisive they are:
+Seven diagnostics, in decreasing order of how decisive they are:
 
+0. **The uv plane**, which ``pfb restore --outputs F`` already writes as FITS.
+   Homogenisation is a pure multiplication there, so the whole question can be
+   settled in one place.  The sampling function ``FFT(PSF/WSUM)`` gives the
+   support and the hole, both of which scale as ``nu`` -- so no two bands carry
+   the same set of angular scales, neither the finest nor the coarsest, and the
+   coarsest end corrupts extended emission whatever the sidelobes do.  Then the
+   consistency ratio ``E_b = FFT(PSF_b) T_b / Ghat``, weighted by where the
+   residual actually has power, says how far the Gaussian reconvolution ``T_b``
+   is from scaling the residual correctly: ``E_b == 1`` iff band b's dirty beam
+   really is the Gaussian ``PSFPARSN_b``.  Its trend across bands is a uniform
+   spurious alpha; its scatter is the scale-dependent part that ripples.  A
+   self-check feeds the machinery exactly Gaussian PSFs and asserts ``E == 1``,
+   so a convention error cannot masquerade as a detection.
 1. **Sidelobes survive homogenisation.**  Convolve each band's stored PSF from
    ``PSFPARSN_b`` to ``G`` -- exactly what restore does to the residual -- and
    compare bands.  The cores must agree by construction; if the sidelobes do
@@ -347,6 +360,147 @@ def psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, psf_size, nthread
         "psf_corr_raw": np.array(corr_raw),
         "psf_corr_scaled": np.array(corr_scaled),
         "beam_volume_ratio": np.array(eps),
+    }, psfs
+
+
+def uv_diagnostics(resids, psfs, psfparsn, gcommon, freqs, cell_rad, say):
+    """Diagnostic 0: the uv plane, which ``pfb restore --outputs F`` already writes.
+
+    ``FFT(RESIDUAL_b / WSUM_b)`` is the gridded residual visibility and
+    ``FFT(PSF_b / WSUM_b)`` is the sampling function itself.  Homogenisation is a
+    pure multiplication in this plane, so the whole question can be settled here.
+
+    Support and hole come from the PSF, which is the sampling function exactly
+    and carries no noise; the residual is used only to weight *where* in the uv
+    plane the errors actually matter.  Both edges scale as ``nu``: the finest
+    structure each band carries shrinks with frequency, and so does the coarsest,
+    which corrupts extended emission independently of any sidelobe argument.
+
+    The decisive quantity is the consistency ratio::
+
+        E_b(u) = Phat_b(u) T_b(u) / Ghat(u),
+        T_b(u) = sqrt(|S_G|/|S_b|) exp(-2 pi^2 u^T (S_G - S_b) u)
+
+    ``T_b`` is the Gaussian reconvolution restore applies.  If band b's dirty
+    beam really were the Gaussian ``PSFPARSN_b``, then ``Phat_b T_b`` would equal
+    the common clean beam ``Ghat`` and ``E_b`` would be 1 at every u, for every
+    band.  Wherever ``E_b`` departs from 1 the residual is being mis-scaled, and
+    wherever ``E_b`` differs *between bands* that mis-scaling is frequency
+    dependent -- which is precisely a spurious spectral index.
+    """
+    from pfb_imaging.utils.misc import gauss_cov
+
+    nband, ny, nx = resids.shape
+    win = np.hanning(ny)[:, None] * np.hanning(nx)[None, :]
+    rhat = np.stack([np.abs(np.fft.fftshift(np.fft.fft2(r * win))) for r in resids])
+    phat = np.stack([np.abs(np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(p)))) for p in psfs])
+
+    def transfer(shape, cov_i, cov_f):
+        n0, n1 = shape
+        ky = np.fft.fftshift(np.fft.fftfreq(n0))[:, None] * np.ones((1, n1))
+        kx = np.ones((n0, 1)) * np.fft.fftshift(np.fft.fftfreq(n1))[None, :]
+        d = cov_f - cov_i
+        amp = np.sqrt(np.linalg.det(cov_f) / np.linalg.det(cov_i))
+        # gauss_cov indexes (x, y) but these arrays are (y, x)-ordered (wiki D19),
+        # so axis 0 pairs with d[1, 1] and axis 1 with d[0, 0]. Transposing the
+        # covariance leaves the cross term alone.
+        return amp * np.exp(-2 * np.pi**2 * (d[1, 1] * ky**2 + 2 * d[0, 1] * kx * ky + d[0, 0] * kx**2))
+
+    cov_g = gauss_cov(gcommon)
+    npy, npx = psfs.shape[1:]
+    # The target every band should reach. It must be built with the SAME
+    # convention as phat -- the FFT of the peak-1 sampled beam -- so that a band
+    # whose dirty beam really is the Gaussian PSFPARSN_b gives E_b == 1 exactly:
+    # phat_b = Ghat_b there, and Ghat_b * (Ghat / Ghat_b) = Ghat.
+    gxx, gyy = grids(npy, npx)
+    gkern = gaussian2d(gxx, gyy, gcommon, normalise=False).T
+    ghat = np.abs(np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(gkern))))
+    gcut = 1e-6 * ghat.max()
+
+    # Self-check: feed the machinery PSFs that really ARE the Gaussians PSFPARSN
+    # claims. E must come back exactly 1, for every band and every position
+    # angle. Two convention bugs were caught this way -- a (y, x) vs (x, y)
+    # transpose in the transfer function, and zeros averaged in where the mask
+    # bites -- both of which faked a band-dependent signal. Cheap, so it runs.
+    gx, gy = grids(npy, npx)
+    fake = np.stack([gaussian2d(gx, gy, p, normalise=False).T for p in psfparsn])
+    fhat = np.stack([np.abs(np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(p)))) for p in fake])
+    checks = []
+    for b in range(nband):
+        tb = transfer((npy, npx), gauss_cov(psfparsn[b]), cov_g)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            e = np.where(ghat > gcut, fhat[b] * tb / np.maximum(ghat, 1e-30), np.nan)
+        checks.append(float(np.nanmax(np.abs(radial_profile(e, nbins=140)[1] - 1.0))))
+    worst = max(checks)
+    if worst > 1e-3:
+        say(f"  SELF-CHECK FAILED: E is {worst:.3e} from 1 for exactly Gaussian PSFs.")
+        say("  The numbers below are measuring a convention error, not the data. Stop here.")
+    else:
+        say(f"  (self-check: E = 1 to {worst:.1e} when the PSFs are exactly Gaussian)")
+
+    say("DIAGNOSTIC 0 -- the uv plane (this is what restore --outputs F writes).")
+    say("  Support and hole are read off the sampling function FFT(PSF/WSUM); the residual")
+    say("  FFT weights where those errors matter. u is in cycles/pixel.")
+    say(f"{'band':>5} {'u_max':>9} {'u_max*nu0/nu':>13} {'u_min':>9} {'u_min*nu0/nu':>13} {'max scale/px':>13}")
+    umax, umin = [], []
+    for b in range(nband):
+        r, prof = radial_profile(phat[b], nbins=140)
+        prof = np.nan_to_num(prof)
+        u = r / npy
+        floor = np.median(prof[int(0.9 * len(prof)) :])
+        lvl = floor + 0.05 * (prof.max() - floor)
+        above = np.where(prof > lvl)[0]
+        umax.append(float(u[above[-1]]) if len(above) else np.nan)
+        umin.append(float(u[above[0]]) if len(above) else np.nan)
+        say(
+            f"{b:5d} {umax[-1]:9.5f} {umax[-1] * freqs[0] / freqs[b]:13.5f} {umin[-1]:9.5f} "
+            f"{umin[-1] * freqs[0] / freqs[b]:13.5f} {1 / max(umin[-1], 1e-9):13.1f}"
+        )
+    say("  Columns 3 and 5 rescale columns 2 and 4 back to band 0. Flat columns mean the uv")
+    say("  support really does scale as nu, so no two bands carry the same set of angular")
+    say("  scales -- neither the finest (u_max) nor the coarsest (u_min).")
+    if np.allclose(umin, umin[0]) and umin[0] <= 2.0 / npy:
+        say("  NOTE: u_min sits in the first radial bin for every band, so the short-baseline")
+        say("  hole is unresolved at this cutout size and the u_min columns say nothing.")
+    say()
+    say("  Consistency ratio E_b = FFT(PSF_b) * T_b / Ghat, weighted by residual power.")
+    say("  E_b == 1 everywhere would mean the Gaussian reconvolution scales the residual")
+    say("  exactly right. Departures are mis-scaling; band-to-band differences are a")
+    say("  spurious spectral index.")
+    say(f"{'band':>5} {'<E_b>':>10} {'rms(E_b - 1)':>14} {'kept vs band 0':>16}")
+    ebar, edev, eprof = [], [], []
+    for b in range(nband):
+        tb = transfer((npy, npx), gauss_cov(psfparsn[b]), cov_g)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            e = np.where(ghat > gcut, phat[b] * tb / np.maximum(ghat, 1e-30), np.nan)
+        # weight by where the residual has power, resampled onto the psf grid
+        w = np.nan_to_num(radial_profile(rhat[b] ** 2, nbins=140)[1])
+        # NOT nan_to_num: radial_profile skips NaN, but zeros would be averaged in
+        # and drag every bin straddling the cut towards zero
+        er, ep = radial_profile(e, nbins=140)
+        eprof.append(ep)
+        ok = np.isfinite(ep) & (w > 0)
+        m = float(np.sum(ep[ok] * w[ok]) / max(np.sum(w[ok]), 1e-30)) if ok.any() else np.nan
+        d = float(np.sqrt(np.sum((ep[ok] - 1) ** 2 * w[ok]) / max(np.sum(w[ok]), 1e-30))) if ok.any() else np.nan
+        ebar.append(m)
+        edev.append(d)
+        say(f"{b:5d} {m:10.4f} {d:14.4f} {m / max(ebar[0], 1e-30):16.4f}")
+    trend = np.log(max(ebar[-1], 1e-12) / max(ebar[0], 1e-12)) / np.log(freqs[-1] / freqs[0])
+    say(f"  band-to-band trend in <E_b> implies a spurious alpha of {trend:+.4f}, uniform over")
+    say("  every pixel the residual touches. rms(E_b - 1) is the scale-dependent part on top")
+    say("  of that -- the piece that varies across the image and shows up as ripples.")
+    say()
+
+    return {
+        "uv_u": np.array(radial_profile(phat[0], nbins=140)[0]) / npy,
+        "uv_sampling_amp": np.stack([np.nan_to_num(radial_profile(p, nbins=140)[1]) for p in phat]),
+        "uv_residual_amp": np.stack([np.nan_to_num(radial_profile(r, nbins=140)[1]) for r in rhat]),
+        "uv_consistency": np.stack(eprof),
+        "uv_umax": np.array(umax),
+        "uv_umin": np.array(umin),
+        "uv_ebar": np.array(ebar),
+        "uv_edev": np.array(edev),
+        "uv_cell_rad": np.array(cell_rad),
     }
 
 
@@ -429,22 +583,23 @@ def main():
         say(f"  (--size {args.size} was clamped to the image)")
     say()
 
-    bundle = psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, args.psf_size, args.nthreads, say)
+    bundle, psfs = psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, args.psf_size, args.nthreads, say)
 
     # ---- rebuild the restored image, term by term -------------------------
     say("Rebuilding the restored cutout term by term (this repeats what restore did).")
     sel = dict(corr=0, y=slice(y0, y1), x=slice(x0, x1))
-    mconv, rconv, rconv1, beams = [], [], [], []
+    mconv, rconv, rconv1, beams, resids = [], [], [], [], []
     for b, node in enumerate(keep):
         ds = dt[node].ds
         model = np.asarray(ds[args.model_name].isel(**sel).values, dtype=np.float64)
         resid = np.asarray(ds[args.residual_name].isel(**sel).values, dtype=np.float64) / wsums[b]
         beams.append(np.asarray(ds.BEAM.isel(**sel).values, dtype=np.float64)[trim])
+        resids.append(resid[trim])
         mconv.append(conv(model, gcommon, nthreads=args.nthreads)[trim])
         rconv.append(conv(resid, gcommon, gausspari=psfparsn[b], nthreads=args.nthreads)[trim])
         rconv1.append(conv(resid, gcommon, gausspari=psfparsn[b], nthreads=args.nthreads, pfrac=1.0)[trim])
     mconv, rconv, rconv1 = np.stack(mconv), np.stack(rconv), np.stack(rconv1)
-    beams = np.stack(beams)
+    beams, resids = np.stack(beams), np.stack(resids)
 
     with np.errstate(invalid="ignore", divide="ignore"):
         image_full = mconv + np.where(beams > 0, rconv / beams, 0.0)
@@ -462,6 +617,8 @@ def main():
             say("  --gausspar, or with a different pfrac? Interpret the alpha maps with care.")
         del stored
     say()
+
+    bundle.update(uv_diagnostics(resids, psfs, psfparsn, gcommon, freqs, float(ref.attrs["cell_rad"]), say))
 
     # ---- mask, matching what spifit would cut on --------------------------
     # spifit takes the rms as std(RESIDUAL/WSUM); reproduce that, but report a
@@ -655,6 +812,32 @@ def write_png(path, bundle, say):
     ax[1, 3].set_xlabel("frequency [MHz]")
     ax[1, 3].set_title("sidelobe correlation with band 0", fontsize=10)
     ax[1, 3].legend(fontsize=8)
+
+    # the uv plane: where the residual has power, and what homogenisation does there
+    fig2, bx = plt.subplots(1, 3, figsize=(17, 4.6))
+    u, amp, tra = bundle["uv_u"], bundle["uv_residual_amp"], bundle["uv_consistency"]
+    for b in range(amp.shape[0]):
+        c = plt.cm.viridis(b / max(amp.shape[0] - 1, 1))
+        bx[0].loglog(u, np.maximum(amp[b], 1e-30), color=c, label=f"{bundle['freqs'][b] / 1e6:.0f} MHz")
+        bx[1].loglog(u, np.maximum(bundle["uv_sampling_amp"][b], 1e-30), color=c)
+        bx[2].loglog(u, np.clip(tra[b], 1e-3, 1e3), color=c)
+    for a, t in zip(
+        bx,
+        (
+            "|FFT(residual)| per band",
+            "sampling function |FFT(PSF)|",
+            "consistency ratio E_b (1 = exact)",
+        ),
+    ):
+        a.set_xlabel("|u| [cycles/pixel]")
+        a.set_title(t, fontsize=10)
+    bx[0].legend(fontsize=7)
+    bx[2].axhline(1.0, color="k", lw=0.8, ls="--")
+    bx[2].set_ylim(1e-1, 1e1)  # E blows up where Ghat has decayed and nothing is left to scale
+    fig2.tight_layout()
+    fig2.savefig(path.replace(".png", "_uv.png"), dpi=110)
+    plt.close(fig2)
+    say(f"wrote {path.replace('.png', '_uv.png')}")
 
     fig.tight_layout()
     fig.savefig(path, dpi=110)

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python
+"""Diagnose the ripples in a per-pixel spectral index fit of a restored ``.dt``.
+
+Runs where the tree lives and writes a few MB of cutouts and summary statistics
+that can be pulled back for inspection.  Nothing here modifies the tree.
+
+The hypothesis under test (pfb-imaging issue #312, wiki D31/D32).  ``pfb restore``
+builds the intrinsic band image as::
+
+    IMAGE_b = MODEL_b (x) G  +  (RESIDUAL_b / WSUM_b) (x) [G / PSFPARSN_b] / BEAM_b
+
+The second term reconvolves the residual from the band's *fitted Gaussian*
+``PSFPARSN_b`` to the common restoring beam ``G``.  But the residual's actual
+resolution is the dirty beam -- the uv sampling function -- which is Gaussian
+only in its core.  A Gaussian reconvolution matches the cores across bands and
+cannot move the sidelobes, whose angular scale goes as ``1/nu``.  Each pixel
+therefore sees a flux that oscillates with frequency on top of the true power
+law, and a per-pixel fit reads that as spectral index: coherent, spatially
+periodic ripples, strongest where the residual carries a large fraction of the
+flux (the diffuse emission), weakest on the bright deconvolved structure.
+
+Six diagnostics, in decreasing order of how decisive they are:
+
+1. **Sidelobes survive homogenisation.**  Convolve each band's stored PSF from
+   ``PSFPARSN_b`` to ``G`` -- exactly what restore does to the residual -- and
+   compare bands.  The cores must agree by construction; if the sidelobes do
+   not, the mechanism above is demonstrated on the actual data.
+2. **The dirty beam scales as 1/nu.**  Correlate band b's PSF sidelobes with
+   band 0's, raw and after rescaling band 0 radially by ``nu_b / nu_0``.  A big
+   jump confirms the frequency dependence that drives the ripples.
+3. **alpha with and without the residual.**  Fit the per-pixel power law on
+   ``MODEL (x) G`` alone and on the full intrinsic image.  Their difference map
+   isolates what the residual term does to the spectral index; if it carries the
+   striping, the case is closed.
+4. **Restoration flux units.**  The main-lobe volume of the dirty beam over the
+   clean beam volume, per band.  It is not 1 and it is not constant in
+   frequency, which biases the restored spectrum wherever the residual matters.
+5. **FFT padding.**  ``restore_products`` convolves at ``pfrac=0.2``.  For a
+   source filling the frame that wraps, and it wraps differently per band.
+   Refit with ``pfrac=1.0`` and difference.
+6. **Beam model.**  Azimuthal profile of alpha about the pointing centre, plus
+   the angular and radial power spectra of the alpha maps.  A primary beam error
+   gives concentric structure; a PSF error gives the striping.
+
+Run (from the repo root, on the box holding the tree)::
+
+    uv run python scripts/test_spi_ripples.py /path/to/out_I.dt --nthreads 16
+
+Writes ``<outdir>/spi_ripples_report.txt`` (read this first),
+``spi_ripples_diagnostics.npz`` and ``spi_ripples_summary.png``.  Default
+``--size 512`` keeps the bundle under ~15 MB; shrink it if that is too much.
+"""
+
+import argparse
+import os
+import textwrap
+
+import numpy as np
+import xarray as xr
+from ducc0.misc import resize_thread_pool
+from scipy.ndimage import map_coordinates
+
+from pfb_imaging.utils.misc import convolve2gaussres, gaussian2d
+
+FWHM = 2 * np.sqrt(2 * np.log(2))
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("dt", help="Path to the restored tree, <output-filename>_<PRODUCT>.dt")
+    p.add_argument("--outdir", default=None, help="Where to write the bundle (default: alongside the tree)")
+    p.add_argument("--size", type=int, default=512, help="Side of the analysed cutout, in pixels")
+    p.add_argument(
+        "--centre",
+        default=None,
+        help="Cutout centre as 'y,x' in pixels. Default is the image centre; aim it at a "
+        "diffuse region where the ripples are visible",
+    )
+    p.add_argument("--psf-size", type=int, default=256, help="Side of the PSF window used for the sidelobe tests")
+    p.add_argument("--timeid", type=int, default=None, help="Which timeid to analyse (default: the first)")
+    p.add_argument("--drop-bands", type=int, nargs="*", default=(), help="Band ids to exclude, as spifit would")
+    p.add_argument("--threshold", type=float, default=2.5, help="SNR cut, matching the spifit run being diagnosed")
+    p.add_argument("--pb-min", type=float, default=0.15, help="Beam cut, matching the spifit run being diagnosed")
+    p.add_argument(
+        "--rms",
+        type=float,
+        default=None,
+        help="Override the noise estimate (Jy/beam) with the value the spifit run reported, "
+        "so the mask matches the alpha map being diagnosed",
+    )
+    p.add_argument("--model-name", default="MODEL")
+    p.add_argument("--residual-name", default="RESIDUAL")
+    p.add_argument("--image-name", default="IMAGE", help="Stored restored product, used as a consistency check")
+    p.add_argument("--nthreads", type=int, default=8)
+    p.add_argument("--maxiter", type=int, default=50, help="Gauss-Newton iterations in the alpha fit")
+    p.add_argument("--no-png", action="store_true")
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
+
+
+def grids(ny, nx):
+    """The (X, Y)-ordered coordinate grids convolve2gaussres expects (wiki D19)."""
+    x = -(nx // 2) + np.arange(nx)
+    y = -(ny // 2) + np.arange(ny)
+    return np.meshgrid(x, y, indexing="ij")
+
+
+def conv(image, gaussparf, gausspari=None, nthreads=1, pfrac=0.2):
+    """restore_products' convolution, on a single (ny, nx) plane."""
+    ny, nx = image.shape
+    xx, yy = grids(ny, nx)
+    out = convolve2gaussres(
+        image[None],
+        xx,
+        yy,
+        np.asarray(gaussparf, dtype=float),
+        nthreads=nthreads,
+        gausspari=None if gausspari is None else np.asarray(gausspari, dtype=float),
+        pfrac=pfrac,
+        norm_kernel=False,
+        yx_order=True,
+    )[0]
+    return np.ascontiguousarray(out)
+
+
+def fit_alpha(cube, weights, freqs, nu_ref, maxiter=50, tol=1e-6):
+    """Weighted Gauss-Newton fit of I(nu) = I0 (nu/nu_ref)**alpha, per pixel.
+
+    Mirrors spimple.utils.fit_spi._fit_spi_components_impl (beam folded into the
+    weights, which is the intrinsic-scale form), vectorised over pixels.
+
+    Args:
+        cube: (nband, npix) fluxes.
+        weights: (nband, npix) or (nband,) inverse-variance weights.
+        freqs: (nband,) frequencies.
+        nu_ref: reference frequency.
+
+    Returns:
+        (alpha, i0, converged) each (npix,); converged is a bool array.
+    """
+    cube = np.asarray(cube, dtype=np.float64)
+    nband, npix = cube.shape
+    w = (freqs / nu_ref).astype(np.float64)[:, None]  # (nband, 1)
+    wgt = np.broadcast_to(np.atleast_2d(weights.T).T if weights.ndim > 1 else weights[:, None], (nband, npix))
+
+    # initialise from a log-space linear fit where every band is positive, which
+    # is most of the mask; elsewhere fall back to a flat spectrum
+    pos = np.all(cube > 0, axis=0)
+    alpha = np.full(npix, -0.7)
+    lw = np.log(w[:, 0])
+    with np.errstate(invalid="ignore", divide="ignore"):
+        ly = np.log(np.where(cube > 0, cube, 1.0))
+    sw = wgt.sum(axis=0)
+    mx = (wgt * lw[:, None]).sum(axis=0) / sw
+    my = (wgt * ly).sum(axis=0) / sw
+    cov = (wgt * (lw[:, None] - mx) * (ly - my)).sum(axis=0)
+    var = (wgt * (lw[:, None] - mx) ** 2).sum(axis=0)
+    alpha[pos] = np.where(var > 0, cov / np.maximum(var, 1e-30), -0.7)[pos]
+    alpha = np.clip(alpha, -6.0, 6.0)
+    i0 = np.maximum((wgt * cube).sum(axis=0) / sw, 1e-12)
+
+    converged = np.zeros(npix, dtype=bool)
+    for _ in range(maxiter):
+        jac1 = w**alpha  # (nband, npix)
+        model = i0 * jac1
+        jac0 = model * np.log(w)
+        res = cube - model
+        h00 = (jac0 * wgt * jac0).sum(axis=0)
+        h01 = (jac0 * wgt * jac1).sum(axis=0)
+        h11 = (jac1 * wgt * jac1).sum(axis=0)
+        jr0 = (jac0 * wgt * res).sum(axis=0)
+        jr1 = (jac1 * wgt * res).sum(axis=0)
+        det = h00 * h11 - h01**2
+        det = np.where(np.abs(det) < 1e-30, 1e-30, det)
+        da = (h11 * jr0 - h01 * jr1) / det
+        di = (-h01 * jr0 + h00 * jr1) / det
+        step = np.maximum(np.abs(da), np.abs(di / np.maximum(np.abs(i0), 1e-12)))
+        alpha = np.clip(alpha + da, -8.0, 8.0)
+        i0 = i0 + di
+        converged = step < tol
+        if converged.all():
+            break
+    return alpha, i0, converged
+
+
+def radial_profile(image, nbins=120, centre=None):
+    """Azimuthal mean and the radii it was taken at, ignoring NaN."""
+    ny, nx = image.shape
+    cy, cx = (ny // 2, nx // 2) if centre is None else centre
+    y, x = np.mgrid[:ny, :nx]
+    r = np.hypot(y - cy, x - cx)
+    bins = np.linspace(0, r.max(), nbins + 1)
+    idx = np.digitize(r.ravel(), bins) - 1
+    flat = image.ravel()
+    prof = np.full(nbins, np.nan)
+    for b in range(nbins):
+        sel = (idx == b) & np.isfinite(flat)
+        if sel.any():
+            prof[b] = flat[sel].mean()
+    return 0.5 * (bins[1:] + bins[:-1]), prof
+
+
+def power_spectra(image, mask, smooth=8):
+    """Radial and angular power spectra of the fine structure in a masked map.
+
+    Returns (wavelengths_px, radial_power, pa_deg, angular_power). The map is
+    high-passed mask-aware first, so the astrophysical gradient does not swamp
+    the ripples, and apodised so the mask edge does not ring.
+    """
+    from scipy.ndimage import gaussian_filter
+
+    m = mask.astype(float)
+    filled = np.where(mask, image, 0.0)
+    num = gaussian_filter(filled * m, smooth)
+    den = gaussian_filter(m, smooth)
+    hp = (filled - np.where(den > 1e-3, num / np.maximum(den, 1e-9), 0.0)) * m
+
+    n = min(hp.shape)
+    hp = hp[:n, :n]
+    win = np.hanning(n)[:, None] * np.hanning(n)[None, :]
+    hat = np.fft.fftshift(np.abs(np.fft.fft2(hp * win)) ** 2)
+    ky = np.fft.fftshift(np.fft.fftfreq(n))[:, None] * np.ones((1, n))
+    kx = np.ones((n, 1)) * np.fft.fftshift(np.fft.fftfreq(n))[None, :]
+    kr = np.hypot(kx, ky)
+    hat[kr < 3.0 / n] = 0.0
+
+    bins = np.geomspace(3.0 / n, 0.5, 41)
+    idx = np.digitize(kr.ravel(), bins)
+    rad = np.array([hat.ravel()[idx == b].mean() if (idx == b).any() else np.nan for b in range(1, len(bins))])
+    kmid = 0.5 * (bins[1:] + bins[:-1])
+
+    pa = np.rad2deg(np.arctan2(ky, kx)) % 180
+    band = (kr > 0.01) & (kr < 0.25)
+    edges = np.arange(0, 181, 10)
+    ang = np.array([hat[band & (pa >= lo) & (pa < lo + 10)].mean() for lo in edges[:-1]])
+    return 1.0 / kmid, rad, 0.5 * (edges[1:] + edges[:-1]), ang
+
+
+def psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, psf_size, nthreads, say):
+    """Diagnostics 1, 2 and 4: sidelobes, their 1/nu scaling, and flux units.
+
+    Returns a dict of arrays for the bundle.
+    """
+    ref = dt[keep[0]].ds
+    _, nyp, nxp = ref.PSF.shape
+    h = int(min(psf_size, nyp, nxp)) // 2
+    sy = slice(nyp // 2 - h, nyp // 2 + h)
+    sx = slice(nxp // 2 - h, nxp // 2 + h)
+    n = 2 * h
+
+    psfs, homog = [], []
+    for b, node in enumerate(keep):
+        p = np.asarray(dt[node].ds.PSF.isel(corr=0, y_psf=sy, x_psf=sx).values, dtype=np.float64) / wsums[b]
+        psfs.append(p)
+        # exactly what restore does to the residual: PSFPARSN_b -> G
+        homog.append(conv(p, gcommon, gausspari=psfparsn[b], nthreads=nthreads))
+    psfs = np.stack(psfs)
+    homog = np.stack(homog)
+
+    yy, xx = np.mgrid[:n, :n]
+    r = np.hypot(yy - n // 2, xx - n // 2)
+    # "main lobe" = inside the common restoring beam's major axis; everything
+    # beyond it is sidelobe as far as the restoration is concerned
+    core = r <= gcommon[0]
+    wings = r > 1.5 * gcommon[0]
+
+    # --- diagnostic 1: does homogenisation equalise the sidelobes? ----------
+    say("DIAGNOSTIC 1 -- do the sidelobes survive homogenisation to the common beam?")
+    say("  Each band's PSF is convolved from PSFPARSN_b to PSFPARSF, which is exactly what")
+    say("  restore does to RESIDUAL. The cores must agree by construction. If the wings do")
+    say("  not, a Gaussian reconvolution cannot equalise them and the residual carries")
+    say("  band-dependent structure into the fit.")
+    say(f"{'band':>5} {'core rms diff':>15} {'wing rms diff':>15} {'wing rms':>12} {'ratio wing/core':>16}")
+    core_diff, wing_diff, wing_rms = [], [], []
+    p0 = homog[0]
+    p0c = np.sqrt(np.mean(p0[core] ** 2))
+    for b in range(len(keep)):
+        d = homog[b] - p0
+        cd = np.sqrt(np.mean(d[core] ** 2)) / p0c
+        wd = np.sqrt(np.mean(d[wings] ** 2)) / p0c
+        wr = np.sqrt(np.mean(homog[b][wings] ** 2)) / p0c
+        core_diff.append(cd)
+        wing_diff.append(wd)
+        wing_rms.append(wr)
+        say(f"{b:5d} {cd:15.3e} {wd:15.3e} {wr:12.3e} {wd / max(cd, 1e-30):16.1f}")
+    say("  Read: wing rms diff >> core rms diff means homogenisation matched the cores and")
+    say("  left the sidelobes mismatched -- the mechanism behind the ripples.")
+    say()
+
+    # --- diagnostic 2: do the sidelobes scale as 1/nu? ---------------------
+    say("DIAGNOSTIC 2 -- do the dirty beam's sidelobes scale as 1/nu?")
+    say("  Correlation of band b's PSF wings with band 0's, raw and after rescaling band 0")
+    say("  radially by nu_b/nu_0. A jump from raw to rescaled confirms the frequency")
+    say("  dependence that turns a static sidelobe pattern into a spectral signal.")
+    say(f"{'band':>5} {'nu_b/nu_0':>10} {'corr raw':>10} {'corr rescaled':>15}")
+    corr_raw, corr_scaled = [], []
+    cy = cx = n // 2
+    for b in range(len(keep)):
+        s = freqs[b] / freqs[0]
+        # PSF_b(x) ~ PSF_0(x * nu_b/nu_0) if the beam shrinks as 1/nu
+        coords = np.array([(yy - cy) * s + cy, (xx - cx) * s + cx])
+        p0s = map_coordinates(psfs[0], coords, order=1, mode="constant", cval=0.0)
+        a, braw, bsc = psfs[b][wings], psfs[0][wings], p0s[wings]
+
+        def cc(u, v):
+            u = u - u.mean()
+            v = v - v.mean()
+            d = np.sqrt((u * u).sum() * (v * v).sum())
+            return float((u * v).sum() / d) if d > 0 else np.nan
+
+        corr_raw.append(cc(a, braw))
+        corr_scaled.append(cc(a, bsc))
+        say(f"{b:5d} {s:10.4f} {corr_raw[-1]:10.4f} {corr_scaled[-1]:15.4f}")
+    say()
+
+    # --- diagnostic 4: restoration flux units ------------------------------
+    say("DIAGNOSTIC 4 -- clean beam volume vs dirty beam main-lobe volume.")
+    say("  MODEL (x) G is Jy per clean beam; RESIDUAL is Jy per dirty beam. The restored sum")
+    say("  is only consistent if the ratio below is 1 and constant in frequency. It is")
+    say("  neither, so the residual enters the spectrum with a band-dependent scale.")
+    xxg, yyg = grids(n, n)
+    say(f"{'band':>5} {'dirty mainlobe':>16} {'clean volume':>14} {'ratio':>10} {'vs band 0':>11}")
+    eps = []
+    for b in range(len(keep)):
+        gk = gaussian2d(xxg, yyg, psfparsn[b], normalise=False).T
+        dirty_vol = float(psfs[b][core].sum())
+        clean_vol = float(gk[core].sum())
+        eps.append(dirty_vol / clean_vol if clean_vol else np.nan)
+        say(f"{b:5d} {dirty_vol:16.4e} {clean_vol:14.4e} {eps[-1]:10.5f} {eps[-1] / eps[0]:11.5f}")
+    spread = (max(eps) - min(eps)) / np.mean(eps)
+    say(f"  spread across bands: {100 * spread:.2f} percent of the mean")
+    say()
+
+    prof = np.stack([radial_profile(p, nbins=120)[1] for p in psfs])
+    rad = radial_profile(psfs[0], nbins=120)[0]
+    return {
+        "psf_radial_r": rad,
+        "psf_radial": prof,
+        "psf_homog": homog.astype(np.float32),
+        "psf_core_diff": np.array(core_diff),
+        "psf_wing_diff": np.array(wing_diff),
+        "psf_wing_rms": np.array(wing_rms),
+        "psf_corr_raw": np.array(corr_raw),
+        "psf_corr_scaled": np.array(corr_scaled),
+        "beam_volume_ratio": np.array(eps),
+    }
+
+
+def main():
+    args = parse_args()
+    resize_thread_pool(args.nthreads)
+    outdir = args.outdir or os.path.dirname(os.path.abspath(args.dt.rstrip("/"))) or "."
+    os.makedirs(outdir, exist_ok=True)
+    lines = []
+
+    def say(msg=""):
+        print(msg, flush=True)
+        lines.append(msg)
+
+    say(f"spi ripple diagnostics for {args.dt}")
+    say("=" * 78)
+
+    # ---- tree, bands, geometry -------------------------------------------
+    dt = xr.open_datatree(args.dt, engine="zarr", chunks={})
+    band_nodes = [n for n in dt.children if n.startswith("band")]
+    if not band_nodes:
+        raise SystemExit(f"{args.dt} has no band nodes")
+    tids = sorted({int(dt[n].ds.attrs["timeid"]) for n in band_nodes})
+    tid = tids[0] if args.timeid is None else args.timeid
+    nodes = sorted(
+        (n for n in band_nodes if int(dt[n].ds.attrs["timeid"]) == tid),
+        key=lambda n: int(dt[n].ds.attrs["bandid"]),
+    )
+    dropped = set(args.drop_bands or ())
+    keep = [n for n in nodes if int(dt[n].ds.attrs["bandid"]) not in dropped]
+    keep = [n for n in keep if float(np.sum(dt[n].ds.WSUM.values)) > 0]
+    if len(keep) < 2:
+        raise SystemExit("Need at least two live bands")
+
+    ref = dt[keep[0]].ds
+    ncorr, ny, nx = ref[args.model_name].shape
+    cell_deg = np.rad2deg(float(ref.attrs["cell_rad"]))
+    nband = len(keep)
+    freqs = np.array([float(dt[n].ds.attrs["freq_out"]) for n in keep])
+    wsums = np.array([float(np.atleast_1d(dt[n].ds.WSUM.values)[0]) for n in keep])
+    psfparsn = np.stack([np.asarray(dt[n].ds.PSFPARSN.values, dtype=float)[0] for n in keep])
+    has_psfparsf = "PSFPARSF" in ref
+    gcommon = np.asarray(ref.PSFPARSF.values, dtype=float)[0] if has_psfparsf else psfparsn.max(axis=0)
+
+    say(f"timeid {tid}: {nband} live bands of {len(nodes)}, image {ny} x {nx}, cell {cell_deg * 3600:.3f} arcsec")
+    say(f"frequencies {freqs[0] / 1e6:.1f} - {freqs[-1] / 1e6:.1f} MHz (ratio {freqs[-1] / freqs[0]:.3f})")
+    say(
+        f"common restoring beam PSFPARSF = ({gcommon[0]:.3f}, {gcommon[1]:.3f}) px, pa {np.rad2deg(gcommon[2]):.2f} deg"
+    )
+    if not has_psfparsf:
+        say("  WARNING: no PSFPARSF -- the tree was not homogenised; using max axes as the target")
+    say()
+    say("per band: native beam PSFPARSN, and how far it is from the common target")
+    say(f"{'band':>5} {'freq/MHz':>10} {'emaj':>8} {'emin':>8} {'pa/deg':>8} {'wsum':>11} {'emaj_G/emaj_b':>14}")
+    for b, n in enumerate(keep):
+        say(
+            f"{int(dt[n].ds.attrs['bandid']):5d} {freqs[b] / 1e6:10.2f} {psfparsn[b, 0]:8.3f} {psfparsn[b, 1]:8.3f} "
+            f"{np.rad2deg(psfparsn[b, 2]):8.2f} {wsums[b]:11.4e} {gcommon[0] / psfparsn[b, 0]:14.4f}"
+        )
+    say()
+
+    # ---- cutout window ----------------------------------------------------
+    if args.centre:
+        cy, cx = (int(v) for v in args.centre.split(","))
+    else:
+        cy, cx = ny // 2, nx // 2
+    # clamp so a cutout larger than the image, or a centre near an edge, still works
+    size = int(min(args.size, ny, nx))
+    half = size // 2
+    size = 2 * half
+    cy = int(np.clip(cy, half, ny - half))
+    cx = int(np.clip(cx, half, nx - half))
+    margin = int(np.ceil(4 * gcommon[0]))
+    y0, y1 = max(0, cy - half - margin), min(ny, cy + half + margin)
+    x0, x1 = max(0, cx - half - margin), min(nx, cx + half + margin)
+    ty0, tx0 = cy - half - y0, cx - half - x0
+    trim = (slice(ty0, ty0 + size), slice(tx0, tx0 + size))
+    say(f"cutout centred on (y={cy}, x={cx}), {size} px analysed with a {margin} px convolution margin")
+    if size < args.size:
+        say(f"  (--size {args.size} was clamped to the image)")
+    say()
+
+    bundle = psf_diagnostics(dt, keep, freqs, wsums, psfparsn, gcommon, args.psf_size, args.nthreads, say)
+
+    # ---- rebuild the restored image, term by term -------------------------
+    say("Rebuilding the restored cutout term by term (this repeats what restore did).")
+    sel = dict(corr=0, y=slice(y0, y1), x=slice(x0, x1))
+    mconv, rconv, rconv1, beams = [], [], [], []
+    for b, node in enumerate(keep):
+        ds = dt[node].ds
+        model = np.asarray(ds[args.model_name].isel(**sel).values, dtype=np.float64)
+        resid = np.asarray(ds[args.residual_name].isel(**sel).values, dtype=np.float64) / wsums[b]
+        beams.append(np.asarray(ds.BEAM.isel(**sel).values, dtype=np.float64)[trim])
+        mconv.append(conv(model, gcommon, nthreads=args.nthreads)[trim])
+        rconv.append(conv(resid, gcommon, gausspari=psfparsn[b], nthreads=args.nthreads)[trim])
+        rconv1.append(conv(resid, gcommon, gausspari=psfparsn[b], nthreads=args.nthreads, pfrac=1.0)[trim])
+    mconv, rconv, rconv1 = np.stack(mconv), np.stack(rconv), np.stack(rconv1)
+    beams = np.stack(beams)
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        image_full = mconv + np.where(beams > 0, rconv / beams, 0.0)
+        image_p1 = mconv + np.where(beams > 0, rconv1 / beams, 0.0)
+
+    # consistency: does the rebuild match what restore stored?
+    if args.image_name in ref:
+        stored = np.stack(
+            [np.asarray(dt[n].ds[args.image_name].isel(**sel).values, dtype=np.float64)[trim] for n in keep]
+        )
+        err = np.nanmax(np.abs(image_full - stored)) / np.nanmax(np.abs(stored))
+        say(f"  rebuild vs stored {args.image_name}: max relative difference {err:.3e}")
+        if err > 1e-3:
+            say("  WARNING: the rebuild does not match the tree. Was restore run at a different")
+            say("  --gausspar, or with a different pfrac? Interpret the alpha maps with care.")
+        del stored
+    say()
+
+    # ---- mask, matching what spifit would cut on --------------------------
+    # spifit takes the rms as std(RESIDUAL/WSUM); reproduce that, but report a
+    # MAD estimate too -- over a cutout full of source the std is signal, not noise
+    rms_b = np.array([float(np.std(rconv[b])) for b in range(nband)])
+    mad_b = np.array([float(1.4826 * np.median(np.abs(rconv[b] - np.median(rconv[b])))) for b in range(nband)])
+    weights_b = wsums / wsums.max()
+    rms_mfs = float(np.sum(rms_b * weights_b) / weights_b.sum())
+    mad_mfs = float(np.sum(mad_b * weights_b) / weights_b.sum())
+    if args.rms is not None:
+        rms_mfs = args.rms
+        say(f"mask: rms {rms_mfs:.4e} Jy/beam (from --rms)")
+    else:
+        say(f"mask: rms {rms_mfs:.4e} Jy/beam (std, as spifit computes it); MAD estimate {mad_mfs:.4e}")
+        if rms_mfs > 3 * mad_mfs:
+            say("      NOTE: std is much larger than MAD, so it is measuring source not noise.")
+            say("      Pass --rms with the value your spifit run reported to match its mask.")
+    thresh = args.threshold * rms_mfs
+    apparent = image_full * beams  # spifit compares on the apparent scale
+    mask = (beams.min(axis=0) > args.pb_min) & np.isfinite(apparent).all(axis=0) & (apparent.min(axis=0) > thresh)
+    say(f"      threshold {args.threshold} x rms = {thresh:.4e} Jy/beam")
+    say(f"      {int(mask.sum())} of {mask.size} pixels fitted ({100 * mask.mean():.1f} percent)")
+    if mask.sum() < 500:
+        say("      WARNING: very few pixels. Lower --threshold, pass --rms, or move --centre.")
+    say()
+
+    # ---- diagnostics 3 and 5: alpha with and without the residual ---------
+    idx = np.argwhere(mask)
+    nu_ref = float(np.sum(freqs * wsums) / np.sum(wsums))
+    pb = beams[:, idx[:, 0], idx[:, 1]]
+    wfit = weights_b[:, None] * pb**2  # intrinsic-scale weights, as spifit uses
+
+    say("DIAGNOSTIC 3 -- what does the residual term do to alpha?")
+    say(f"  Reference frequency {nu_ref / 1e6:.2f} MHz. Fitting {len(idx)} pixels three ways.")
+    maps, good = {}, np.ones(len(idx), dtype=bool)
+    for name, cube in (("full", image_full), ("model", mconv), ("pfrac1", image_p1)):
+        a, i0, ok = fit_alpha(cube[:, idx[:, 0], idx[:, 1]], wfit, freqs, nu_ref, maxiter=args.maxiter)
+        m = np.full(mask.shape, np.nan, dtype=np.float32)
+        m[idx[:, 0], idx[:, 1]] = np.where(ok, a, np.nan)
+        maps[name] = m
+        good &= ok
+        say(
+            f"  alpha[{name:6}] median {np.nanmedian(a[ok]) if ok.any() else np.nan:7.3f}  "
+            f"std {np.nanstd(a[ok]) if ok.any() else np.nan:7.3f}  "
+            f"unconverged {100 * (1 - ok.mean()):5.1f} percent"
+        )
+    # compare only where every fit converged, else the statistic is contaminated
+    # by pixels the model-only fit could not constrain (no model flux there)
+    dalpha = maps["full"] - maps["model"]
+    dg = dalpha[idx[good, 0], idx[good, 1]]
+    say(f"  comparing on the {int(good.sum())} pixels ({100 * good.mean():.1f} percent) where all three converged")
+    say(f"  alpha[full] - alpha[model]: median {np.nanmedian(dg):.4f}, std {np.nanstd(dg):.4f}")
+    a_model = maps["model"][idx[good, 0], idx[good, 1]]
+    say(f"  for reference, alpha[model] over the same pixels has std {np.nanstd(a_model):.4f}")
+    say("  The first std is the spectral index the residual term invents; the second is the")
+    say("  spread the deconvolved sky actually has. If the first is comparable to or larger")
+    say("  than the second, the ripples are the residual and not the sky.")
+    say()
+
+    resfrac = np.full(mask.shape, np.nan, dtype=np.float32)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        rf = np.abs(rconv / np.maximum(beams, 1e-12)) / (np.abs(mconv) + np.abs(rconv / np.maximum(beams, 1e-12)))
+    resfrac[mask] = np.nanmedian(rf, axis=0)[mask]
+    say(f"  median residual flux fraction over the mask: {np.nanmedian(resfrac[mask]):.3f}")
+    say("  (the fraction of each pixel's restored flux that comes from the residual term)")
+    say()
+
+    say("DIAGNOSTIC 5 -- is the pfrac=0.2 padding in restore_products contributing?")
+    dp = maps["pfrac1"] - maps["full"]
+    say(f"  alpha[pfrac=1] - alpha[pfrac=0.2]: median {np.nanmedian(dp):.4f}, std {np.nanstd(dp):.4f}")
+    say("  A std comparable to the ripple amplitude means FFT wrap-around is a real")
+    say("  contributor and restore_products should pad more.")
+    say()
+
+    # ---- diagnostic 6: geometry of the ripples ---------------------------
+    say("DIAGNOSTIC 6 -- geometry: is it striping (PSF) or rings (primary beam)?")
+    spectra = {}
+    for name in ("full", "model"):
+        wl, rad, pa, ang = power_spectra(np.nan_to_num(maps[name]), mask)
+        spectra[name] = (wl, rad, pa, ang)
+    wl, rad_full, pa, ang_full = spectra["full"]
+    peak = int(np.nanargmax(rad_full))
+    say(
+        f"  alpha[full] fine-structure power peaks at {wl[peak]:.1f} px = "
+        f"{wl[peak] / gcommon[0]:.2f} restoring beams = {wl[peak] * cell_deg * 3600:.1f} arcsec"
+    )
+    aniso = np.nanmax(ang_full) / np.nanmin(ang_full)
+    say(f"  angular anisotropy {aniso:.2f} (peak at PA {pa[int(np.nanargmax(ang_full))]:.0f} deg)")
+    say("  A high anisotropy at a fixed PA is PSF striping. A flat angular spectrum with a")
+    say("  strong radial signal about the pointing centre is a primary beam error.")
+    rr, aprof = radial_profile(np.where(mask, maps["full"], np.nan), nbins=80)
+    say()
+
+    # ---- write the bundle -------------------------------------------------
+    bundle.update(
+        alpha_full=maps["full"],
+        alpha_model=maps["model"],
+        alpha_pfrac1=maps["pfrac1"],
+        dalpha_residual=dalpha.astype(np.float32),
+        dalpha_pfrac=dp.astype(np.float32),
+        residual_fraction=resfrac,
+        mask=mask,
+        beam_band0=beams[0].astype(np.float32),
+        freqs=freqs,
+        wsums=wsums,
+        psfparsn=psfparsn,
+        gcommon=gcommon,
+        cell_deg=np.array(cell_deg),
+        nu_ref=np.array(nu_ref),
+        rms_per_band=rms_b,
+        centre=np.array([cy, cx]),
+        image_shape=np.array([ny, nx]),
+        ps_wavelength=wl,
+        ps_radial_full=rad_full,
+        ps_radial_model=spectra["model"][1],
+        ps_pa=pa,
+        ps_angular_full=ang_full,
+        ps_angular_model=spectra["model"][3],
+        alpha_radial_r=rr,
+        alpha_radial=aprof,
+    )
+    npz = os.path.join(outdir, "spi_ripples_diagnostics.npz")
+    np.savez_compressed(npz, **bundle)
+    say(f"wrote {npz} ({os.path.getsize(npz) / 1e6:.1f} MB)")
+
+    if not args.no_png:
+        write_png(os.path.join(outdir, "spi_ripples_summary.png"), bundle, say)
+
+    report = os.path.join(outdir, "spi_ripples_report.txt")
+    with open(report, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    print(f"wrote {report}")
+    print(
+        textwrap.dedent(f"""
+        Pull these back:
+          {report}
+          {npz}
+          {os.path.join(outdir, "spi_ripples_summary.png")}
+    """)
+    )
+
+
+def write_png(path, bundle, say):
+    """Panels: the alpha maps, what the residual adds, and the spectra."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(2, 4, figsize=(22, 10))
+    mask = bundle["mask"]
+
+    def show(a, key, title, cmap="plasma", robust=True):
+        arr = np.where(mask, bundle[key], np.nan)
+        lo, hi = np.nanpercentile(arr, [2, 98]) if robust else (None, None)
+        im = a.imshow(arr, origin="lower", cmap=cmap, vmin=lo, vmax=hi)
+        a.set_title(title, fontsize=10)
+        a.set_xticks([])
+        a.set_yticks([])
+        plt.colorbar(im, ax=a, fraction=0.046)
+
+    show(ax[0, 0], "alpha_full", "alpha from the full restored image")
+    show(ax[0, 1], "alpha_model", "alpha from MODEL (x) G only")
+    show(ax[0, 2], "dalpha_residual", "what the residual term adds to alpha", cmap="RdBu_r")
+    show(ax[0, 3], "residual_fraction", "residual fraction of the restored flux", cmap="viridis")
+
+    ax[1, 0].plot(bundle["ps_wavelength"], bundle["ps_radial_full"], label="alpha full")
+    ax[1, 0].plot(bundle["ps_wavelength"], bundle["ps_radial_model"], label="alpha model")
+    ax[1, 0].set_xscale("log")
+    ax[1, 0].set_yscale("log")
+    ax[1, 0].set_xlabel("wavelength [px]")
+    ax[1, 0].set_title("radial power spectrum of alpha", fontsize=10)
+    ax[1, 0].legend(fontsize=8)
+
+    ax[1, 1].plot(bundle["ps_pa"], bundle["ps_angular_full"], label="alpha full")
+    ax[1, 1].plot(bundle["ps_pa"], bundle["ps_angular_model"], label="alpha model")
+    ax[1, 1].set_xlabel("PA of the wavevector [deg]")
+    ax[1, 1].set_title("angular power (striping direction)", fontsize=10)
+    ax[1, 1].legend(fontsize=8)
+
+    # band 0 is the reference and identically zero; plotting it flattens the axis
+    nb = len(bundle["freqs"])
+    ax[1, 2].semilogy(range(1, nb), bundle["psf_core_diff"][1:], "o-", label="core")
+    ax[1, 2].semilogy(range(1, nb), bundle["psf_wing_diff"][1:], "s-", label="wings")
+    ax[1, 2].set_xlabel("band")
+    ax[1, 2].set_title("PSF difference from band 0 after homogenisation", fontsize=10)
+    ax[1, 2].legend(fontsize=8)
+
+    ax[1, 3].plot(bundle["freqs"] / 1e6, bundle["psf_corr_raw"], "o-", label="raw")
+    ax[1, 3].plot(bundle["freqs"] / 1e6, bundle["psf_corr_scaled"], "s-", label="rescaled by nu")
+    ax[1, 3].set_xlabel("frequency [MHz]")
+    ax[1, 3].set_title("sidelobe correlation with band 0", fontsize=10)
+    ax[1, 3].legend(fontsize=8)
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=110)
+    plt.close(fig)
+    say(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -605,6 +605,16 @@ def main():
         image_full = mconv + np.where(beams > 0, rconv / beams, 0.0)
         image_p1 = mconv + np.where(beams > 0, rconv1 / beams, 0.0)
 
+    # if restore stored CRESIDUAL (--outputs s), check the rebuild against it
+    # directly rather than only through the restored image
+    if "CRESIDUAL" in ref:
+        cres = np.stack([np.asarray(dt[n].ds.CRESIDUAL.isel(**sel).values, dtype=np.float64)[trim] for n in keep])
+        e = np.nanmax(np.abs(rconv - cres)) / max(np.nanmax(np.abs(cres)), 1e-30)
+        say(f"  rebuild vs stored CRESIDUAL: max relative difference {e:.3e}")
+        del cres
+    else:
+        say("  (no CRESIDUAL in the tree; re-run restore with --outputs s to store it)")
+
     # consistency: does the rebuild match what restore stored?
     if args.image_name in ref:
         stored = np.stack(

--- a/scripts/test_spi_ripples.py
+++ b/scripts/test_spi_ripples.py
@@ -86,8 +86,9 @@ def parse_args():
     p.add_argument(
         "--centre",
         default=None,
-        help="Cutout centre as 'y,x' in pixels. Default is the image centre; aim it at a "
-        "diffuse region where the ripples are visible",
+        help="Cutout centre as 'y,x' array indices into the full image (not offsets from "
+        "its centre). Default is the image centre; aim it at a diffuse region where the "
+        "ripples are visible. Clamped so the window stays inside the image",
     )
     p.add_argument("--psf-size", type=int, default=256, help="Side of the PSF window used for the sidelobe tests")
     p.add_argument("--timeid", type=int, default=None, help="Which timeid to analyse (default: the first)")
@@ -651,8 +652,23 @@ def main():
     mask = (beams.min(axis=0) > args.pb_min) & np.isfinite(apparent).all(axis=0) & (apparent.min(axis=0) > thresh)
     say(f"      threshold {args.threshold} x rms = {thresh:.4e} Jy/beam")
     say(f"      {int(mask.sum())} of {mask.size} pixels fitted ({100 * mask.mean():.1f} percent)")
-    if mask.sum() < 500:
-        say("      WARNING: very few pixels. Lower --threshold, pass --rms, or move --centre.")
+    if mask.sum() < 200:
+        # stop here rather than write a bundle of NaN: on a remote run that
+        # costs a download before anyone notices the maps are empty
+        peak = float(np.nanmax(apparent.min(axis=0))) if np.isfinite(apparent).any() else np.nan
+        bmin = float(np.nanmax(beams.min(axis=0)))
+        raise SystemExit(
+            f"\nOnly {int(mask.sum())} pixels pass the cuts -- not enough to diagnose anything.\n"
+            f"  brightest pixel (min over bands, apparent): {peak:.4e} Jy/beam\n"
+            f"  threshold currently:                        {thresh:.4e} Jy/beam\n"
+            f"  best beam value in the cutout:              {bmin:.3f} (--pb-min is {args.pb_min})\n"
+            f"Aim --centre at emission (it is (y, x) array indices into the full "
+            f"{ny} x {nx} image, so the middle is {ny // 2},{nx // 2}), pass --rms with the "
+            f"value your spifit run reported, or lower --threshold."
+        )
+    if mask.sum() < 2000:
+        say("      WARNING: few pixels. The power spectra will be noisy; consider a")
+        say("      brighter --centre or a lower --threshold.")
     say()
 
     # ---- diagnostics 3 and 5: alpha with and without the residual ---------

--- a/src/pfb_imaging/cabs/restore.yml
+++ b/src/pfb_imaging/cabs/restore.yml
@@ -41,6 +41,7 @@ cabs:
           (d)irty, (m)odel, (r)esidual, (k) restored with intrinsic model and apparent residual.
           (a) restored fully apparent, (i) restored fully intrinsic (primary beam corrected).
           (c)lean beam image, (f)ft of the residual.
+          (s)moothed residual, the residual convolved to the restoring resolution.
           Use capitals to produce corresponding cubes.
         default: kK
         metadata:

--- a/src/pfb_imaging/cli/restore.py
+++ b/src/pfb_imaging/cli/restore.py
@@ -101,6 +101,7 @@ def restore(
             "(d)irty, (m)odel, (r)esidual, (k) restored with intrinsic model and apparent residual. "
             "(a) restored fully apparent, (i) restored fully intrinsic (primary beam corrected). "
             "(c)lean beam image, (f)ft of the residual. "
+            "(s)moothed residual, the residual convolved to the restoring resolution. "
             "Use capitals to produce corresponding cubes.",
             rich_help_panel="Output",
         ),

--- a/src/pfb_imaging/core/restore.py
+++ b/src/pfb_imaging/core/restore.py
@@ -27,6 +27,7 @@ from pfb_imaging.utils.restoration import (
     beams_table,
     clean_beam,
     lowest_resolution,
+    resolution_deficit,
     restore_products,
     write_fits,
 )
@@ -180,11 +181,29 @@ def restore(
             log.info(
                 f"Using specified resolution of ({gausspar[0]:.3e} deg, {gausspar[1]:.3e} deg, {gausspar[2]:.3e} deg)"
             )
+            # fail here rather than inside the FFT: a target sharper than some
+            # band along some direction is a deconvolution (wiki D31)
+            native = np.concatenate([psfparsn, gausspar_mfs_native[None]], axis=0)
+            deficit = np.nanmax(resolution_deficit(target, native))
+            if deficit > 1.0:
+                floor = lowest_resolution(native)
+                log.error_and_raise(
+                    f"--gausspar ({gausspar[0]:.3e}, {gausspar[1]:.3e}, {gausspar[2]:.3e}) deg is sharper than "
+                    f"the data along some direction, by a factor {np.sqrt(deficit):.4f} in each axis. Restoring "
+                    f"to it is a deconvolution, not a convolution. The lowest resolution that works here is "
+                    f"({floor[0, 0] * cell_deg:.3e}, {floor[0, 1] * cell_deg:.3e}, "
+                    f"{np.rad2deg(floor[0, 2]):.3e}) deg, which --gausspar 0 0 0 selects automatically.",
+                    ValueError,
+                )
             gaussparf = np.tile(target, (nband, 1, 1))
             gaussparf_mfs = target
             gausspari_band, gausspari_mfs = psfparsn, gausspar_mfs_native
         elif gausspar is not None:
-            target = lowest_resolution(psfparsn)
+            # the MFS residual is reconvolved to this target too, from its own
+            # native beam, so that beam has to be inside the envelope. It is a
+            # fit to the summed PSF, not an average of the band fits (D29), and
+            # is not bounded by them.
+            target = lowest_resolution(np.concatenate([psfparsn, gausspar_mfs_native[None]], axis=0))
             log.info(
                 f"Using lowest resolution of ({target[0, 0] * cell_deg:.3e} deg, "
                 f"{target[0, 1] * cell_deg:.3e} deg, {np.rad2deg(target[0, 2]):.3e} deg)"

--- a/src/pfb_imaging/core/restore.py
+++ b/src/pfb_imaging/core/restore.py
@@ -57,6 +57,9 @@ def restore(
         residual_name: band variable holding the residual image.
         suffix: namespaces the FITS outputs only, never the tree path.
         outputs: product letters, lowercase for MFS and uppercase for cubes.
+            ``s`` stores ``CRESIDUAL``, the residual convolved to the restoring
+            resolution -- the term the restored images add to the model, kept
+            because nothing else records what the resolution change did to it.
         gausspar: restoring resolution ``(emaj, emin, pa)`` in degrees, degrees
             and degrees. ``(0, 0, 0)`` selects the lowest-resolution band. None
             restores each band at its native resolution.
@@ -108,7 +111,7 @@ def restore(
         log.error_and_raise(f"No band nodes found in {dt_name}", ValueError)
 
     dropped = set(drop_bands or ())
-    products = tuple(k for k in ("a", "i", "k") if k in outputs.lower())
+    products = tuple(k for k in ("a", "i", "k", "s") if k in outputs.lower())
     timeids = sorted({int(dt[n].ds.attrs["timeid"]) for n in band_nodes})
     log.info(f"Number of output times = {len(timeids)}")
 

--- a/src/pfb_imaging/utils/misc.py
+++ b/src/pfb_imaging/utils/misc.py
@@ -176,6 +176,81 @@ def get_padding_info(nx, ny, pfrac):
     return padding, unpad_x, unpad_y
 
 
+def gauss_cov(gausspar):
+    """Real-space covariance of a Gaussian given as (emaj, emin, pa).
+
+    Args:
+        gausspar: (emaj, emin, pa) with the axes as FWHM in grid units and pa
+            in radians, using gaussian2d's rotation convention.
+
+    Returns:
+        (2, 2) covariance in squared grid units, i.e. the inverse of the
+        quadratic form gaussian2d exponentiates.
+    """
+    smaj, smin, pa = gausspar
+    fwhm_conv = 2 * np.sqrt(2 * np.log(2))
+    rmat = np.array([[-np.sin(pa), -np.cos(pa)], [np.cos(pa), -np.sin(pa)]])
+    sigmas = np.diag([(smaj / fwhm_conv) ** 2, (smin / fwhm_conv) ** 2])
+    return rmat @ sigmas @ rmat.T
+
+
+def gauss_ratio_hat(gausspari, gaussparf, shape, dx=1.0, dy=1.0, normalise=False):
+    """Transform of the kernel taking resolution gausspari to gaussparf.
+
+    The ratio of two Gaussian transforms is itself a Gaussian, so it is written
+    down rather than obtained by dividing two sampled kernels' FFTs:
+
+        Kf(k) / Ki(k) = sqrt(|Sf| / |Si|) exp(-2 pi^2 k^T (Sf - Si) k)
+
+    That division is the failure mode of issue #312. A sampled Gaussian's DFT
+    sinks into round-off well before Nyquist, so beyond some |k| the quotient is
+    noise over noise -- unbounded, since nothing masks it -- and the resulting
+    ringing displaces sources. Widening gaussian2d's support fixes the
+    truncation half of that, but not the round-off half, which grows with
+    --super-resolution-factor. Evaluating the ratio directly has neither
+    problem, conserves flux exactly, and costs two FFTs less per plane.
+
+    Args:
+        gausspari: (emaj, emin, pa) initial resolution, FWHM in grid units.
+        gaussparf: (emaj, emin, pa) target resolution, FWHM in grid units.
+        shape: (nx, ny) real-space shape of the padded grid.
+        dx: Grid spacing along the first axis, in the units of gausspar.
+        dy: Grid spacing along the second axis, in the units of gausspar.
+        normalise: Match norm_kernel=True, where both kernels carry unit volume
+            and the ratio therefore has unit DC gain.
+
+    Returns:
+        (nx, ny // 2 + 1) real array matching the layout of an r2c transform of
+        the padded grid.
+
+    Raises:
+        ValueError: If gaussparf is not at least as wide as gausspari in every
+            direction. The operation is then a deconvolution, which this
+            amplifies without bound rather than performing.
+    """
+    covi = gauss_cov(gausspari)
+    covf = gauss_cov(gaussparf)
+    dcov = covf - covi
+    # a positive semi-definite difference is exactly the condition for the
+    # ratio to be a convolution rather than a deconvolution. A rotation between
+    # the two position angles can make it indefinite even when both axes grow.
+    evals = np.linalg.eigvalsh(dcov)
+    tol = 1e-8 * max(np.trace(covi), np.trace(covf))
+    if evals.min() < -tol:
+        raise ValueError(
+            f"Cannot convolve from {tuple(np.asarray(gausspari, dtype=float))} to "
+            f"{tuple(np.asarray(gaussparf, dtype=float))}: the target resolution is sharper than the "
+            f"initial one along some direction (smallest eigenvalue of the covariance difference is "
+            f"{evals.min():.3e}). This is a deconvolution, not a convolution."
+        )
+    nx, ny = shape
+    kx = np.fft.fftfreq(nx, d=dx)[:, None]
+    ky = np.fft.rfftfreq(ny, d=dy)[None, :]
+    quad = dcov[0, 0] * kx**2 + 2 * dcov[0, 1] * kx * ky + dcov[1, 1] * ky**2
+    amp = 1.0 if normalise else np.sqrt(np.linalg.det(covf) / np.linalg.det(covi))
+    return amp * np.exp(-2 * np.pi**2 * quad)
+
+
 def convolve2gaussres(
     image, xx, yy, gaussparf, nthreads=1, gausspari=None, pfrac=0.5, norm_kernel=False, yx_order=False
 ):
@@ -195,7 +270,9 @@ def convolve2gaussres(
         nthreads: Number of threads to use for the FFT's.
         gausspari: Initial resolution, same shapes as gaussparf. By default
             the image is assumed to be a clean component image with no
-            associated resolution.
+            associated resolution. When given, the resolution change is applied
+            with the closed-form transform ratio (see gauss_ratio_hat), so
+            gaussparf must be at least as wide as gausspari.
         pfrac: Padding used for the FFT based convolution. Will pad by
             pfrac/2 on both sides of image.
         norm_kernel: Normalise the Gaussian kernel to have volume 1.
@@ -211,7 +288,8 @@ def convolve2gaussres(
 
     Raises:
         ValueError: If gausspari is per-plane (ndim > 1) and its length does
-            not match the number of planes in image.
+            not match the number of planes in image, or if gaussparf is sharper
+            than gausspari along some direction (see gauss_ratio_hat).
         AssertionError: If gaussparf is per-plane (ndim > 1) and its length
             does not match the number of planes in image.
     """
@@ -228,42 +306,38 @@ def convolve2gaussres(
     image = np.pad(image, padding, mode="constant")
     imhat = r2c(ifftshift(image, axes=ax), axes=ax, forward=True, nthreads=nthreads, inorm=0)
 
-    if np.ndim(gaussparf) == 1:  # single final resolution shared by all planes
-        gausskern = gaussian2d(xx, yy, gaussparf, normalise=norm_kernel)
-        gausskern = np.pad(gausskern, padding[1:], mode="constant")
-        gausskernhat = r2c(ifftshift(gausskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0)
-        gausskernhat = np.broadcast_to(gausskernhat[None], imhat.shape)
-    else:
+    if np.ndim(gaussparf) > 1:
         assert np.shape(gaussparf)[0] == nband
-        gausskernhat = np.zeros_like(imhat)
-        for b in range(nband):
-            gausskern = gaussian2d(xx, yy, gaussparf[b], normalise=norm_kernel)
-            gausskern = np.pad(gausskern, padding[1:], mode="constant")
-            r2c(
-                ifftshift(gausskern, axes=(0, 1)),
-                out=gausskernhat[b],
-                axes=(0, 1),
-                forward=True,
-                nthreads=nthreads,
-                inorm=0,
-            )
 
-    # convolve to desired resolution
     if gausspari is None:
-        imhat *= gausskernhat
+        # no initial resolution: a plain convolution by the sampled kernel
+        if np.ndim(gaussparf) == 1:  # single final resolution shared by all planes
+            gausskern = gaussian2d(xx, yy, gaussparf, normalise=norm_kernel)
+            gausskern = np.pad(gausskern, padding[1:], mode="constant")
+            gausskernhat = r2c(ifftshift(gausskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0)
+            imhat *= gausskernhat[None]
+        else:
+            for b in range(nband):
+                gausskern = gaussian2d(xx, yy, gaussparf[b], normalise=norm_kernel)
+                gausskern = np.pad(gausskern, padding[1:], mode="constant")
+                gausskernhat = r2c(
+                    ifftshift(gausskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0
+                )
+                imhat[b] *= gausskernhat
     else:
+        # resolution change: use the closed-form ratio of the two transforms
+        # rather than dividing sampled kernels (issue #312, gauss_ratio_hat)
         gausspari = np.asarray(gausspari)
+        shape = (nx + np.sum(padding[1]), ny + np.sum(padding[2]))
+        # gausspar is in the units of the grids, so the frequency axes need
+        # their spacing; every caller passes pixels, but do not assume it
+        xs, ys = np.squeeze(xx), np.squeeze(yy)
+        dx = float(xs[1, 0] - xs[0, 0]) if xs.ndim == 2 and nx > 1 else 1.0
+        dy = float(ys[0, 1] - ys[0, 0]) if ys.ndim == 2 and ny > 1 else 1.0
         for b in range(nband):
             gpi = gausspari if gausspari.ndim == 1 else gausspari[b]
-            thiskern = gaussian2d(xx, yy, gpi, normalise=norm_kernel)
-            thiskern = np.pad(thiskern, padding[1:], mode="constant")
-            thiskernhat = r2c(ifftshift(thiskern, axes=(0, 1)), axes=(0, 1), forward=True, nthreads=nthreads, inorm=0)
-
-            convkernhat = np.zeros_like(thiskernhat)
-            msk = np.abs(thiskernhat) > 0.0
-            convkernhat[msk] = gausskernhat[b, msk] / thiskernhat[msk]
-
-            imhat[b] *= convkernhat
+            gpf = gaussparf if np.ndim(gaussparf) == 1 else gaussparf[b]
+            imhat[b] *= gauss_ratio_hat(gpi, gpf, shape, dx=dx, dy=dy, normalise=norm_kernel)
 
     image = fftshift(c2r(imhat, axes=ax, forward=False, lastsize=lastsize, inorm=2, nthreads=nthreads), axes=ax)[
         :, unpad_x, unpad_y
@@ -566,13 +640,19 @@ def construct_mappings(
     )
 
 
-def gaussian2d(xin, yin, gausspar=(1.0, 1.0, 0.0), normalise=True, nsigma=5):
+def gaussian2d(xin, yin, gausspar=(1.0, 1.0, 0.0), normalise=True, nfwhm=5):
     """
     xin         - grid of x coordinates
     yin         - grid of y coordinates
     gausspar    - (emaj, emin, pa) with emaj/emin as FWHM in units of xin/yin and pa in radians.
     normalise   - normalise kernel to have volume 1
-    nsigma      - compute kernel out to this many standard deviations of the major axis
+    nfwhm       - compute kernel out to this many major-axis FWHMs
+
+    The support is deliberately far outside the core, and the parameter counts
+    FWHMs rather than standard deviations to say so (issue #312): 5 sigma
+    truncates at 3.7e-6 of peak, whose spectral ripple swamps the transform's
+    own ~1e-14 floor near Nyquist, while 5 FWHM (11.8 sigma) truncates at
+    ~1e-30 and the transform is clean everywhere.
     """
     smaj, smin, pa = gausspar
     fwhm_conv = 2 * np.sqrt(2 * np.log(2))
@@ -585,9 +665,8 @@ def gaussian2d(xin, yin, gausspar=(1.0, 1.0, 0.0), normalise=True, nsigma=5):
     rmat = np.array([[-np.sin(pa), -np.cos(pa)], [np.cos(pa), -np.sin(pa)]])
     amat = np.dot(np.dot(rmat, amat), rmat.T)
     sout = xin.shape
-    # only compute the result out to nsigma standard deviations
-    sigma_maj = smaj / fwhm_conv
-    extent = (nsigma * sigma_maj) ** 2
+    # only compute the result out to nfwhm major-axis FWHMs (see the docstring)
+    extent = (nfwhm * smaj) ** 2
     xflat = xin.squeeze()
     yflat = yin.squeeze()
     idx, idy = np.where(xflat**2 + yflat**2 <= extent)

--- a/src/pfb_imaging/utils/misc.py
+++ b/src/pfb_imaging/utils/misc.py
@@ -334,6 +334,14 @@ def convolve2gaussres(
         xs, ys = np.squeeze(xx), np.squeeze(yy)
         dx = float(xs[1, 0] - xs[0, 0]) if xs.ndim == 2 and nx > 1 else 1.0
         dy = float(ys[0, 1] - ys[0, 0]) if ys.ndim == 2 and ny > 1 else 1.0
+        if dx == 0.0 or dy == 0.0:
+            # np.meshgrid's default indexing="xy" transposes the grids, which
+            # makes both differences zero and every frequency infinite. Say so:
+            # the resulting all-NaN image is otherwise silent.
+            raise ValueError(
+                f"xx/yy must be (X, Y)-ordered grids, i.e. np.meshgrid(x, y, indexing='ij'); "
+                f"the inferred grid spacing is ({dx}, {dy})"
+            )
         for b in range(nband):
             gpi = gausspari if gausspari.ndim == 1 else gausspari[b]
             gpf = gaussparf if np.ndim(gaussparf) == 1 else gaussparf[b]

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -18,6 +18,7 @@ must say which scale it is on. Three are offered, keyed by their CLI letter.
 
 import numpy as np
 import xarray as xr
+from scipy.linalg import eigh
 
 from pfb_imaging.utils.fits import create_beams_table, save_fits, set_wcs
 from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam
@@ -46,22 +47,104 @@ def clean_beam(psf, wsum):
     return np.array(fitcleanbeam(norm, yx_order=True))
 
 
-def lowest_resolution(gausspars):
-    """Reduce per-band resolutions to the lowest-resolution one.
+def _mean_pa(pas):
+    """Circular mean of position angles, which are defined modulo pi.
+
+    ``np.nanmean`` is wrong for angles: PAs of 0.05 and pi - 0.05 describe two
+    nearly identical orientations but average to pi/2, which is orthogonal to
+    both. Doubling before averaging maps the modulo-pi circle onto a full one.
+    """
+    pas = np.asarray(pas, dtype=float)
+    return 0.5 * np.arctan2(np.nanmean(np.sin(2 * pas)), np.nanmean(np.cos(2 * pas)))
+
+
+def resolution_deficit(target, gausspars):
+    """How far short of dominating every input the target resolution falls.
 
     Args:
-        gausspars: ``(nband, ncorr, 3)`` in pixels, pixels, radians. NaN rows
-            (fully flagged bands) are skipped.
+        target: ``(ncorr, 3)`` candidate restoring resolution.
+        gausspars: ``(n, ncorr, 3)`` resolutions it must be convolvable from.
+            NaN rows are skipped.
 
     Returns:
-        ``(ncorr, 3)``: the largest major and minor axes over bands and the mean
-        position angle.
+        ``(ncorr,)`` largest factor by which ``target``'s axes must grow, as a
+        ratio of areas. At most 1.0 means the target is valid; above 1.0 the
+        target is sharper than some input along some direction, and each axis
+        must grow by its square root. NaN where every input is NaN.
     """
+    # deferred: import cycle with utils.misc (see lowest_resolution)
+    from pfb_imaging.utils.misc import gauss_cov
+
+    target = np.asarray(target, dtype=float)
     gausspars = np.asarray(gausspars, dtype=float)
-    out = np.empty(gausspars.shape[1:], dtype=float)
-    out[:, 0] = np.nanmax(gausspars[:, :, 0], axis=0)
-    out[:, 1] = np.nanmax(gausspars[:, :, 1], axis=0)
-    out[:, 2] = np.nanmean(gausspars[:, :, 2], axis=0)
+    out = np.full(gausspars.shape[1], np.nan, dtype=float)
+    for c in range(gausspars.shape[1]):
+        rows = gausspars[:, c, :]
+        rows = rows[~np.isnan(rows).any(axis=1)]
+        if not len(rows):
+            continue
+        shape = gauss_cov(target[c])
+        out[c] = max(eigh(gauss_cov(row), shape, eigvals_only=True).max() for row in rows)
+    return out
+
+
+def lowest_resolution(gausspars):
+    """Smallest common resolution every input Gaussian can be convolved to.
+
+    "At least as wide as every input" is a statement about the covariances in
+    the Loewner order -- ``Sf - Sj`` positive semi-definite for every input j --
+    not about the axes separately. Taking the max of each axis and the mean of
+    the position angles satisfies the second and not the first: a rotated
+    ellipse pokes out diagonally, and convolving to such a target is a
+    deconvolution along some direction. ``convolve2gaussres`` now refuses it
+    (wiki D31), where it used to silently amplify noise.
+
+    So the max-axis, mean-PA ellipse is used only as a candidate *shape*. Each
+    candidate is inflated by the smallest scalar that makes it dominate every
+    input -- the largest generalised eigenvalue, exact in closed form -- and the
+    smallest resulting ellipse wins. Candidates are the circular-mean PA plus
+    each input's own PA, so when one input is the widest at its own angle the
+    result is that input, with no inflation at all.
+
+    Args:
+        gausspars: ``(n, ncorr, 3)`` in pixels, pixels, radians, over whatever
+            set must be dominated -- the per-band beams, and the MFS beam too
+            when it is reconvolved to the same target. NaN rows (fully flagged
+            bands) are skipped.
+
+    Returns:
+        ``(ncorr, 3)``: a resolution at least as low as every input, in every
+        direction. Rows are NaN where every input is NaN.
+    """
+    # deferred: import cycle with utils.misc, which imports utils.fits, which
+    # this module also imports -- gauss_cov is only needed on this path
+    from pfb_imaging.utils.misc import gauss_cov
+
+    gausspars = np.asarray(gausspars, dtype=float)
+    out = np.full(gausspars.shape[1:], np.nan, dtype=float)
+    for c in range(gausspars.shape[1]):
+        rows = gausspars[:, c, :]
+        rows = rows[~np.isnan(rows).any(axis=1)]
+        if not len(rows):
+            continue
+        covs = [gauss_cov(row) for row in rows]
+        emaj, emin = rows[:, 0].max(), rows[:, 1].max()
+        best = None
+        # candidate orientations, and candidate axis ratios between the widest
+        # input's and circular. Neither alone is enough: when the inputs share a
+        # PA the max-axis ellipse wins, and when they are spread over a wide
+        # range of angles a rounder beam contains them more tightly.
+        for pa in np.concatenate([[_mean_pa(rows[:, 2])], rows[:, 2]]):
+            for ratio in np.linspace(emin / emaj, 1.0, 5):
+                shape = gauss_cov((emaj, emaj * ratio, pa))
+                # smallest s with s * shape >= cov, i.e. the largest generalised
+                # eigenvalue of the pencil (cov, shape). A margin keeps the
+                # binding input inside gauss_ratio_hat's definiteness check.
+                scale = (1.0 + 1e-6) * max(eigh(cov, shape, eigvals_only=True).max() for cov in covs)
+                area = emaj * emaj * ratio * scale
+                if best is None or area < best[0]:
+                    best = (area, np.sqrt(scale) * emaj, np.sqrt(scale) * emaj * ratio, pa)
+        out[c] = best[1:]
     return out
 
 

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -24,8 +24,9 @@ from pfb_imaging.utils.fits import create_beams_table, save_fits, set_wcs
 from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam
 
 # CLI letter -> DataTree variable name. The B prefix follows the tree's
-# convention for beam-attenuated quantities (BDIRTY, BRESIDUAL).
-PRODUCT_VARS = {"a": "BIMAGE", "i": "IMAGE", "k": "KIMAGE"}
+# convention for beam-attenuated quantities (BDIRTY, BRESIDUAL); the C prefix on
+# CRESIDUAL means convolved to the restoring resolution.
+PRODUCT_VARS = {"a": "BIMAGE", "i": "IMAGE", "k": "KIMAGE", "s": "CRESIDUAL"}
 
 
 def clean_beam(psf, wsum):
@@ -160,8 +161,12 @@ def restore_products(model, residual, beam, gaussparf, gausspari=None, products=
         gausspari: ``(ncorr, 3)`` intrinsic resolution of ``residual``, or None
             to skip the residual reconvolution. None is correct whenever
             ``gaussparf`` is the residual's own resolution.
-        products: iterable over ``"a"`` (apparent), ``"i"`` (intrinsic) and
-            ``"k"`` (intrinsic model plus apparent residual).
+        products: iterable over ``"a"`` (apparent), ``"i"`` (intrinsic),
+            ``"k"`` (intrinsic model plus apparent residual) and ``"s"``, the
+            residual convolved to ``gaussparf`` on its own. ``"s"`` is not a
+            restored image; it is the term the other three add to the model, and
+            it is stored because nothing else in the tree records what the
+            resolution change actually did to the residual.
         pb_min: beam floor below which the intrinsic image is zeroed, matching
             the cutoff convention in ``utils/spi.py``.
         nthreads: threads for the convolution FFTs.
@@ -201,6 +206,10 @@ def restore_products(model, residual, beam, gaussparf, gausspari=None, products=
         # (B*m) (x) G, NOT B*(m (x) G) -- convolution does not commute with
         # multiplication by a spatially varying beam, so mconv cannot be reused
         out["a"] = convolve2gaussres(beam * model, xx, yy, gaussparf, **kw) + rconv
+    if "s" in products:
+        # apparent, pre-beam-division: BEAM is on the node, so the intrinsic form
+        # is one divide away, and this is the scale image-plane noise is flat on
+        out["s"] = rconv if rconv is not residual else residual.copy()
     return out
 
 

--- a/src/pfb_imaging/utils/restoration.py
+++ b/src/pfb_imaging/utils/restoration.py
@@ -21,7 +21,7 @@ import xarray as xr
 from scipy.linalg import eigh
 
 from pfb_imaging.utils.fits import create_beams_table, save_fits, set_wcs
-from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam
+from pfb_imaging.utils.misc import convolve2gaussres, fitcleanbeam, gauss_cov
 
 # CLI letter -> DataTree variable name. The B prefix follows the tree's
 # convention for beam-attenuated quantities (BDIRTY, BRESIDUAL); the C prefix on
@@ -73,9 +73,6 @@ def resolution_deficit(target, gausspars):
         target is sharper than some input along some direction, and each axis
         must grow by its square root. NaN where every input is NaN.
     """
-    # deferred: import cycle with utils.misc (see lowest_resolution)
-    from pfb_imaging.utils.misc import gauss_cov
-
     target = np.asarray(target, dtype=float)
     gausspars = np.asarray(gausspars, dtype=float)
     out = np.full(gausspars.shape[1], np.nan, dtype=float)
@@ -117,10 +114,6 @@ def lowest_resolution(gausspars):
         ``(ncorr, 3)``: a resolution at least as low as every input, in every
         direction. Rows are NaN where every input is NaN.
     """
-    # deferred: import cycle with utils.misc, which imports utils.fits, which
-    # this module also imports -- gauss_cov is only needed on this path
-    from pfb_imaging.utils.misc import gauss_cov
-
     gausspars = np.asarray(gausspars, dtype=float)
     out = np.full(gausspars.shape[1:], np.nan, dtype=float)
     for c in range(gausspars.shape[1]):

--- a/tests/test_convolve2gaussres.py
+++ b/tests/test_convolve2gaussres.py
@@ -331,3 +331,149 @@ def test_convolve2gaussres_gausspari_shared_triple_matches_per_plane():
     per_plane = convolve2gaussres(img, xx, yy, gaussparf, nthreads=1, pfrac=0.2, gausspari=gausspari_per_plane)
 
     np.testing.assert_allclose(shared, per_plane, rtol=0, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Resolution changes (gausspari given). Issue #312: these all passed vacuously
+# before, because every test above uses gausspari None, equal to gaussparf, or
+# a smooth centred Gaussian whose spectrum dies exactly where the old sampled
+# division went wrong.
+# ---------------------------------------------------------------------------
+
+
+@pmp("npix", [128, 512])
+def test_convolve2gaussres_preserves_position_when_deconvolving(npix):
+    """A delta must land where it started after a resolution change.
+
+    The old sampled division put it elsewhere entirely -- at npix=512 a source
+    at (170, 260) came out at (146, 260), displaced by twice its offset from
+    the image centre, with -0.81 of peak in ringing (issue #312).
+    """
+    y0, x0 = npix // 3, npix // 2 + 4
+    image = np.zeros((1, npix, npix))
+    image[0, y0, x0] = 1.0
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+
+    out = convolve2gaussres(
+        image,
+        xx,
+        yy,
+        np.array([[6.3, 4.2, 0.0]]),
+        nthreads=1,
+        gausspari=np.array([[6.0, 4.0, 0.0]]),
+        norm_kernel=False,
+        yx_order=True,
+    )[0]
+
+    assert np.unravel_index(np.argmax(out), out.shape) == (y0, x0)
+    # a small broadening of a delta is a near-identity: no deep negatives
+    assert out.min() > -0.05 * out.max()
+
+
+@pmp("norm_kernel", [False, True])
+def test_convolve2gaussres_conserves_flux_through_a_resolution_change(norm_kernel):
+    """Total flux scales by the ratio of the kernels' volumes, exactly.
+
+    With norm_kernel both kernels carry unit volume, so the gain is 1; without
+    it the gain is (emaj_f * emin_f) / (emaj_i * emin_i). The old sampled
+    division missed this by +6 percent at a 6 px beam and -25 percent at 12 px.
+    """
+    npix = 256
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 3, npix // 2 + 4] = 1.0
+    gausspari = np.array([5.0, 3.0, 0.4])
+    gaussparf = np.array([11.0, 7.0, 0.4])
+
+    out = convolve2gaussres(image, xx, yy, gaussparf, nthreads=1, gausspari=gausspari, norm_kernel=norm_kernel)
+
+    expected = 1.0 if norm_kernel else (gaussparf[0] * gaussparf[1]) / (gausspari[0] * gausspari[1])
+    assert out.sum() == pytest.approx(expected, rel=1e-6)
+
+
+@pmp("srf", [2.0, 3.0, 4.0])
+def test_convolve2gaussres_two_step_matches_direct_across_srf(srf):
+    """Going to gf via gi must equal going to gf directly.
+
+    The beam is 2 * srf pixels across and the sky is band limited to the uv
+    coverage that implies, so this is the invariant a restore run actually
+    depends on. The old sampled division broke it by 1.8e-3 and 1.4e-4 of peak
+    at srf 3 and 4, where the beam is well enough sampled that its transform
+    sinks into round-off before Nyquist and the quotient is noise over noise.
+    srf 2 is the one case it survived (4.0e-10): a 4 px FWHM aliases enough
+    that the transform never gets that small. The closed-form ratio is exact
+    at every srf, leaving only that aliasing floor (8.1e-10 at srf 2, 6e-16
+    above it).
+
+    The sky is windowed away from the frame edge and only the interior is
+    compared: the two-step path pads and unpads twice, and the flux that spills
+    into the pad is dropped at the first unpad. That edge artefact is real but
+    is not what this test is about, and it swamps everything at ~1e-1.
+    """
+    npix = 256
+    rng = np.random.default_rng(42)
+    # band limited to |k| <= 1 / (2 * srf) cycles/pixel, then tapered
+    k = np.fft.fftfreq(npix)
+    kr = np.sqrt(k[:, None] ** 2 + k[None, :] ** 2)
+    hat = np.fft.fft2(rng.standard_normal((npix, npix)))
+    hat[kr > 1.0 / (2 * srf)] = 0.0
+    sky = np.real(np.fft.ifft2(hat))
+    coord = -(npix // 2) + np.arange(npix)
+    radius = np.sqrt(coord[:, None] ** 2 + coord[None, :] ** 2)
+    sky = sky * np.exp(-0.5 * (radius / (npix / 8.0)) ** 2)
+    sky = (sky / np.abs(sky).max())[None]
+
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    fwhm = 2 * srf
+    gausspari = np.array([fwhm, 0.7 * fwhm, 0.0])
+    gaussparf = np.array([2 * fwhm, 1.4 * fwhm, 0.0])
+
+    im_i = convolve2gaussres(sky, xx, yy, gausspari, nthreads=1)
+    two_step = convolve2gaussres(im_i, xx, yy, gaussparf, nthreads=1, gausspari=gausspari)
+    direct = convolve2gaussres(sky, xx, yy, gaussparf, nthreads=1)
+
+    interior = slice(npix // 4, 3 * npix // 4)
+    err = np.abs(two_step[:, interior, interior] - direct[:, interior, interior]).max()
+    assert err < 1e-8 * np.abs(direct).max()
+
+
+@pmp(
+    "gausspari, gaussparf",
+    [
+        ((6.0, 4.0, 0.0), (5.0, 3.0, 0.0)),  # sharper on both axes
+        ((6.0, 4.0, 0.0), (7.0, 3.5, 0.0)),  # minor axis shrinks
+        ((10.0, 5.0, 0.0), (10.0, 5.0, 0.3)),  # same axes, rotated
+    ],
+)
+def test_convolve2gaussres_refuses_to_sharpen(gausspari, gaussparf):
+    """Sharpening is a deconvolution; say so instead of amplifying noise.
+
+    The rotated case is the one that catches callers by surprise:
+    restoration.lowest_resolution takes the max of each axis but the *mean* of
+    the position angles, so a band whose PA differs from the mean can land here
+    even though both its axes grew.
+    """
+    npix = 64
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 2, npix // 2] = 1.0
+
+    with pytest.raises(ValueError, match="deconvolution"):
+        convolve2gaussres(image, xx, yy, np.array(gaussparf), nthreads=1, gausspari=np.array(gausspari))
+
+
+def test_convolve2gaussres_allows_an_unchanged_resolution():
+    """gaussparf == gausspari must survive the positive semi-definite check."""
+    npix = 64
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 2 + 3, npix // 2 - 2] = 1.0
+    gausspar = np.array([6.0, 4.0, 0.7])
+
+    out = convolve2gaussres(image, xx, yy, gausspar, nthreads=1, gausspari=gausspar)
+
+    np.testing.assert_allclose(out, image, rtol=0, atol=1e-10)

--- a/tests/test_convolve2gaussres.py
+++ b/tests/test_convolve2gaussres.py
@@ -450,10 +450,10 @@ def test_convolve2gaussres_two_step_matches_direct_across_srf(srf):
 def test_convolve2gaussres_refuses_to_sharpen(gausspari, gaussparf):
     """Sharpening is a deconvolution; say so instead of amplifying noise.
 
-    The rotated case is the one that catches callers by surprise:
-    restoration.lowest_resolution takes the max of each axis but the *mean* of
-    the position angles, so a band whose PA differs from the mean can land here
-    even though both its axes grew.
+    The rotated case is the one that catches callers by surprise, and it is
+    what forced restoration.lowest_resolution to become a Loewner envelope
+    (D32): its old max-of-each-axis, mean-of-the-position-angles target landed
+    here routinely, with both axes grown.
     """
     npix = 64
     coord = -(npix // 2) + np.arange(npix)
@@ -463,6 +463,23 @@ def test_convolve2gaussres_refuses_to_sharpen(gausspari, gaussparf):
 
     with pytest.raises(ValueError, match="deconvolution"):
         convolve2gaussres(image, xx, yy, np.array(gaussparf), nthreads=1, gausspari=np.array(gausspari))
+
+
+def test_convolve2gaussres_rejects_xy_ordered_grids():
+    """The closed-form ratio reads the pixel size off xx/yy, so order matters.
+
+    np.meshgrid's *default* indexing is "xy", which transposes both grids and
+    makes the inferred spacings zero -- every frequency infinite and the whole
+    image NaN. Fail instead of returning that.
+    """
+    npix = 64
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord)  # note: no indexing="ij"
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 2, npix // 2] = 1.0
+
+    with pytest.raises(ValueError, match="indexing='ij'"):
+        convolve2gaussres(image, xx, yy, np.array([6.3, 4.2, 0.0]), nthreads=1, gausspari=np.array([6.0, 4.0, 0.0]))
 
 
 def test_convolve2gaussres_allows_an_unchanged_resolution():

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -398,6 +398,67 @@ def test_restore_zero_gausspar_selects_lowest_resolution(tmp_path):
         np.testing.assert_allclose(pf[2], 0.3, rtol=1e-6)  # mean pa
 
 
+def test_restore_cresidual_completes_the_restored_image(tmp_path):
+    """CRESIDUAL is exactly the term KIMAGE adds to the convolved model.
+
+    That is the whole point of storing it: the resolution change applied to the
+    residual is otherwise unrecoverable from the tree, so nothing records what
+    it did (issue #312).
+    """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kKsS", gausspar=(0.0, 0.0, 0.0))
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    for b in range(2):
+        ds = dt[f"band{b:04d}_time0000"].ds
+        assert "CRESIDUAL" in ds
+        model = ds.MODEL.values
+        _, ny, nx = model.shape
+        x = -(nx // 2) + np.arange(nx)
+        y = -(ny // 2) + np.arange(ny)
+        xx, yy = np.meshgrid(x, y, indexing="ij")
+        mconv = convolve2gaussres(
+            model, xx, yy, ds.PSFPARSF.values, nthreads=1, pfrac=0.2, norm_kernel=False, yx_order=True
+        )
+        np.testing.assert_allclose(mconv + ds.CRESIDUAL.values, ds.KIMAGE.values, rtol=0, atol=1e-5)
+
+
+def test_restore_cresidual_is_apparent_and_not_the_raw_residual(tmp_path):
+    """It is pre-beam-division, and it is not RESIDUAL untouched.
+
+    Apparent because that is the scale image-plane noise is flat on and BEAM is
+    already on the node; not RESIDUAL because the whole point is the resolution
+    change. RESIDUAL itself must survive unmodified.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+    before = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds.RESIDUAL.values.copy()
+
+    _run_restore(tmp_path, outputs="iIsS", gausspar=(0.0, 0.0, 0.0))
+
+    ds = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds
+    np.testing.assert_array_equal(ds.RESIDUAL.values, before)
+    raw = ds.RESIDUAL.values / ds.WSUM.values[:, None, None]
+    # band 0 is the narrow band, so it is genuinely broadened to reach the target
+    assert not np.allclose(ds.CRESIDUAL.values, raw, atol=1e-8)
+    # apparent: IMAGE divides it by the beam, CRESIDUAL does not
+    assert np.nanmax(np.abs(ds.CRESIDUAL.values)) < np.nanmax(np.abs(ds.CRESIDUAL.values / ds.BEAM.values)) * 1.001
+
+
+def test_restore_without_s_writes_no_cresidual(tmp_path):
+    """It is opt-in: a default run must not pay for another cube per band."""
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    _run_restore(tmp_path, outputs="kK")
+
+    assert "CRESIDUAL" not in xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds
+
+
 def test_restore_zero_gausspar_handles_bands_at_different_angles(tmp_path):
     """The real --gausspar 0 0 0 hazard: bands whose position angles differ.
 

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -434,6 +434,8 @@ def test_restore_cresidual_is_apparent_and_not_the_raw_residual(tmp_path):
     already on the node; not RESIDUAL because the whole point is the resolution
     change. RESIDUAL itself must survive unmodified.
     """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
     store = str(tmp_path / "rt_I.dt")
     _write_restore_dt(store)
     before = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds.RESIDUAL.values.copy()
@@ -445,8 +447,20 @@ def test_restore_cresidual_is_apparent_and_not_the_raw_residual(tmp_path):
     raw = ds.RESIDUAL.values / ds.WSUM.values[:, None, None]
     # band 0 is the narrow band, so it is genuinely broadened to reach the target
     assert not np.allclose(ds.CRESIDUAL.values, raw, atol=1e-8)
-    # apparent: IMAGE divides it by the beam, CRESIDUAL does not
-    assert np.nanmax(np.abs(ds.CRESIDUAL.values)) < np.nanmax(np.abs(ds.CRESIDUAL.values / ds.BEAM.values)) * 1.001
+
+    # apparent: the beam divide happens in IMAGE, not in CRESIDUAL, so what
+    # IMAGE adds to the convolved model is CRESIDUAL / BEAM and not CRESIDUAL.
+    # Band 1 carries the sub-unit beam, so it is the one where that differs.
+    ds1 = xr.open_datatree(store, engine="zarr", chunks=None)["band0001_time0000"].ds
+    beam = ds1.BEAM.values
+    assert beam.max() < 0.9, "a unit beam would make this vacuous"
+    _, ny, nx = ds1.MODEL.shape
+    xx, yy = np.meshgrid(-(nx // 2) + np.arange(nx), -(ny // 2) + np.arange(ny), indexing="ij")
+    mconv = convolve2gaussres(
+        ds1.MODEL.values, xx, yy, ds1.PSFPARSF.values, nthreads=1, pfrac=0.2, norm_kernel=False, yx_order=True
+    )
+    keep = beam > 0.1  # the pb_min core/restore.py defaults to
+    np.testing.assert_allclose((ds1.IMAGE.values - mconv)[keep], (ds1.CRESIDUAL.values / beam)[keep], rtol=0, atol=1e-5)
 
 
 def test_restore_without_s_writes_no_cresidual(tmp_path):

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -147,11 +147,85 @@ def test_clean_beam_zero_wsum_is_nan_not_a_crash():
     assert np.isnan(out).all()
 
 
-def test_lowest_resolution_takes_max_axes_and_mean_pa():
+def test_lowest_resolution_takes_max_axes_when_the_angles_agree():
+    """Aligned inputs: the answer is still just the max of each axis."""
     from pfb_imaging.utils.restoration import lowest_resolution
 
-    gp = np.array([[[6.0, 3.0, 0.2]], [[4.0, 5.0, 0.6]]])
-    np.testing.assert_allclose(lowest_resolution(gp), np.array([[6.0, 5.0, 0.4]]))
+    gp = np.array([[[6.0, 3.0, 0.2]], [[5.0, 4.0, 0.2]]])
+    np.testing.assert_allclose(lowest_resolution(gp), np.array([[6.0, 4.0, 0.2]]), rtol=1e-5)
+
+
+LOWEST_RESOLUTION_CASES = [
+    ([(10.0, 5.0, 0.3), (11.0, 5.4, 0.3), (12.0, 6.0, 0.3)], "aligned"),
+    ([(10.0, 5.0, 0.0), (10.2, 5.1, 0.15), (10.4, 5.2, -0.1)], "small pa spread"),
+    ([(10.0, 5.0, 0.0), (10.2, 5.1, 0.8), (9.8, 4.9, -0.7)], "large pa spread"),
+    ([(10.0, 5.0, 0.05), (10.1, 5.05, np.pi - 0.05)], "across the mod-pi seam"),
+    ([(20.0, 12.0, 0.4), (8.0, 4.0, -0.9), (7.0, 3.5, 1.2)], "one dominant band"),
+    ([(9.0, 8.9, 0.2), (9.1, 8.8, 1.3)], "near circular"),
+]
+
+
+@pytest.mark.parametrize("rows, label", LOWEST_RESOLUTION_CASES)
+def test_lowest_resolution_dominates_every_input(rows, label):
+    """Every input must be convolvable to the result.
+
+    Taking the max of each axis and the mean of the angles does not give this:
+    a rotated ellipse pokes out diagonally, so the difference of covariances is
+    indefinite and the "convolution" is a deconvolution along some direction.
+    Only one of these six cases passed under that heuristic (issue #312, D31).
+    """
+    from pfb_imaging.utils.misc import convolve2gaussres
+    from pfb_imaging.utils.restoration import lowest_resolution, resolution_deficit
+
+    gausspars = np.array(rows)[:, None, :]  # (n, ncorr=1, 3)
+    target = lowest_resolution(gausspars)
+
+    assert resolution_deficit(target, gausspars)[0] <= 1.0
+
+    # and end to end: convolve2gaussres must accept every one of them
+    npix = 128
+    coord = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(coord, coord, indexing="ij")
+    image = np.zeros((1, npix, npix))
+    image[0, npix // 2 + 3, npix // 2 - 2] = 1.0
+    for row in rows:
+        convolve2gaussres(image, xx, yy, target[0], nthreads=1, gausspari=np.array(row))
+
+
+def test_lowest_resolution_averages_position_angles_modulo_pi():
+    """PA is defined mod pi, so 0.05 and pi - 0.05 are nearly the same angle.
+
+    np.mean puts them at pi/2, orthogonal to both, which then needs a hugely
+    inflated beam to still dominate. The circular mean keeps them together.
+    """
+    from pfb_imaging.utils.restoration import lowest_resolution
+
+    gp = np.array([[[10.0, 5.0, 0.05]], [[10.0, 5.0, np.pi - 0.05]]])
+    target = lowest_resolution(gp)[0]
+
+    assert abs(target[2]) < 0.1 or abs(abs(target[2]) - np.pi) < 0.1
+    # near-aligned inputs need only a slight inflation, not a near-circular beam
+    assert target[0] / target[1] > 1.8
+
+
+def test_lowest_resolution_skips_nan_rows():
+    """Fully flagged bands come through as NaN and must not poison the result."""
+    from pfb_imaging.utils.restoration import lowest_resolution
+
+    gp = np.array([[[10.0, 5.0, 0.2]], [[np.nan] * 3], [[11.0, 5.5, 0.2]]])
+    np.testing.assert_allclose(lowest_resolution(gp), np.array([[11.0, 5.5, 0.2]]), rtol=1e-5)
+
+    assert np.isnan(lowest_resolution(np.array([[[np.nan] * 3]]))).all()
+
+
+def test_resolution_deficit_flags_a_target_that_is_too_sharp():
+    """The guard the --gausspar branch uses to fail early with a useful message."""
+    from pfb_imaging.utils.restoration import resolution_deficit
+
+    gausspars = np.array([[[10.0, 5.0, 0.0]], [[10.0, 5.0, 0.6]]])
+
+    assert resolution_deficit(np.array([[10.0, 5.0, 0.0]]), gausspars)[0] > 1.0
+    assert resolution_deficit(np.array([[20.0, 20.0, 0.0]]), gausspars)[0] <= 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -322,6 +396,46 @@ def test_restore_zero_gausspar_selects_lowest_resolution(tmp_path):
         np.testing.assert_allclose(pf[0], 10.0, rtol=1e-6)  # max emaj over bands
         np.testing.assert_allclose(pf[1], 6.0, rtol=1e-6)  # max emin over bands
         np.testing.assert_allclose(pf[2], 0.3, rtol=1e-6)  # mean pa
+
+
+def test_restore_zero_gausspar_handles_bands_at_different_angles(tmp_path):
+    """The real --gausspar 0 0 0 hazard: bands whose position angles differ.
+
+    Max-of-each-axis with the mean angle is not wide enough to contain a
+    rotated ellipse, so restoring to it is a deconvolution along some direction
+    (issue #312). The envelope must both complete and dominate every band.
+    """
+    from pfb_imaging.utils.restoration import resolution_deficit
+
+    store = str(tmp_path / "rt_I.dt")
+    gpars = ((10.0, 5.0, 0.0), (10.4, 5.2, 0.7))
+    _write_restore_dt(store, gpars=gpars)
+
+    _run_restore(tmp_path, outputs="kK", gausspar=(0.0, 0.0, 0.0))
+
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    target = dt["band0000_time0000"].ds.PSFPARSF.values  # (ncorr, 3)
+    # every band shares the target, and the target contains every band
+    for b in range(2):
+        np.testing.assert_allclose(dt[f"band{b:04d}_time0000"].ds.PSFPARSF.values, target, rtol=1e-12)
+    assert resolution_deficit(target, np.array(gpars)[:, None, :])[0] <= 1.0
+    # the old max-axis, mean-pa answer would not have contained them
+    old = np.array([[10.4, 5.2, 0.35]])
+    assert resolution_deficit(old, np.array(gpars)[:, None, :])[0] > 1.0
+
+
+def test_restore_gausspar_sharper_than_the_data_raises(tmp_path):
+    """An impossible --gausspar must say so, not ring the image.
+
+    The old code divided by a near-zero transform and returned noise; the error
+    names the factor short and the resolution that would work.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+    cell_deg = np.rad2deg(1.0e-6)
+
+    with pytest.raises(ValueError, match="deconvolution"):
+        _run_restore(tmp_path, outputs="kK", gausspar=(4.0 * cell_deg, 2.0 * cell_deg, 0.3))
 
 
 def test_restore_skips_zero_wsum_bands(tmp_path):


### PR DESCRIPTION
Closes #312. Based on `issue307` so the diff is only this work — retarget to `dev-0.1.0` once #308 lands.

## The bug

`convolve2gaussres` changed an image's resolution by FFT-ing two sampled `gaussian2d` kernels and dividing (`convkernhat[msk] = gausskernhat[msk] / thiskernhat[msk]`, masked only by `> 0.0`). #312 measured that **displacing sources**: a delta at (170, 260) came out at (146, 260) with −0.81 of peak in ringing. It reaches users through `pfb restore --gausspar` and the lowest-resolution mode.

The issue diagnosed one of **two** independent error sources, and the proposed support widening only fixes that one:

1. **Truncation.** `gaussian2d` cut its kernel at 5 **standard deviations**, leaving a step of `exp(−12.5) = 3.7e-6` of peak whose spectral ripple dwarfs the transform's own ~1e-14 floor near Nyquist.
2. **Round-off.** A *sampled* Gaussian's DFT sinks into FFT round-off before Nyquist whatever its support, so past that point the quotient is noise over noise — unbounded, since the mask was `> 0.0`. This one gets **worse as the beam is better sampled**, i.e. it grows with `--super-resolution-factor`, which is the opposite of the intuition.

## The fix

The ratio of two Gaussian transforms is itself a Gaussian, so write it down instead of dividing samples:

```
Kf(k) / Ki(k) = sqrt(|Σf| / |Σi|) · exp(−2π² · kᵀ(Σf − Σi) k)
```

evaluated directly on the padded rfft grid (`gauss_cov`, `gauss_ratio_hat`). It has neither problem, conserves flux exactly, and costs two FFTs less per plane. `gaussian2d`'s support still widens to `nfwhm` major-axis FWHMs (renamed from `nsigma` to say so) for spimple parity, but no longer carries correctness. A non-PSD `Σf − Σi` — a deconvolution — now raises instead of being applied. The `gausspari=None` path (a plain convolution) is untouched.

Measured on a band-limited sky with a matched `2·srf` px beam, the two-step invariant (`sky→gi→gf` vs `sky→gf`) as a fraction of peak:

| srf | sampled division | closed form |
|-----|-----------------|-------------|
| 2 | 4.0e-10 | 8.1e-10 |
| 3 | **1.8e-3** | 6e-16 |
| 4 | **1.4e-4** | 6e-16 |

Flux through a resolution change was off by **+6%** at a 6 px beam and **−25%** at 12 px; it is now exact.

## What the new check immediately exposed

`restoration.lowest_resolution` had been producing **invalid targets all along** — of six representative band sets, only the perfectly-aligned one gave a target every band can actually be convolved to. Three defects in one line (`nanmax(emaj)`, `nanmax(emin)`, `nanmean(pa)`):

- **Rotation.** "At least as wide as every input" is a statement about covariances in the Loewner order, not about the axes separately. Eigenvalues 4 and 1 at 45° project to 2.5 on both coordinate axes, and `2.5·I` does not dominate them.
- **`nanmean` on angles.** PA is defined mod π, so 0.05 and π − 0.05 are near-identical orientations that average to π/2 — orthogonal to both.
- **The MFS beam.** It is `fitcleanbeam(Σ_b PSF_b)`, not an average of the band fits (D29), so nothing bounds it by the per-band envelope — yet it is reconvolved to the same target.

`lowest_resolution` is now the smallest ellipse dominating every input in the Loewner order: candidate shapes (max axes at the circular-mean PA and at each input's PA, crossed with five axis ratios) each inflated by the largest generalised eigenvalue of the pencil, smallest area winning. `resolution_deficit` exposes the same quantity so the explicit `--gausspar` branch fails early, naming the shortfall factor and the viable floor, instead of failing inside an FFT.

**Resolution cost:** with aligned PAs the answer is bit-identical to the old one. Otherwise the restoring beam grows 1.02× to 2.0× in area over the six cases — real, and the honest price of a target every band can reach.

## `--outputs s`/`S` → `CRESIDUAL`

The restored image is `MODEL ⊗ G + (RESIDUAL/WSUM) ⊗ [G/PSFPARSN_b]`, and that second term was computed and discarded — so "what did homogenisation do to the residual" could only be answered by redoing the convolution with the exact `G` and `PSFPARSN_b` of the run. `--outputs s`/`S` now stores it as `CRESIDUAL`, apparent and pre-beam-division, off by default. `MODEL ⊗ G + CRESIDUAL` reproduces `KIMAGE` exactly, which is what the tests pin.

This matters because that term is the leading suspect for the ripples left in a per-pixel spectral-index fit; `scripts/check_spi_ripples.py` is the seven-diagnostic probe for that question, with a self-check that feeds it exactly-Gaussian PSFs and asserts the consistency ratio is 1, so a convention error cannot masquerade as a detection.

## Review pass on my own work

Three findings from re-reading the branch before opening this:

- The closed form reads the pixel size off `xx`/`yy` rather than evaluating a kernel on them, so `np.meshgrid`'s **default** `indexing="xy"` gave zero spacings, infinite frequencies and an **all-NaN image with no error**. The sampled division it replaced was immune. Now raises, and pinned.
- Two deferred `gauss_cov` imports in `restoration.py` claimed an import cycle with `utils.misc` that cannot exist — the module already imports `convolve2gaussres` from it at top level. Hoisted.
- `test_restore_cresidual_is_apparent_and_not_the_raw_residual` asserted `|CRESIDUAL| < |CRESIDUAL/BEAM|`, true for any beam ≤ 1 and so pinning nothing. It now checks `IMAGE − MODEL ⊗ G == CRESIDUAL / BEAM`.

## Notes for the reviewer

- **`nsigma` → `nfwhm` on `gaussian2d` is a signature change.** No in-repo caller passes it by keyword; `nsigma` survives in `fitcleanbeam`, where it does mean standard deviations.
- **`lowest_resolution`'s candidate sweep is a search, not a proof of optimality.** Every candidate is *valid* by construction (the inflation guarantees domination); the sweep only picks the smallest of `(n+1) × 5`. Sub-optimal by at most a few percent, and microseconds either way.
- `scripts/check_spi_ripples.py` is a diagnostic probe, not a test — it wants a restored `.dt` on disk. It was named `test_spi_ripples.py`, which read as a pytest module; renamed to match its `check_*`/`profile_*` siblings.

## Verification

```
uv run pytest tests/ -m ""   →  669 passed in 475s
uv run ruff format --check . →  116 files already formatted
uv run ruff check .          →  All checks passed
hip-cargo generate-cabs      →  clean diff
```

Wiki: **D31** (closed-form ratio), **D32** (Loewner envelope), **D33** (`CRESIDUAL`), plus two new gotchas — never divide two sampled kernels' FFTs, and the `indexing="ij"` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
