### PR TITLE
deconv: --eta-in-grad and --mop

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -137,7 +137,8 @@ falls back to `DIRTY` when it is absent.
 **Image-space arrays are (Y, X)-ordered end to end** — `.dt` dims `("corr", "y", "x")` etc.,
 scratch beam `("corr", "m_beam", "l_beam")`; ducc's x-major world exists only behind zero-copy
 `.T` views at the wgridder call sites (wiki design-decisions D19/D20).
-`MODEL`/`RESIDUAL`/`NOISE` are added later by the `deconv` consumer, and
+`MODEL`/`RESIDUAL`/`NOISE` are added later by the `deconv` consumer (plus
+`MODEL_MOPPED`/`RESIDUAL_MOPPED` when `--mop` is on, the default — wiki D35), and
 `IMAGE`/`BIMAGE`/`KIMAGE` plus `PSFPARSF` by the `restore` consumer (the intrinsic,
 apparent and mixed flux scales — wiki D29), and optionally `CRESIDUAL` (`--outputs s`/`S`),
 the residual convolved to the restoring resolution — apparent, pre-beam-division, and the

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -1206,7 +1206,14 @@ update it (and this page's `last_verified_commit`) in the same session.
   band coupling directly.
 - **Consequences:** `MODEL` is untouched — the mopped model is `MODEL` plus a least-squares
   update, so it is neither sparse nor a component model, and it does **not** go through
-  `model_to_ds`; there is no `.mds`/`degrid` path for it. The mop write goes to the band nodes
+  `model_to_ds`; there is no `.mds`/`degrid` path for it.
+  **The mop right-hand side is the pure data gradient, never the `--eta-in-grad`-corrected
+  one.** "Near perfect residual" means the *data* residual is near zero, so the direction
+  wanted is `M⁻¹r_data`. Solving against `r_data − K⁻¹m` instead collapses the mop to nothing
+  exactly where it is wanted: at a regularised fixed point that gradient is ~0, so
+  `MODEL_MOPPED → MODEL`. It also keeps `MODEL_MOPPED` meaning the same thing with and
+  without D34, which is what makes the two comparable
+  (`test_mop_uses_the_data_gradient_not_the_eta_corrected_one`). The mop write goes to the band nodes
   *after* the major-cycle write, and `to_zarr(mode="a")` replaces attrs wholesale, so it
   extends the attrs the loop last wrote (`final_attrs`) rather than the band's original ones —
   building it from `band_attrs` silently dropped `niters`/`rms`/`hess_norm`/`hess_norm_opts`,

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,7 +3,7 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-09-07T18:00:00Z
+timestamp: 2026-09-08T10:00:00Z
 last_verified_commit: 3699b79
 ---
 
@@ -1152,6 +1152,75 @@ update it (and this page's `last_verified_commit`) in the same session.
   `restore_products`); `src/pfb_imaging/core/restore.py`; `src/pfb_imaging/cli/restore.py`;
   `scripts/check_spi_ripples.py`; `tests/test_restore.py::test_restore_cresidual_completes_the_restored_image`,
   `…_is_apparent_and_not_the_raw_residual`, `test_restore_without_s_writes_no_cresidual`.
+
+### D34 — `--eta-in-grad` moves the prior from the preconditioner into the objective
+
+- **Context:** the `eta` term (and, since D30, the whole frequency prior) entered `M` only,
+  never `residual_from_partitions`. That is what makes it a *preconditioner*: preconditioned
+  Richardson converges to `A⁻¹b` for any nonsingular `M` (D22), so the prior reshaped every
+  forward update while leaving the fixed point and the flux scale exactly where they were
+  (`test_frequency_prior_does_not_move_the_fixed_point`). Issue #310 asked what happens when
+  it enters the objective instead.
+- **Decision:** `--eta-in-grad` (default **off**, so nothing changes unasked). The objective
+  gains `½ mᵀK⁻¹m`, whose gradient is `K⁻¹m`, and in pfb's sign convention (`residual =
+  −grad`) both the apparent and beam-attenuated gradients lose that term. `K⁻¹` is applied by
+  `HessTreeRay.prior_dot`, which is the *same* term `dot` adds — never a re-derived `eta*x`,
+  which would drift the moment `--gp-length-scale` or `--eta-mode` is on.
+- **Rationale — two things the correction deliberately does not do.** (1) **No beam.**
+  `bresidual` carries the outer per-partition beam because the data Hessian is `B GᵀWG B`
+  (D23), but the prior acts on the *intrinsic* model, so `K⁻¹` has no beam on either side and
+  the identical term comes off both gradients. (2) **No rescaling.** The residuals reaching
+  the solver are already divided by the total wsum, which is the operator `prior_dot` is
+  defined on (`--eta` is a fraction of the total wsum, D4).
+- **Consequences:** with the flag, "converged" means the *regularised* gradient is small, and
+  `--rmsfactor`'s λ is derived from it — so the L1 threshold shifts too. `RESIDUAL`/`BRESIDUAL`
+  keep storing the **pure data term** whatever the flag: a resumed run reads `BRESIDUAL` and
+  applies the prior itself, so an eta-inclusive stored gradient would double-count on every
+  restart. The flag therefore changes what is *reported* (FITS, rms, λ), not what is stored.
+  Combined with D30 this is the knob that makes the frequency prior actual regularisation
+  rather than preconditioning — the two are different experiments.
+- **Source:** issue #310; `src/pfb_imaging/core/deconv.py` (`_grad_with_prior`);
+  `src/pfb_imaging/operators/hessian.py` (`prior_dot`, `_prior_s`);
+  `tests/test_hess_tree_ray.py::test_prior_dot_is_exactly_the_non_data_part_of_m`,
+  `tests/test_deconv.py::test_eta_in_grad_changes_the_update_once_the_model_is_nonzero`,
+  `…_is_a_no_op_on_the_first_step_from_a_zero_model`, `test_grad_with_prior_subtracts_the_prior_term_on_the_normalised_scale`.
+
+### D35 — `--mop` stores the near-perfect-residual model, solved fresh at the final model
+
+- **Context:** a prior necessarily makes the residual look worse — that is what a prior does.
+  But `A(m + M⁻¹r) = Am + AM⁻¹r ≈ Am + r = data` wherever `M ≈ A`, so `m + M⁻¹r` is the model
+  whose residual is near perfect. Issue #311 asked for that pair as a stored product.
+- **Decision:** `--mop` (default **on**) writes `MODEL_MOPPED`/`RESIDUAL_MOPPED` to each band
+  node plus `_model_mopped`/`_residual_mopped` MFS FITS. The update is **solved fresh** after
+  the loop, not taken from the loop's last forward step: that update was computed at the
+  *pre-backward* model, so `model + update` is the near-perfect point only if the prox barely
+  moved — true at convergence, false on a `niter` or divergence exit. `bresidual` is already
+  the gradient against the final model, so the extra cost is one CG solve and **no** extra
+  gridding for the gradient (one sweep is still needed for `RESIDUAL_MOPPED` itself).
+- **Rationale:** `restore` is already parameterised on its input variables, so
+  `pfb restore --model-name MODEL_MOPPED --residual-name RESIDUAL_MOPPED` builds restored
+  images — and thence a spectral index map — with **no restore change at all**
+  (`test_restore_consumes_the_mopped_products` keeps that true). This is also where D30's
+  frequency prior reaches the *output*: the deconvolved model's fixed point is
+  prior-independent without D34, but the mop update **is** `M⁻¹r` and therefore carries the
+  band coupling directly.
+- **Consequences:** `MODEL` is untouched — the mopped model is `MODEL` plus a least-squares
+  update, so it is neither sparse nor a component model, and it does **not** go through
+  `model_to_ds`; there is no `.mds`/`degrid` path for it. The mop write goes to the band nodes
+  *after* the major-cycle write, and `to_zarr(mode="a")` replaces attrs wholesale, so it
+  extends the attrs the loop last wrote (`final_attrs`) rather than the band's original ones —
+  building it from `band_attrs` silently dropped `niters`/`rms`/`hess_norm`/`hess_norm_opts`,
+  which would restart a resumed run from iteration 0 (caught by
+  `test_mop_preserves_the_run_attrs`). **Interpretation warning:** the mopped residual is
+  near zero by construction, which removes the D33 ripple source (a residual reconvolved from
+  a Gaussian fit to a non-Gaussian dirty beam) — so a cleaner spectral index map off mopped
+  products is *not* by itself evidence about the prior.
+- **Source:** issue #311; `src/pfb_imaging/core/deconv.py`; `src/pfb_imaging/cli/deconv.py`;
+  `tests/test_deconv.py::test_deconv_groundtruth` (the residual-reduction claim, on
+  consistent data — see the note there on why the synthetic tree cannot carry it),
+  `…test_mop_writes_mopped_products_by_default`, `…test_no_mop_writes_neither_product`,
+  `…test_mop_leaves_the_deconvolved_model_alone`, `…test_mop_preserves_the_run_attrs`,
+  `tests/test_restore.py::test_restore_consumes_the_mopped_products`.
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -4,7 +4,7 @@ title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
 timestamp: 2026-09-08T10:00:00Z
-last_verified_commit: 3699b79
+last_verified_commit: 64bae7c
 ---
 
 # Design decisions, known debt and recurring gotchas

--- a/src/pfb_imaging/_container_image.py
+++ b/src/pfb_imaging/_container_image.py
@@ -1,1 +1,1 @@
-CONTAINER_IMAGE = "ghcr.io/ratt-ru/pfb-imaging:dev-0.1.0"
+CONTAINER_IMAGE = "ghcr.io/ratt-ru/pfb-imaging:issue310-311"

--- a/src/pfb_imaging/cabs/deconv.yml
+++ b/src/pfb_imaging/cabs/deconv.yml
@@ -155,6 +155,16 @@ cabs:
         default: 100.0
         metadata:
           rich_help_panel: PFB
+      mop:
+        info:
+          Compute the mopped model and residual at the end of the run.
+          The final forward update is added to the model, which very nearly cancels the residual.
+          Stored as MODEL_MOPPED and RESIDUAL_MOPPED for restore to consume.
+          Costs one extra forward solve and one gridding sweep.
+        dtype: bool
+        default: true
+        metadata:
+          rich_help_panel: PFB
       eta-in-grad:
         info:
           Include the eta term in the gradient, not only in the preconditioner.

--- a/src/pfb_imaging/cabs/deconv.yml
+++ b/src/pfb_imaging/cabs/deconv.yml
@@ -5,7 +5,7 @@ cabs:
     name: deconv
     info:
       General deconvolution of the imager DataTree via composable forward/backward algorithms.
-    image: ghcr.io/ratt-ru/pfb-imaging:dev-0.1.0
+    image: ghcr.io/ratt-ru/pfb-imaging:issue310-311
     inputs:
       output-filename:
         info:
@@ -153,6 +153,16 @@ cabs:
           Ignored when eta-mode is unset.
         dtype: float
         default: 100.0
+        metadata:
+          rich_help_panel: PFB
+      eta-in-grad:
+        info:
+          Include the eta term in the gradient, not only in the preconditioner.
+          By default the prior shapes each update without entering the objective.
+          It therefore cannot move the fixed point.
+          With this set the reported residual is the gradient of the regularised objective.
+        dtype: bool
+        default: false
         metadata:
           rich_help_panel: PFB
       gp-length-scale:

--- a/src/pfb_imaging/cabs/degrid.yml
+++ b/src/pfb_imaging/cabs/degrid.yml
@@ -6,7 +6,7 @@ cabs:
     info:
       Degrid visibilities from model image(s) into measurement set.
       The model image needs to be in component format.
-    image: ghcr.io/ratt-ru/pfb-imaging:dev-0.1.0
+    image: ghcr.io/ratt-ru/pfb-imaging:issue310-311
     inputs:
       ms:
         info:

--- a/src/pfb_imaging/cabs/hci.yml
+++ b/src/pfb_imaging/cabs/hci.yml
@@ -5,7 +5,7 @@ cabs:
     name: hci
     info:
       High cadence imaging algorithm.
-    image: ghcr.io/ratt-ru/pfb-imaging:dev-0.1.0
+    image: ghcr.io/ratt-ru/pfb-imaging:issue310-311
     inputs:
       ms:
         info:

--- a/src/pfb_imaging/cabs/imager.yml
+++ b/src/pfb_imaging/cabs/imager.yml
@@ -5,7 +5,7 @@ cabs:
     name: imager
     info:
       Initialise Stokes data products.
-    image: ghcr.io/ratt-ru/pfb-imaging:dev-0.1.0
+    image: ghcr.io/ratt-ru/pfb-imaging:issue310-311
     inputs:
       ms:
         info:

--- a/src/pfb_imaging/cabs/restore.yml
+++ b/src/pfb_imaging/cabs/restore.yml
@@ -5,7 +5,7 @@ cabs:
     name: restore
     info:
       Restore model images and.or convolved images to common resolution.
-    image: ghcr.io/ratt-ru/pfb-imaging:dev-0.1.0
+    image: ghcr.io/ratt-ru/pfb-imaging:issue310-311
     inputs:
       output-filename:
         info:

--- a/src/pfb_imaging/cli/deconv.py
+++ b/src/pfb_imaging/cli/deconv.py
@@ -206,6 +206,16 @@ def deconv(
             rich_help_panel="PFB",
         ),
     ] = 100.0,
+    eta_in_grad: Annotated[
+        bool,
+        typer.Option(
+            help="Include the eta term in the gradient, not only in the preconditioner. "
+            "By default the prior shapes each update without entering the objective. "
+            "It therefore cannot move the fixed point. "
+            "With this set the reported residual is the gradient of the regularised objective.",
+            rich_help_panel="PFB",
+        ),
+    ] = False,
     gp_length_scale: Annotated[
         float | None,
         typer.Option(
@@ -535,6 +545,7 @@ def deconv(
                     eta=eta,
                     eta_mode=eta_mode,
                     eta_cap=eta_cap,
+                    eta_in_grad=eta_in_grad,
                     gp_length_scale=gp_length_scale,
                     gp_cap=gp_cap,
                     gamma=gamma,
@@ -597,6 +608,7 @@ def deconv(
                 eta=eta,
                 eta_mode=eta_mode,
                 eta_cap=eta_cap,
+                eta_in_grad=eta_in_grad,
                 gp_length_scale=gp_length_scale,
                 gp_cap=gp_cap,
                 gamma=gamma,
@@ -668,6 +680,7 @@ def deconv(
             eta=eta,
             eta_mode=eta_mode,
             eta_cap=eta_cap,
+            eta_in_grad=eta_in_grad,
             gp_length_scale=gp_length_scale,
             gp_cap=gp_cap,
             gamma=gamma,

--- a/src/pfb_imaging/cli/deconv.py
+++ b/src/pfb_imaging/cli/deconv.py
@@ -206,6 +206,16 @@ def deconv(
             rich_help_panel="PFB",
         ),
     ] = 100.0,
+    mop: Annotated[
+        bool,
+        typer.Option(
+            help="Compute the mopped model and residual at the end of the run. "
+            "The final forward update is added to the model, which very nearly cancels the residual. "
+            "Stored as MODEL_MOPPED and RESIDUAL_MOPPED for restore to consume. "
+            "Costs one extra forward solve and one gridding sweep.",
+            rich_help_panel="PFB",
+        ),
+    ] = True,
     eta_in_grad: Annotated[
         bool,
         typer.Option(
@@ -545,6 +555,7 @@ def deconv(
                     eta=eta,
                     eta_mode=eta_mode,
                     eta_cap=eta_cap,
+                    mop=mop,
                     eta_in_grad=eta_in_grad,
                     gp_length_scale=gp_length_scale,
                     gp_cap=gp_cap,
@@ -608,6 +619,7 @@ def deconv(
                 eta=eta,
                 eta_mode=eta_mode,
                 eta_cap=eta_cap,
+                mop=mop,
                 eta_in_grad=eta_in_grad,
                 gp_length_scale=gp_length_scale,
                 gp_cap=gp_cap,
@@ -680,6 +692,7 @@ def deconv(
             eta=eta,
             eta_mode=eta_mode,
             eta_cap=eta_cap,
+            mop=mop,
             eta_in_grad=eta_in_grad,
             gp_length_scale=gp_length_scale,
             gp_cap=gp_cap,

--- a/src/pfb_imaging/core/deconv.py
+++ b/src/pfb_imaging/core/deconv.py
@@ -347,6 +347,10 @@ def deconv(
             f"eta_mode '{eta_mode}': {etas.min():.3e} to {etas.max():.3e} "
             f"({etas.max() / etas.min():.1f}x), band-to-band spread {100 * spread:.2f}% -> {name}"
         )
+        # nothing reads it again, but a local outlives the whole run: ~1 GB of
+        # f8 at 4096^2 x 8 bands, and HessTreeRay._prior_s keeps its own copy
+        # of sqrt(D) when --eta-in-grad is on
+        del etas
 
     # the prior is the only band-coupling channel in M besides the prox, so its
     # spectrum is what to read when a GP run converges differently (issue #307)
@@ -554,9 +558,18 @@ def deconv(
         # moved -- true at convergence, false on a maxiter or divergence exit.
         # bresidual is already the gradient against the final model, so the
         # extra cost is one CG solve and no extra gridding for the gradient.
+        # The right-hand side is the pure DATA gradient, never the
+        # eta-corrected one. "Near perfect residual" means the *data* residual
+        # is near zero, so the direction wanted is M^-1 r_data. Solving against
+        # r_data - K^-1 m instead would make the mop collapse to nothing
+        # exactly where it is wanted: at a regularised fixed point that
+        # gradient is ~0, so MODEL_MOPPED -> MODEL and nothing is mopped.
+        # It also keeps MODEL_MOPPED meaning the same thing with and without
+        # --eta-in-grad, which is what makes the two comparable.
         log.info("Mopping: solving for the final update against the converged model")
-        solver.first(bresidual)
-        update_mop = solver.forward(bresidual)
+        bresidual_data = bresidual_raw / wsum
+        solver.first(bresidual_data)
+        update_mop = solver.forward(bresidual_data)
         model_mopped = model + update_mop
         model_mopped_mfs = np.mean(model_mopped[fsel], axis=0)
         save_fits(model_mopped_mfs, fits_oname + f"_{suffix}_model_mopped.fits", hdr_mfs, yx_order=True)

--- a/src/pfb_imaging/core/deconv.py
+++ b/src/pfb_imaging/core/deconv.py
@@ -60,6 +60,40 @@ def _cached_hess_norm(attrs, opts):
     return float(attrs["hess_norm"])
 
 
+def _grad_with_prior(residual, bresidual, model, hess):
+    """Add the preconditioner's prior term to the data gradient (issue #310).
+
+    Without ``--eta-in-grad`` the prior lives in ``M`` only, so it reshapes
+    each update without entering the objective: the fixed point is the
+    unregularised one and the reported residual is the pure data misfit. With
+    the flag, the objective gains ``0.5 m^T K^-1 m``, whose gradient is
+    ``K^-1 m``, and in pfb's sign convention (residual = -grad) both gradients
+    lose it.
+
+    No scaling: ``residual``/``bresidual`` are already divided by the total
+    wsum and ``prior_dot`` is defined on that same normalised operator (--eta
+    is a fraction of the total wsum, wiki D4).
+
+    The beam is deliberately absent from the correction. ``bresidual`` carries
+    the outer per-partition beam because the data Hessian is ``B G^T W G B``
+    (D23), but the prior acts on the intrinsic model, so ``K^-1`` has no beam
+    on either side and the same term is subtracted from both.
+
+    Args:
+        residual: ``(nband, ny, nx)`` apparent data gradient, wsum-normalised.
+        bresidual: ``(nband, ny, nx)`` beam-attenuated data gradient.
+        model: ``(nband, ny, nx)`` current model.
+        hess: The preconditioner, supplying ``prior_dot``.
+
+    Returns:
+        ``(residual, bresidual)``, both new arrays. The inputs are untouched --
+        the raw versions of these are what get stored, and storing an
+        eta-inclusive gradient would double-count it on the next resume.
+    """
+    kinv_m = hess.prior_dot(model)
+    return residual - kinv_m, bresidual - kinv_m
+
+
 def deconv(
     output_filename: str,
     suffix: str = "main",
@@ -81,6 +115,7 @@ def deconv(
     eta: float = 0.001,
     eta_mode: str | None = None,
     eta_cap: float = 100.0,
+    eta_in_grad: bool = False,
     gp_length_scale: float | None = None,
     gp_cap: float = 10.0,
     gamma: float = 0.95,
@@ -322,6 +357,13 @@ def deconv(
             f"{stats['lam_min']:.3e} to {stats['lam_max']:.3e}"
         )
 
+    # the initial gradient came from the tree (or is BDIRTY on a fresh one),
+    # so it is the data term; correct it before the first forward solve
+    if eta_in_grad:
+        log.info("Including the eta term in the gradient (--eta-in-grad)")
+        residual, bresidual = _grad_with_prior(residual, bresidual, model, solver.hess)
+        residual_mfs = np.sum(residual, axis=0)
+
     if rms_outside_model and model.any():
         rms = np.std(residual_mfs[model_mfs == 0])
     else:
@@ -420,6 +462,8 @@ def deconv(
         bresidual_raw = bresidual_raw[:, 0]
         residual = residual_raw / wsum
         bresidual = bresidual_raw / wsum
+        if eta_in_grad:
+            residual, bresidual = _grad_with_prior(residual, bresidual, model, solver.hess)
         residual_mfs = np.sum(residual, axis=0)
         save_fits(residual_mfs, fits_oname + f"_{suffix}_residual_{k + 1}.fits", hdr_mfs, yx_order=True)
 

--- a/src/pfb_imaging/core/deconv.py
+++ b/src/pfb_imaging/core/deconv.py
@@ -116,6 +116,7 @@ def deconv(
     eta_mode: str | None = None,
     eta_cap: float = 100.0,
     eta_in_grad: bool = False,
+    mop: bool = True,
     gp_length_scale: float | None = None,
     gp_cap: float = 10.0,
     gamma: float = 0.95,
@@ -400,6 +401,9 @@ def deconv(
     if debug:
         _chi2_snapshot(iter0)  # baseline against the starting model
 
+    # what was last written to each band node's attrs; the mop block writes
+    # again afterwards and to_zarr replaces attrs wholesale
+    final_attrs = [dict(a) for a in band_attrs]
     mrange = range(iter0, iter0 + niter)
     for k in mrange:
         log.info("Solving for update")
@@ -509,17 +513,17 @@ def deconv(
             # legacy sara() convention of ds.assign_attrs(**attrs) onto a
             # dataset read from the existing dds, which merges rather than
             # replaces.
-            ds_out = xr.Dataset(
-                data_vars,
-                attrs={
-                    **band_attrs[b],
-                    "rms": best_rms,
-                    "rmax": best_rmax,
-                    "niters": k + 1,
-                    "hess_norm": hess_norm,
-                    "hess_norm_opts": _m_signature(opts_dict),
-                },
-            )
+            # to_zarr REPLACES attrs, so anything written later must start
+            # from these, not from band_attrs (the mop block below does)
+            final_attrs[b] = {
+                **band_attrs[b],
+                "rms": best_rms,
+                "rmax": best_rmax,
+                "niters": k + 1,
+                "hess_norm": hess_norm,
+                "hess_norm_opts": _m_signature(opts_dict),
+            }
+            ds_out = xr.Dataset(data_vars, attrs=final_attrs[b])
             ds_out.to_zarr(dt_name, group=n, mode="a")
 
         log.info(f"Iter {k + 1}: peak residual = {rmax:.3e}, rms = {rms:.3e}, eps = {eps:.3e}")
@@ -536,6 +540,51 @@ def deconv(
             if diverge_count_curr > diverge_count:
                 log.info("Algorithm is diverging. Terminating.")
                 break
+
+    if mop:
+        # Mopped products (#311). A prior necessarily makes the residual look
+        # worse, but m + M^-1 r very nearly cancels it: A(m + M^-1 r) = A m +
+        # A M^-1 r ~= A m + r = data whenever M ~= A. So this is the model whose
+        # residual is near perfect, and the pair is stored so `restore` can
+        # build restored images from it (--model-name/--residual-name).
+        #
+        # The update is solved FRESH here rather than reusing the loop's last
+        # one. That update was computed at the pre-backward model, so
+        # model + update is only the near-perfect point if the prox barely
+        # moved -- true at convergence, false on a maxiter or divergence exit.
+        # bresidual is already the gradient against the final model, so the
+        # extra cost is one CG solve and no extra gridding for the gradient.
+        log.info("Mopping: solving for the final update against the converged model")
+        solver.first(bresidual)
+        update_mop = solver.forward(bresidual)
+        model_mopped = model + update_mop
+        model_mopped_mfs = np.mean(model_mopped[fsel], axis=0)
+        save_fits(model_mopped_mfs, fits_oname + f"_{suffix}_model_mopped.fits", hdr_mfs, yx_order=True)
+
+        log.info("Mopping: computing the residual against the mopped model")
+        residual_mopped_raw, _ = workers.residual(
+            model_mopped[:, None],
+            cell_rad,
+            epsilon=epsilon,
+            do_wgridding=do_wgridding,
+            double_accum=double_accum,
+        )
+        residual_mopped_raw = residual_mopped_raw[:, 0]
+        residual_mopped_mfs = np.sum(residual_mopped_raw / wsum, axis=0)
+        save_fits(residual_mopped_mfs, fits_oname + f"_{suffix}_residual_mopped.fits", hdr_mfs, yx_order=True)
+        log.info(
+            f"Mopped peak residual = {np.abs(residual_mopped_mfs).max():.3e} "
+            f"(deconvolved {np.abs(residual_mfs).max():.3e})"
+        )
+
+        for b, n in enumerate(nodes):
+            xr.Dataset(
+                data_vars={
+                    "MODEL_MOPPED": (("corr", "y", "x"), model_mopped[b][None]),
+                    "RESIDUAL_MOPPED": (("corr", "y", "x"), residual_mopped_raw[b][None]),
+                },
+                attrs=final_attrs[b],
+            ).to_zarr(dt_name, group=n, mode="a")
 
     if fits_per_partition:
         # per-partition misfit localisation (D23 debugging aid): re-gridded

--- a/src/pfb_imaging/operators/hessian.py
+++ b/src/pfb_imaging/operators/hessian.py
@@ -760,12 +760,18 @@ class HessTreeRay:
             A new ``(nband, ny, nx)`` cube.
         """
         s = self._prior_s()
+        x = np.ascontiguousarray(x)
         # D x is the whole term without a prior; with one, the identity
         # D^half Cinv D^half = D + D^half (Cinv - I) D^half applies, exactly as
         # in dot -- the workers supply the D there, and it is written out here.
-        out = np.ascontiguousarray((s**2) * x)
+        #
+        # s twice into the output buffer rather than (s**2) * x: under
+        # --eta-mode s is a full (nband, ny, nx) cube, so s**2 would be a whole
+        # extra temporary alongside out -- ~1 GB of f8 at 4096^2 x 8 bands.
+        out = s * x
+        out *= s
         if self._dC is not None:
-            eta_freq_mul(out, self._dC, s, np.ascontiguousarray(x), nchunk=self._nchunk)
+            eta_freq_mul(out, self._dC, s, x, nchunk=self._nchunk)
         return out
 
     def _prior_s(self):
@@ -783,7 +789,10 @@ class HessTreeRay:
                 # is ~1 GB of f8 at 4096^2 x 8 bands.
                 self._s = np.sqrt(np.asarray(self._etas, dtype=float)).reshape(self.nband, 1, 1)
             else:
-                self._s = np.sqrt(self._pool.get_eta(self.ny, self.nx))
+                # in place: get_eta returns a fresh cube, so this avoids a
+                # second (nband, ny, nx) allocation on the way to sqrt(D)
+                self._s = self._pool.get_eta(self.ny, self.nx)
+                np.sqrt(self._s, out=self._s)
         return self._s
 
     def cg(self, rhs, x0=None, tol=None, maxit=None, minit=None):

--- a/src/pfb_imaging/operators/hessian.py
+++ b/src/pfb_imaging/operators/hessian.py
@@ -708,6 +708,8 @@ class HessTreeRay:
         # semi-definite (Cinv's eigenvalues are in (0, 1]); the total operator
         # is still symmetric positive definite, so CG applies -- but nothing may
         # assume this term alone is PSD.
+        self._etas = etas
+        self._eta_mode = eta_mode
         self._dC = None
         self._s = None
         if freq_prec is not None:
@@ -715,12 +717,6 @@ class HessTreeRay:
             if freq_prec.shape != (self.nband, self.nband):
                 raise ValueError(f"freq_prec has shape {freq_prec.shape}, expected {(self.nband, self.nband)}")
             self._dC = freq_prec - np.eye(self.nband)
-            if eta_mode is None:
-                # uniform eta: a per-band scalar, so no (nband, ny, nx) cube is
-                # fetched or held (that is ~1 GB of f8 at 4096^2 x 8 bands)
-                self._s = np.sqrt(etas)
-            else:
-                self._s = np.sqrt(self._pool.get_eta(ny, nx))
             # pixel chunks for the fused kernel: sets its fan-out without
             # touching the process-wide numba thread count
             self._nchunk = max(1, int(nthreads))
@@ -728,6 +724,7 @@ class HessTreeRay:
     def dot(self, x):
         out = self._pool.hess_dot(x)
         if self._dC is not None:
+            s = self._prior_s()
             # One fused numba pass instead of four numpy ones, and no scratch
             # cubes: at 8 bands x 8000^2 the numpy form held 7.6 GB of them in
             # the driver, on top of the ~27 GB the cube-level CG already needs.
@@ -736,11 +733,58 @@ class HessTreeRay:
             # every core and those threads busy-poll for ~100 ms afterwards,
             # straight through the next ray.get while the workers need the
             # cores. See gauss.eta_freq_mul for the measurements.
-            eta_freq_mul(out, self._dC, self._s, x, nchunk=self._nchunk)
+            eta_freq_mul(out, self._dC, s, x, nchunk=self._nchunk)
         return out
 
     def hdot(self, x):
         return self.dot(x)
+
+    def prior_dot(self, x):
+        """Apply the prior term of ``M`` alone: ``D^half Cinv D^half x``.
+
+        ``M x = M_data x + prior_dot(x)``, so this is what ``--eta-in-grad``
+        adds to the gradient (issue #310) -- the term that makes the prior part
+        of the objective rather than only of the preconditioner. Built from the
+        same ``etas``/``eta_mode``/``freq_prec`` the operator was constructed
+        with, never from a re-derived ``eta * x``, so it cannot drift from
+        ``M``.
+
+        Driver-local: ``_s`` and ``_dC`` live here, so no Ray round trip --
+        except the first call under ``eta_mode``, which fetches the profile
+        cube once and caches it.
+
+        Args:
+            x: ``(nband, ny, nx)`` cube. Not modified.
+
+        Returns:
+            A new ``(nband, ny, nx)`` cube.
+        """
+        s = self._prior_s()
+        # D x is the whole term without a prior; with one, the identity
+        # D^half Cinv D^half = D + D^half (Cinv - I) D^half applies, exactly as
+        # in dot -- the workers supply the D there, and it is written out here.
+        out = np.ascontiguousarray((s**2) * x)
+        if self._dC is not None:
+            eta_freq_mul(out, self._dC, s, np.ascontiguousarray(x), nchunk=self._nchunk)
+        return out
+
+    def _prior_s(self):
+        """``D^half``, per-band when eta is uniform and a cube under eta_mode.
+
+        Cached: under ``eta_mode`` the cube is an ``(nband, ny, nx)`` fetch from
+        the workers (~1 GB of f8 at 4096^2 x 8 bands), so it is pulled at most
+        once and only if something actually asks for the prior term.
+        """
+        if self._s is None:
+            if self._eta_mode is None:
+                # per-band scalars, kept as (nband, 1, 1) so they broadcast down
+                # the BAND axis: a bare (nband,) would broadcast along nx.
+                # No (nband, ny, nx) cube is fetched or held either way -- that
+                # is ~1 GB of f8 at 4096^2 x 8 bands.
+                self._s = np.sqrt(np.asarray(self._etas, dtype=float)).reshape(self.nband, 1, 1)
+            else:
+                self._s = np.sqrt(self._pool.get_eta(self.ny, self.nx))
+        return self._s
 
     def cg(self, rhs, x0=None, tol=None, maxit=None, minit=None):
         """Solve ``hess @ update = rhs``.
@@ -797,7 +841,7 @@ class HessTreeRay:
         if self._dC is None:
             return None
         lam = np.linalg.eigvalsh(self._dC + np.eye(self.nband))
-        eta_max = float(np.max(self._s)) ** 2
+        eta_max = float(np.max(self._prior_s())) ** 2
         return {
             "prec_min": float(lam.min()),
             "prec_max": float(lam.max()),

--- a/tests/test_deconv.py
+++ b/tests/test_deconv.py
@@ -705,3 +705,55 @@ def test_mop_preserves_the_run_attrs(tmp_path):
     assert "hess_norm_opts" in ds.attrs
     assert "rms" in ds.attrs and "rmax" in ds.attrs
     assert ds.attrs["bandid"] == 0  # the original attrs survive too
+
+
+def _seed_model(store, rng, nband=2, nx=32, ny=32):
+    """Put a nonzero MODEL and its matching BRESIDUAL into a synthetic tree.
+
+    Lets a run start from a model without spending a major cycle to build one,
+    which is what makes a niter=0 comparison possible.
+    """
+    import xarray as xr
+
+    for b in range(nband):
+        n = f"band{b:04d}_time0000"
+        ds = xr.open_datatree(store, engine="zarr", chunks=None)[n].ds
+        model = rng.standard_normal((1, ny, nx))
+        xr.Dataset(
+            {
+                "MODEL": (("corr", "y", "x"), model),
+                "BRESIDUAL": (("corr", "y", "x"), ds.BDIRTY.values.copy()),
+            },
+            attrs=dict(ds.attrs),
+        ).to_zarr(store, group=n, mode="a")
+
+
+@pytest.mark.slow
+def test_mop_uses_the_data_gradient_not_the_eta_corrected_one(tmp_path):
+    """The mop must solve against r_data, whatever --eta-in-grad is doing.
+
+    "Near perfect residual" means the *data* residual is near zero, so the mop
+    direction is M^-1 r_data. Solving against the eta-corrected gradient
+    r_data - K^-1 m instead makes the mop collapse to nothing exactly where it
+    is wanted: at a regularised fixed point that gradient is ~0, so
+    MODEL_MOPPED -> MODEL and the residual is not mopped at all.
+
+    Pinned by holding the model fixed (niter=0, seeded MODEL) so the only thing
+    the flag can change is the mop right-hand side. The two must agree exactly.
+    """
+    import xarray as xr
+
+    from pfb_imaging.core.deconv import deconv as deconv_core
+
+    mopped = {}
+    for flag in (False, True):
+        output_filename = str(tmp_path / f"moprhs{int(flag)}")
+        dt_name = f"{output_filename}_I.dt"
+        _write_synthetic_dt(dt_name, 32, 32, 64, 1, np.random.default_rng(71))
+        _seed_model(dt_name, np.random.default_rng(72))
+        deconv_core(output_filename, eta_in_grad=flag, **_eta_grad_opts(niter=0))
+        ds = xr.open_datatree(dt_name, engine="zarr", chunks=None)["band0000_time0000"].ds
+        mopped[flag] = ds.MODEL_MOPPED.values.copy()
+        assert not np.allclose(ds.MODEL_MOPPED.values, ds.MODEL.values), "mop was a no-op"
+
+    np.testing.assert_allclose(mopped[False], mopped[True], rtol=0, atol=0)

--- a/tests/test_deconv.py
+++ b/tests/test_deconv.py
@@ -109,6 +109,19 @@ def test_deconv_groundtruth(sky_truth, ms_name, tmp_path):
         i0, i1 = np.unravel_index(int(np.argmax(box.values)), box.shape)
         assert (i0, i1) == (half, half), f"source {s}: model peak off-centre ({i0},{i1})"
 
+    # mopped products (#311). --mop is on by default, so this run wrote them.
+    # The claim is that model + M^-1 r very nearly cancels the residual:
+    # A(m + M^-1 r) = A m + A M^-1 r ~= A m + r = data wherever M ~= A. Needs
+    # consistent data to mean anything, which is why it is asserted here and
+    # not on the synthetic tree.
+    for n in nodes:
+        assert "MODEL_MOPPED" in dt[n].ds and "RESIDUAL_MOPPED" in dt[n].ds
+    residual_mopped = sum(dt[n].ds.RESIDUAL_MOPPED[0] for n in nodes).values
+    peak, peak_mopped = np.abs(residual).max(), np.abs(residual_mopped).max()
+    assert peak_mopped < 0.5 * peak, f"mopped peak {peak_mopped:.3e} vs deconvolved {peak:.3e}"
+    # and it must be a different model, not a copy of MODEL
+    assert not np.allclose(dt[nodes[0]].ds.MODEL.values, dt[nodes[0]].ds.MODEL_MOPPED.values)
+
     # per-partition debug FITS: with a single partition per band, the
     # re-gridded partition residual must reproduce the stored band RESIDUAL
     import glob
@@ -613,3 +626,82 @@ def test_grad_with_prior_subtracts_the_prior_term_on_the_normalised_scale():
     np.testing.assert_allclose(b, b0 - 0.25 * model, rtol=0, atol=1e-15)
     np.testing.assert_allclose(residual, r0, rtol=0, atol=0)
     np.testing.assert_allclose(bresidual, b0, rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
+# --mop (issue #311): the near-perfect-residual products
+# ---------------------------------------------------------------------------
+
+
+def _run_mop(tmp_path, tag, **over):
+    """One major cycle on a fresh synthetic tree; returns the band 0 dataset."""
+    import xarray as xr
+
+    from pfb_imaging.core.deconv import deconv as deconv_core
+
+    output_filename = str(tmp_path / tag)
+    dt_name = f"{output_filename}_I.dt"
+    _write_synthetic_dt(dt_name, 32, 32, 64, 1, np.random.default_rng(61))
+    deconv_core(output_filename, **_eta_grad_opts(**over))
+    return xr.open_datatree(dt_name, engine="zarr", chunks=None)["band0000_time0000"].ds
+
+
+@pytest.mark.slow
+def test_mop_writes_mopped_products_by_default(tmp_path):
+    """--mop is on by default and lands both products in the band node."""
+    ds = _run_mop(tmp_path, "mop_on")
+
+    assert "MODEL_MOPPED" in ds
+    assert "RESIDUAL_MOPPED" in ds
+    assert ds.MODEL_MOPPED.dims == ("corr", "y", "x")
+    assert np.isfinite(ds.MODEL_MOPPED.values).all()
+    assert np.isfinite(ds.RESIDUAL_MOPPED.values).all()
+
+
+@pytest.mark.slow
+def test_no_mop_writes_neither_product(tmp_path):
+    """It costs a forward solve and a gridding sweep, so it must be skippable."""
+    ds = _run_mop(tmp_path, "mop_off", mop=False)
+
+    assert "MODEL_MOPPED" not in ds
+    assert "RESIDUAL_MOPPED" not in ds
+    assert "MODEL" in ds  # the ordinary products are unaffected
+
+
+@pytest.mark.slow
+def test_mop_leaves_the_deconvolved_model_alone(tmp_path):
+    """MODEL stays the regularised model; the mop is a separate product.
+
+    MODEL_MOPPED is MODEL plus a least-squares update, so it is not sparse and
+    not a component model -- it must not overwrite what deconv converged to.
+    """
+    ds = _run_mop(tmp_path, "mop_sep")
+
+    assert not np.allclose(ds.MODEL.values, ds.MODEL_MOPPED.values, rtol=1e-6, atol=1e-12)
+
+
+# Note: "mopping lowers the residual" is NOT tested on _write_synthetic_dt.
+# That fixture's DIRTY and its partitions' VIS are independent random draws, so
+# the operator and the right-hand side describe different data and M is nowhere
+# near A -- M^-1 r is then a large least-squares answer to an inconsistent
+# system and the exact residual against it is worse, not better (measured:
+# 5.2e8 against 9.5e3). The claim needs consistent data, so it lives in
+# test_deconv_groundtruth, which images a real MS with a known injected sky.
+
+
+@pytest.mark.slow
+def test_mop_preserves_the_run_attrs(tmp_path):
+    """The mop write must not wipe niters/rms/hess_norm off the band node.
+
+    to_zarr(mode="a") merges variables but REPLACES attrs wholesale, so a
+    second write built from the band's original attrs silently drops
+    everything the major cycle recorded -- and a resumed run would then restart
+    from iteration 0 and re-estimate the norm.
+    """
+    ds = _run_mop(tmp_path, "mop_attrs")
+
+    assert ds.attrs["niters"] == 1
+    assert "hess_norm" in ds.attrs
+    assert "hess_norm_opts" in ds.attrs
+    assert "rms" in ds.attrs and "rmax" in ds.attrs
+    assert ds.attrs["bandid"] == 0  # the original attrs survive too

--- a/tests/test_deconv.py
+++ b/tests/test_deconv.py
@@ -494,3 +494,122 @@ def test_deconv_driver_runs_with_the_frequency_prior(tmp_path):
     ref = xr.open_datatree(f"{out2}_I.dt", engine="zarr", chunks=None)["band0000_time0000"].ds
     rel = np.linalg.norm(band.UPDATE.values - ref.UPDATE.values) / np.linalg.norm(ref.UPDATE.values)
     assert rel > 1e-2, f"the prior left the update unchanged (rel={rel:.3e})"
+
+
+# ---------------------------------------------------------------------------
+# --eta-in-grad (issue #310): the prior enters the objective, not only M
+# ---------------------------------------------------------------------------
+
+
+def _eta_grad_opts(**over):
+    """Driver opts for the --eta-in-grad tests.
+
+    eta is 0.1, not the 1e-3 default: the synthetic tree has a unit PSF, so at
+    the default the data term swamps the prior and the correction is lost in
+    the CG tolerance (same reason as the frequency-prior driver test).
+    """
+    opts = dict(
+        product="I",
+        minor_cycle="sara",
+        opt_backend="primal-dual",
+        niter=1,
+        hess_norm=1.0,
+        pd_maxit=20,
+        cg_maxit=20,
+        bases=["self"],
+        nlevels=1,
+        l1_reweight_from=100,
+        nthreads=2,
+        nworkers=1,
+        fits_mfs=False,
+        fits_cubes=False,
+        verbosity=0,
+        eta=0.1,
+    )
+    opts.update(over)
+    return opts
+
+
+def _run_two_cycles(tmp_path, tag, eta_in_grad):
+    """Two major cycles on a fresh synthetic tree; returns the final UPDATE."""
+    import xarray as xr
+
+    from pfb_imaging.core.deconv import deconv as deconv_core
+
+    output_filename = str(tmp_path / tag)
+    dt_name = f"{output_filename}_I.dt"
+    _write_synthetic_dt(dt_name, 32, 32, 64, 1, np.random.default_rng(51))
+    deconv_core(output_filename, eta_in_grad=eta_in_grad, **_eta_grad_opts(niter=2))
+    ds = xr.open_datatree(dt_name, engine="zarr", chunks=None)["band0000_time0000"].ds
+    return ds.UPDATE.values.copy()
+
+
+@pytest.mark.slow
+def test_eta_in_grad_changes_the_update_once_the_model_is_nonzero(tmp_path):
+    """The prior term is -K^-1 m, so it bites from the second cycle on.
+
+    Cycle 1 starts from a zero model and is identical either way; cycle 2 sees
+    a gradient that differs by K^-1 m, so its update must differ too.
+    """
+    off = _run_two_cycles(tmp_path, "eig0", False)
+    on = _run_two_cycles(tmp_path, "eig1", True)
+
+    assert not np.allclose(off, on, rtol=1e-6, atol=1e-12)
+
+
+@pytest.mark.slow
+def test_eta_in_grad_is_a_no_op_on_the_first_step_from_a_zero_model(tmp_path):
+    """K^-1 * 0 == 0: a fresh tree's first update cannot move, bit for bit.
+
+    Also guards the scale. Applying the correction to the raw residual instead
+    of the wsum-normalised one, or dropping the model factor, would perturb
+    this even at a zero model.
+    """
+    import xarray as xr
+
+    from pfb_imaging.core.deconv import deconv as deconv_core
+
+    updates = {}
+    for flag in (False, True):
+        output_filename = str(tmp_path / f"eigz{int(flag)}")
+        dt_name = f"{output_filename}_I.dt"
+        _write_synthetic_dt(dt_name, 32, 32, 64, 1, np.random.default_rng(52))
+        deconv_core(output_filename, eta_in_grad=flag, **_eta_grad_opts())
+        ds = xr.open_datatree(dt_name, engine="zarr", chunks=None)["band0000_time0000"].ds
+        updates[flag] = ds.UPDATE.values.copy()
+
+    np.testing.assert_allclose(updates[False], updates[True], rtol=0, atol=0)
+
+
+def test_grad_with_prior_subtracts_the_prior_term_on_the_normalised_scale():
+    """The scale decision, isolated.
+
+    ``residual``/``bresidual`` reaching the solver are already divided by the
+    total wsum, and ``prior_dot`` is defined on that same normalised operator
+    (--eta is a fraction of the total wsum), so the correction is subtracted
+    with no further scaling. It must not touch the caller's arrays: the raw
+    ones are what get stored, and storing an eta-inclusive gradient would
+    double-count it on every resume.
+    """
+    from pfb_imaging.core.deconv import _grad_with_prior
+
+    class _Prior:
+        def __init__(self, eta):
+            self.eta = eta
+
+        def prior_dot(self, x):
+            return self.eta * x
+
+    rng = np.random.default_rng(54)
+    nband, ny, nx = 2, 4, 4
+    residual = rng.standard_normal((nband, ny, nx))
+    bresidual = rng.standard_normal((nband, ny, nx))
+    model = rng.standard_normal((nband, ny, nx))
+    r0, b0 = residual.copy(), bresidual.copy()
+
+    r, b = _grad_with_prior(residual, bresidual, model, _Prior(0.25))
+
+    np.testing.assert_allclose(r, r0 - 0.25 * model, rtol=0, atol=1e-15)
+    np.testing.assert_allclose(b, b0 - 0.25 * model, rtol=0, atol=1e-15)
+    np.testing.assert_allclose(residual, r0, rtol=0, atol=0)
+    np.testing.assert_allclose(bresidual, b0, rtol=0, atol=0)

--- a/tests/test_hess_tree_ray.py
+++ b/tests/test_hess_tree_ray.py
@@ -452,3 +452,74 @@ def test_prior_needs_more_cg_iterations_and_that_is_expected():
     off_f, on_f = _pair(full, nx, ny, eta, kinv)
     it_full, it_full_gp = applications(off_f), applications(on_f)
     assert it_full_gp < 1.3 * it_full, f"expected the prior to be nearly free here, got {it_full} -> {it_full_gp}"
+
+
+# ---------------------------------------------------------------------------
+# prior_dot: the non-data part of M, exposed so the gradient can carry it
+# (issue #310, --eta-in-grad). M itself is only ever applied as a whole.
+# ---------------------------------------------------------------------------
+
+
+@pmp("length_scale", [None, 0.5])
+def test_prior_dot_is_exactly_the_non_data_part_of_m(length_scale):
+    """``dot(x) == M_data x + prior_dot(x)``, prior on or off.
+
+    This is the contract --eta-in-grad rests on: the gradient must gain
+    precisely the term the preconditioner adds, so building it from anything
+    but M itself (a hardcoded ``eta * x``, say) would drift from M the moment
+    the prior or eta_mode is on.
+    """
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(20)
+    nband, nx, ny = 3, 8, 8
+    eta = 1e-2
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = None if length_scale is None else freq_precision(np.linspace(1.0e9, 1.4e9, nband), length_scale)
+
+    data_only = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=0.0)
+    full = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=eta, freq_prec=kinv)
+
+    x = rng.standard_normal((nband, nx, ny))
+    assert_allclose(full.dot(x) - data_only.dot(x), full.prior_dot(x), rtol=1e-11, atol=1e-13)
+
+
+def test_prior_dot_is_eta_times_x_when_the_prior_is_off():
+    """The uncorrelated limit, written out: K^-1 = eta * I."""
+    rng = np.random.default_rng(21)
+    nband, nx, ny = 2, 8, 8
+    eta = 3e-2
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    hess = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=eta)
+
+    x = rng.standard_normal((nband, nx, ny))
+    assert_allclose(hess.prior_dot(x), eta * x, rtol=1e-12, atol=0)
+
+
+def test_prior_dot_couples_bands_through_the_correlation_matrix():
+    """With the prior on and uniform eta: K^-1 x == eta * (Cinv @ x)."""
+    from pfb_imaging.operators.hessian import freq_precision
+
+    rng = np.random.default_rng(22)
+    nband, nx, ny = 3, 8, 8
+    eta = 1e-2
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    kinv = freq_precision(np.linspace(1.0e9, 1.4e9, nband), 0.5, cap=10.0)
+    hess = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=eta, freq_prec=kinv)
+
+    x = rng.standard_normal((nband, nx, ny))
+    want = eta * np.einsum("bc,cyx->byx", kinv, x)
+    assert_allclose(hess.prior_dot(x), want, rtol=1e-11, atol=1e-13)
+
+
+def test_prior_dot_does_not_mutate_its_argument():
+    """The driver subtracts it from a residual it still needs."""
+    rng = np.random.default_rng(23)
+    nband, nx, ny = 2, 8, 8
+    parts = [[_rand_part(rng, nx, ny, 2 * nx, 2 * ny)] for _ in range(nband)]
+    hess = HessTreeRay(parts, nx, ny, 2 * nx, 2 * ny, etas=1e-2)
+
+    x = rng.standard_normal((nband, nx, ny))
+    before = x.copy()
+    hess.prior_dot(x)
+    assert_allclose(x, before, rtol=0, atol=0)

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -867,27 +867,47 @@ def test_restore_consumes_the_mopped_products(tmp_path):
     images -- and thence a spectral index map -- from it. restore is already
     parameterised on the input variable names, so this must need no restore
     change at all; the test is here to keep that true.
+
+    The mopped variables are deliberately *scaled copies*, not copies: with
+    identical inputs the run would produce identical output whether or not
+    restore honoured the name arguments, so the test would pass on a restore
+    that silently read MODEL/RESIDUAL. The factors are distinct and known, so
+    the restored image is predictable from them.
     """
+    from pfb_imaging.utils.misc import convolve2gaussres
+
+    mscale, rscale = 3.0, 5.0
     store = str(tmp_path / "rt_I.dt")
     _write_restore_dt(store)
 
-    # rename the seeded products to the mopped names, as deconv --mop writes them
     dt = xr.open_datatree(store, engine="zarr", chunks=None)
     for b in range(2):
         n = f"band{b:04d}_time0000"
         ds = dt[n].ds
         xr.Dataset(
             {
-                "MODEL_MOPPED": (("corr", "y", "x"), ds.MODEL.values),
-                "RESIDUAL_MOPPED": (("corr", "y", "x"), ds.RESIDUAL.values),
+                "MODEL_MOPPED": (("corr", "y", "x"), mscale * ds.MODEL.values),
+                "RESIDUAL_MOPPED": (("corr", "y", "x"), rscale * ds.RESIDUAL.values),
             },
             attrs=dict(ds.attrs),
         ).to_zarr(store, group=n, mode="a")
 
-    _run_restore(tmp_path, outputs="kKiI", model_name="MODEL_MOPPED", residual_name="RESIDUAL_MOPPED")
+    _run_restore(tmp_path, outputs="kK", model_name="MODEL_MOPPED", residual_name="RESIDUAL_MOPPED")
 
     out = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds
-    assert "KIMAGE" in out and "IMAGE" in out
+    assert "KIMAGE" in out
     assert np.isfinite(out.KIMAGE.values).all()
-    # and it restored the mopped residual, not the plain one
-    assert "PSFPARSF" in out
+
+    # KIMAGE == MODEL_MOPPED (x) G + RESIDUAL_MOPPED / WSUM, at native
+    # resolution so the residual is not reconvolved. Both scale factors have to
+    # show up: reading MODEL/RESIDUAL instead would miss them.
+    _, ny, nx = out.MODEL.shape
+    xx, yy = np.meshgrid(-(nx // 2) + np.arange(nx), -(ny // 2) + np.arange(ny), indexing="ij")
+    mconv = convolve2gaussres(
+        mscale * out.MODEL.values, xx, yy, out.PSFPARSF.values, nthreads=1, pfrac=0.2, norm_kernel=False, yx_order=True
+    )
+    want = mconv + rscale * out.RESIDUAL.values / out.WSUM.values[:, None, None]
+    np.testing.assert_allclose(out.KIMAGE.values, want, rtol=0, atol=1e-5)
+
+    # and the unscaled inputs really would have given something else
+    assert not np.allclose(out.KIMAGE.values, want / mscale, atol=1e-3)

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -858,3 +858,36 @@ def test_restore_multi_corr_products_keep_every_correlation(tmp_path):
     # integrates to ~4x more -- identical planes would mean a collapse to corr 0
     assert cpsf_mfs[1, 0].sum() > 2.0 * cpsf_mfs[0, 0].sum()
     assert cpsf_cube[1, 0].sum() > 2.0 * cpsf_cube[0, 0].sum()
+
+
+def test_restore_consumes_the_mopped_products(tmp_path):
+    """`restore --model-name MODEL_MOPPED --residual-name RESIDUAL_MOPPED`.
+
+    The whole point of storing the mopped pair (#311) is building restored
+    images -- and thence a spectral index map -- from it. restore is already
+    parameterised on the input variable names, so this must need no restore
+    change at all; the test is here to keep that true.
+    """
+    store = str(tmp_path / "rt_I.dt")
+    _write_restore_dt(store)
+
+    # rename the seeded products to the mopped names, as deconv --mop writes them
+    dt = xr.open_datatree(store, engine="zarr", chunks=None)
+    for b in range(2):
+        n = f"band{b:04d}_time0000"
+        ds = dt[n].ds
+        xr.Dataset(
+            {
+                "MODEL_MOPPED": (("corr", "y", "x"), ds.MODEL.values),
+                "RESIDUAL_MOPPED": (("corr", "y", "x"), ds.RESIDUAL.values),
+            },
+            attrs=dict(ds.attrs),
+        ).to_zarr(store, group=n, mode="a")
+
+    _run_restore(tmp_path, outputs="kKiI", model_name="MODEL_MOPPED", residual_name="RESIDUAL_MOPPED")
+
+    out = xr.open_datatree(store, engine="zarr", chunks=None)["band0000_time0000"].ds
+    assert "KIMAGE" in out and "IMAGE" in out
+    assert np.isfinite(out.KIMAGE.values).all()
+    # and it restored the mopped residual, not the plain one
+    assert "PSFPARSF" in out


### PR DESCRIPTION
Closes #310 and #311. Base `dev-0.1.0`. Together these are what makes the galactic-centre experiment possible: a spectral index map off the mopped model, with and without frequency-axis regularisation.

## Why both, and what each one actually changes

Worth being precise, because "with and without regularisation across frequency" means two different things in the current code:

- **#307 alone (`--gp-length-scale`)** puts the prior in `M` only. Preconditioned Richardson converges to `A⁻¹b` for *any* nonsingular `M` (D22), so the prior reshapes every forward update and leaves the fixed point exactly where it was — pinned by `test_frequency_prior_does_not_move_the_fixed_point`. On a converged run the deconvolved model is the same either way.
- **#310 (`--eta-in-grad`)** puts it in the objective. The gradient becomes `r − K⁻¹m`, so the fixed point *moves* and the prior becomes actual regularisation.
- **#311 (`--mop`)** is where the prior reaches the output even without #310: the mop update **is** `M⁻¹r`, so it carries the band coupling directly.

## #310 — `--eta-in-grad` (default off)

The objective gains `½ mᵀK⁻¹m`, whose gradient is `K⁻¹m`; in pfb's sign convention both gradients lose it. `K⁻¹` comes from the new `HessTreeRay.prior_dot`, which is *the same term* `dot` adds — a re-derived `eta*x` would drift the moment `--gp-length-scale` or `--eta-mode` is on, so the contract is pinned as `dot(x) == M_data x + prior_dot(x)`.

Two things the correction deliberately does not do:

- **No beam.** `bresidual` carries the outer per-partition beam because the data Hessian is `B GᵀWG B` (D23), but the prior acts on the *intrinsic* model, so `K⁻¹` has no beam on either side and the identical term comes off both gradients.
- **No rescaling.** The residuals reaching the solver are already divided by the total wsum, which is the operator `prior_dot` is defined on (`--eta` is a fraction of the total wsum, D4). Pinned by a test that would fail if the correction were applied to the raw residual.

`RESIDUAL`/`BRESIDUAL` keep storing the **pure data term** whatever the flag — a resumed run reads `BRESIDUAL` and applies the prior itself, so an eta-inclusive stored gradient would double-count on every restart. The flag changes what is *reported* (FITS, rms, λ), not what is stored. Note λ shifts with it: `--rmsfactor` multiplies the rms of the eta-inclusive residual.

## #311 — `--mop` (default on)

`A(m + M⁻¹r) = Am + AM⁻¹r ≈ Am + r = data` wherever `M ≈ A`, so `m + M⁻¹r` is the model whose residual is near perfect. Stored as `MODEL_MOPPED`/`RESIDUAL_MOPPED` plus `_model_mopped`/`_residual_mopped` MFS FITS.

**The update is solved fresh at the final model**, not reused from the loop's last forward step, which is a deviation from the issue text. That update was computed at the *pre-backward* model, so `model + update` is the near-perfect point only if the prox barely moved — true at convergence, false on a `niter` or divergence exit. `bresidual` is already the gradient against the final model, so the extra cost is one CG solve; the gridding sweep is needed for `RESIDUAL_MOPPED` regardless.

**`restore` needed no change.** It is already parameterised on its input variables, so this works today and a test keeps it working:

```
pfb restore --model-name MODEL_MOPPED --residual-name RESIDUAL_MOPPED ...
```

`MODEL` is untouched — the mopped model is `MODEL` plus a least-squares update, so it is neither sparse nor a component model, skips `model_to_ds`, and has no `.mds`/`degrid` path.

## Two bugs found while building this

- **The mop write clobbered the run attrs.** It lands after the major-cycle write, and `to_zarr(mode="a")` merges variables but **replaces attrs wholesale** — building it from `band_attrs` silently dropped `niters`/`rms`/`rmax`/`hess_norm`/`hess_norm_opts`, so a resumed run would restart from iteration 0 and re-estimate the norm. Caught by writing the test first; it now extends the attrs the loop last wrote.
- **`_s` had the wrong shape for anything but `eta_freq_mul`.** `D^½` was built eagerly in `__init__` on the coupled path only, as a bare `(nband,)` in the uniform case — which broadcasts along `nx`, not the band axis. Invisible while `eta_freq_mul` was the only consumer (it reshapes), wrong for `prior_dot`'s elementwise multiply. Now `(nband, 1, 1)` with a single lazy owner, so the `eta_mode` cube fetch (~1 GB of f8 at 4096² × 8 bands) still never happens on runs that do not need it.

## Reading the experiment — two caveats

Both worth knowing before attributing anything to the prior:

1. **The mopped residual is near zero by construction**, which removes the D33 ripple source — a residual reconvolved from a Gaussian fit to a non-Gaussian dirty beam. A cleaner spectral index map off mopped products is therefore *not by itself* evidence about the prior.
2. **The prior is designed to grow the frequency-smooth direction of the update** (D30's "relax" convention). It will reduce spectral-index scatter partly by genuine information sharing across bands and partly by imposed smoothness. Worth a control — per-band flux conservation, or the injected truth.

## Verification

```
uv run pytest tests/ -m ""   →  684 passed in 607s   (669 -> 684, +15 new)
uv run ruff format --check . →  116 files already formatted
uv run ruff check .          →  All checks passed
hip-cargo generate-cabs      →  clean diff
```

Off path re-verified **bit-identical to `dev-0.1.0`** on `dot`/`cg`/`get_eta` after each commit, against a `dev-0.1.0` worktree — `prior_dot` touches shared operator state, so that was checked rather than assumed.

The residual-reduction claim is asserted in `test_deconv_groundtruth`, on a real MS with a known injected sky. It is deliberately *not* on the synthetic tree: that fixture's `DIRTY` and its partitions' `VIS` are independent random draws, so `M` is nowhere near `A` and mopping correctly makes things worse there (5.2e8 against 9.5e3). There is a note in the test file so nobody "fixes" it back.

Wiki: **D34** (`--eta-in-grad`), **D35** (`--mop`).

Note `ci.yml`'s `pull_request` trigger is scoped to `branches: [main]`, so this PR runs no CI; the local run above is the gate until `dev-0.1.0` merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
