### PR TITLE
docs: explain why hci's zarr coords need rounding (#155)

### DIFF
--- a/.claude/rules/testing-and-ci.md
+++ b/.claude/rules/testing-and-ci.md
@@ -37,8 +37,8 @@ wiki design-decisions D14).
 `pyproject.toml`'s `addopts` carries `-m "not slow"`, so the bare command is the fast loop:
 
 ```bash
-uv run pytest tests/          # fast loop: 616 tests, ~122 s
-uv run pytest -m slow tests/  # only the deselected 27, ~450 s
+uv run pytest tests/          # fast loop: 651 tests, ~153 s
+uv run pytest -m slow tests/  # only the deselected 35, ~450 s
 uv run pytest -m "" tests/    # everything, ~570 s (what CI runs)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ uv run ruff format . && uv run ruff check . --fix
 ```
 
 **Tests are fast by default.** `pyproject.toml`'s `addopts` carries `-m "not slow"`, so
-`uv run pytest tests/` runs 616 tests in ~122 s. The 27 deselected tests are the end-to-end
+`uv run pytest tests/` runs 651 tests in ~153 s. The 35 deselected tests are the end-to-end
 pipeline ones (`*_groundtruth`, the imager/deconv/restore/hci drivers) plus a few whose cost is
 Ray actor startup or a dense operator build (the `_build_hess` preset-wiring pair, the
 frequency-prior fixed-point guard and the frequency-prior spectrum guards). They are left to CI, which overrides with `-m ""`. Use

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-09-08T10:00:00Z
-last_verified_commit: 64bae7c
+timestamp: 2026-09-08T12:00:00Z
+last_verified_commit: af344c5
 ---
 
 # Design decisions, known debt and recurring gotchas
@@ -1228,6 +1228,50 @@ update it (and this page's `last_verified_commit`) in the same session.
   `…test_mop_writes_mopped_products_by_default`, `…test_no_mop_writes_neither_product`,
   `…test_mop_leaves_the_deconvolved_model_alone`, `…test_mop_preserves_the_run_attrs`,
   `tests/test_restore.py::test_restore_consumes_the_mopped_products`.
+
+### D36 — hci's zarr coords are quantised to 1e-12 deg because `region="auto"` demands bitwise equality
+
+- **Context:** `hci --output-format zarr` writes a full-cube scaffold from the driver
+  (`make_dummy_dataset` → `to_zarr(mode="w", compute=False)`), then each Ray worker writes its
+  own `(TIME, FREQ)` slab back with `to_zarr(region="auto")` (`batch_stokes_image`). Both sides
+  compute the `X`/`Y` pixel-centre coordinates *independently*, from the same formula
+  `ref_deg + arange(...) * cell_deg`. `region="auto"` resolves the target slice by **looking
+  the incoming coordinate values up in the stored coordinate arrays**, so it needs exact
+  float64 equality — a 1-ulp difference is `KeyError: Not all values of coordinate 'Y' in the
+  new array were found in the original store`. Issue #155 recorded the rounding needed to make
+  them match and asked why it was ever necessary.
+- **Decision:** both sides quantise with `np.round(..., decimals=12)` before building the
+  coords (`core/hci.py`, `utils/stokes2im.py`), **and** the driver mirrors the worker's
+  conversion arithmetic exactly — `np.rad2deg(np.deg2rad(coord.ra.value))`, not
+  `coord.ra.value` (`core/hci.py`, the `phase_dir is not None` branch).
+- **Rationale:** the divergence was an arithmetic asymmetry in how the reference coordinate
+  reached degrees. The driver took astropy's degrees directly; the worker went
+  degrees → radians (`np.deg2rad`) → degrees (`np.rad2deg`), because everything between
+  (rephasing, `synthesize_uvw`, `radec_to_lm`, the wgridder) works in radians. That round trip
+  is `fl(fl(x·π/180)·180/π)`: the two constants multiply to exactly 1.0 in float64, but the
+  intermediate rounds, so the composition is **not** the identity for all `x` — it is off by
+  1–2 ulp for whichever mantissas do not cancel. Measured over 4000 random phase centres, the
+  pre-fix driver path disagreed with the worker for **13%** of them, worst case 1.42e-14 deg at
+  |dec| ≈ 64°. That is the "sometimes" in the original TODO: it is a property of the
+  coordinate's bit pattern, not of the observation, so it reproduces perfectly on one field and
+  never appears on another. `decimals=12` is a quantum of 1e-12 deg — ~70× the float64 ulp at
+  |coord| ~ 100 deg, so it absorbs the divergence, and 3.6e-9 pixel at 1 arcsec cells, so it
+  costs nothing astrometrically. (`decimals=13` is already too fine to absorb it.)
+- **Consequences:** the rounding is now **belt-and-braces**, not load-bearing: with the
+  `deg2rad`/`rad2deg` symmetry in place, and with the `phase_dir is None` branch passing the
+  driver and the worker the *same* `radecs[ms][idt]` float64, the two sides agree bitwise by
+  construction, and `tests/test_hci.py` passes in full with both `np.round` calls deleted.
+  Keep it anyway — it is two array ops per image against a silent-to-write, loud-to-debug
+  failure mode, and it re-arms automatically if a future path reintroduces an asymmetry.
+  **Do not "fix" the driver's redundant-looking `rad2deg(deg2rad(...))` back to
+  `coord.ra.value`** — that is the bug, restored. Any new consumer that computes these coords
+  a third way must round the same way. Note also that quantisation alone cannot save a path
+  whose reference is *genuinely* different: `--target` makes the worker's `ra_deg`/`dec_deg`
+  the **target** position while the driver's scaffold stays on the phase centre, which is a
+  whole-degree mismatch and a separate open bug on the `--target` + zarr path.
+- **Source:** issue #155; `src/pfb_imaging/core/hci.py` (`make_dummy_dataset`);
+  `src/pfb_imaging/utils/stokes2im.py` (`batch_stokes_image`'s `region="auto"` write and
+  `stokes_image`'s coord construction); xarray `to_zarr` region resolution.
 
 ## Known debt
 

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,7 +3,7 @@ type: Design Ledger
 title: Design decisions, known debt and recurring gotchas
 description: Context/Decision/Rationale/Consequences ledger for pfb-imaging's load-bearing choices, plus the debt list and the gotchas that have already cost real debugging sessions.
 tags: [design, decisions, debt, gotchas, ray, deconvolution, imager]
-timestamp: 2026-09-08T12:00:00Z
+timestamp: 2026-09-08T12:22:55Z
 last_verified_commit: af344c5
 ---
 
@@ -1265,13 +1265,61 @@ update it (and this page's `last_verified_commit`) in the same session.
   failure mode, and it re-arms automatically if a future path reintroduces an asymmetry.
   **Do not "fix" the driver's redundant-looking `rad2deg(deg2rad(...))` back to
   `coord.ra.value`** — that is the bug, restored. Any new consumer that computes these coords
-  a third way must round the same way. Note also that quantisation alone cannot save a path
-  whose reference is *genuinely* different: `--target` makes the worker's `ra_deg`/`dec_deg`
-  the **target** position while the driver's scaffold stays on the phase centre, which is a
-  whole-degree mismatch and a separate open bug on the `--target` + zarr path.
+  a third way must round the same way. Quantisation alone cannot save a path whose reference is
+  *genuinely* different, which is what D37 was: `--target` moved the worker's grid a whole
+  degree away from the scaffold, and no rounding reaches that.
 - **Source:** issue #155; `src/pfb_imaging/core/hci.py` (`make_dummy_dataset`);
   `src/pfb_imaging/utils/stokes2im.py` (`batch_stokes_image`'s `region="auto"` write and
-  `stokes_image`'s coord construction); xarray `to_zarr` region resolution.
+  `stokes_image`'s coord construction); xarray `to_zarr` region resolution;
+  `tests/test_hci.py::test_hci_zarr_coords_survive_an_ulp_hostile_phase_centre`.
+
+### D37 — `--target` recentres hci's grid, so one resolver serves the driver and the worker
+
+- **Context:** on the hci path `--target` is not a label — it is passed to ducc as
+  `center_x`/`center_y`, so the **image centre moves off the tangent point** and
+  `stokes_image` labels its `X`/`Y` coords (and historically its FITS `CRVAL`) from the target
+  rather than the phase centre. `make_dummy_dataset` never looked at `target` at all, so the
+  scaffold stayed on the phase centre: a whole-degree disagreement, and by D36 that is a hard
+  `KeyError` out of `region="auto"`. Behind that sat a second, earlier failure —
+  `radec_to_lm(tcoords, radec_new[None, :])` passed a `(1, 2)` `phase_centre` to africanus,
+  whose implementation unpacks it as two scalars (`pc_ra, pc_dec = …`), so the whole path died
+  in numba type inference before ever reaching the coords. `--target` had no test coverage on
+  this path.
+- **Decision:** one resolver, `astrometry.resolve_target_radec(target, obs_time) ->
+  (ra, dec, moving)`, called by **both** `stokes_image` and `make_dummy_dataset`; the driver
+  sets both the scaffold coords and the header `CRVAL` from it. `stokes2im` now uses the
+  repo's own pure-numpy `misc.radec_to_lm` (identical formula, 1-D `(2,)` convention, already
+  what the imager path uses) instead of africanus's numba version, at both call sites.
+- **Rationale:** the reference coordinate is exactly the quantity D36 shows must not be
+  computed twice. Making it one function removes the possibility of the two sides drifting
+  rather than papering over a drift that already happened. Dropping africanus's `radec_to_lm`
+  here also removes the `(1, 2)`-vs-`(2,)` trap that caused the numba failure: the numpy
+  version takes and returns plain pairs, so the shape confusion cannot recur.
+- **Consequences:** the **ephemeris form** of `--target` (a bare body name, resolved at the
+  image's own `time_out`) moves between output images, but `X`/`Y` is a *single axis shared
+  across `TIME`*, so no one labelling is correct for a multi-bin cube. The driver resolves the
+  target at every output time and **raises** if the positions differ, naming the drift in
+  degrees and pointing at the two ways out (one time bin, or the explicit
+  `'HH:MM:SS,DD:MM:SS'` form). A single time bin is allowed and works, because the driver and
+  the worker average the *same* time slice and so resolve the same position. Recording the
+  per-image centre as a `TIME`-indexed variable would lift the restriction; not done.
+  Two further notes: the header keeps `CRPIX` at the image centre and moves `CRVAL` to the
+  target, which declares the SIN projection tangent at the target while the image was gridded
+  tangent at the phase centre — an `O(θ²)` error in the offset, negligible for the arcminute
+  offsets this is used for but not for a body tens of degrees away (the exact form is D21's
+  `CRPIX` shift, as used on the imager path; the zarr `X`/`Y` ramp is equally approximate, so
+  the two are at least self-consistent). And `integrations_per_image < 1` makes the driver's
+  time loop (`range(tlow, tlow + tcounts, integrations_per_image)`) empty, which used to
+  surface as an `IndexError` on `out_times[0]` while building the WCS; it now raises where it
+  is caused. The CLI help still advertises `-1` as "dataset per scan", which that loop does
+  not implement.
+- **Source:** issue #155 (found while documenting D36); `src/pfb_imaging/utils/astrometry.py`
+  (`resolve_target_radec`); `src/pfb_imaging/core/hci.py` (`make_dummy_dataset`);
+  `src/pfb_imaging/utils/stokes2im.py`;
+  `tests/test_hci.py::test_hci_target_recentres_the_grid` (astrometry: sources injected about
+  the target land at their predicted pixels about the image centre),
+  `…::test_hci_rejects_a_moving_target_across_multiple_time_bins`,
+  `…::test_hci_accepts_a_moving_target_in_a_single_time_bin`.
 
 ## Known debt
 

--- a/src/pfb_imaging/cabs/hci.yml
+++ b/src/pfb_imaging/cabs/hci.yml
@@ -230,7 +230,9 @@ cabs:
       target:
         info:
           Predefined celestial objects known to astropy.
-          Or a string in the format 'HH:MM:SS,DD:MM:SS' (note the , delimiter)
+          Or a string in the format 'HH:MM:SS,DD:MM:SS' (note the , delimiter).
+          The image centre moves to the target.
+          A named body moves between images, so it needs a single time bin.
         dtype: Optional[str]
         metadata:
           rich_help_panel: Imaging

--- a/src/pfb_imaging/cli/hci.py
+++ b/src/pfb_imaging/cli/hci.py
@@ -327,7 +327,9 @@ def hci(
         str | None,
         typer.Option(
             help="Predefined celestial objects known to astropy. "
-            "Or a string in the format 'HH:MM:SS,DD:MM:SS' (note the , delimiter)",
+            "Or a string in the format 'HH:MM:SS,DD:MM:SS' (note the , delimiter). "
+            "The image centre moves to the target. "
+            "A named body moves between images, so it needs a single time bin.",
             rich_help_panel="Imaging",
         ),
     ] = None,

--- a/src/pfb_imaging/core/hci.py
+++ b/src/pfb_imaging/core/hci.py
@@ -25,6 +25,7 @@ from zarr import ProcessSynchronizer
 
 from pfb_imaging import init_ray, pfb_version, set_envs, setup_ray_worker
 from pfb_imaging.utils import logging as pfb_logging
+from pfb_imaging.utils.astrometry import resolve_target_radec
 from pfb_imaging.utils.misc import construct_mappings, set_image_size
 from pfb_imaging.utils.stokes2im import batch_stokes_image
 from pfb_imaging.utils.transients import generate_transient_spectra
@@ -399,6 +400,7 @@ def hci(
         nx_psf,
         ny_psf,
         cell_deg,
+        target=target,
         spatial_chunk=128,  # hardcode for now
         images_per_chunk=images_per_chunk,
         integrations_per_image=integrations_per_image,
@@ -791,6 +793,7 @@ def make_dummy_dataset(
     nx_psf,
     ny_psf,
     cell_deg,
+    target=None,
     spatial_chunk=128,
     images_per_chunk=16,
     integrations_per_image=1,
@@ -847,6 +850,15 @@ def make_dummy_dataset(
     n_times = out_times.size
     n_freqs = out_freqs.size
 
+    if n_times == 0 or n_freqs == 0:
+        # the time loop steps by integrations_per_image, so a value < 1 gives an
+        # empty range and hence no output images at all
+        raise ValueError(
+            f"selection produced {n_times} time bins and {n_freqs} frequency bins, so there is "
+            f"nothing to image. integrations_per_image must be >= 1 (got {integrations_per_image}); "
+            "pass the scan length for a single time bin."
+        )
+
     # spatial coordinates
     if phase_dir is None:
         # these are in radians
@@ -883,6 +895,29 @@ def make_dummy_dataset(
     # remove duplicates
     out_times = np.unique(out_times)
     out_freqs = np.unique(out_freqs)
+
+    # --target moves the image centre off the tangent point, so the scaffold's
+    # X/Y coords (and the header's CRVAL) must move with it: stokes_image labels
+    # its grid from the target, and its slab is written back with
+    # to_zarr(region="auto"), which resolves the region by looking those values
+    # up here. Same resolver on both sides so they cannot disagree.
+    if target is not None:
+        ra_t, dec_t, moving = resolve_target_radec(target, float(out_times[0]))
+        if moving and out_times.size > 1:
+            # an ephemeris target moves between images, but X/Y is one axis shared
+            # across TIME, so no single labelling is correct for the whole cube
+            refs = np.rad2deg([resolve_target_radec(target, float(t))[:2] for t in out_times])
+            if not np.all(refs == refs[0]):
+                raise ValueError(
+                    f"target '{target}' is a solar-system body, so its position differs across the "
+                    f"{out_times.size} output time bins ({np.ptp(refs[:, 0]):.4f} deg in RA, "
+                    f"{np.ptp(refs[:, 1]):.4f} deg in Dec) and the cube's shared X/Y axis cannot "
+                    "label all of them. Either ask for a single time bin "
+                    "(--integrations-per-image >= the number of integrations in the scan), or pass "
+                    "the position explicitly as --target 'HH:MM:SS,DD:MM:SS'."
+                )
+        out_ra_deg = np.array([np.rad2deg(ra_t)])
+        out_dec_deg = np.array([np.rad2deg(dec_t)])
 
     n_stokes = len(set(product))
     n_times = out_times.size
@@ -951,7 +986,7 @@ def make_dummy_dataset(
         "fits_dims": (("X", ra_dim), ("Y", dec_dim), ("TIME", "TIME"), ("FREQ", "FREQ"), ("STOKES", "STOKES")),
     }
 
-    # Quantise to 1e-12 deg (3.6 nano-pixel) so the workers' independently computed
+    # Quantise to 1e-12 deg (3.6 nanoarcsec) so the workers' independently computed
     # X/Y coords agree bitwise with this scaffold: they write back with
     # to_zarr(region="auto"), which looks the values up in the stored coords and
     # raises KeyError on a 1-ulp difference. Redundant with the deg->rad->deg

--- a/src/pfb_imaging/core/hci.py
+++ b/src/pfb_imaging/core/hci.py
@@ -951,7 +951,12 @@ def make_dummy_dataset(
         "fits_dims": (("X", ra_dim), ("Y", dec_dim), ("TIME", "TIME"), ("FREQ", "FREQ"), ("STOKES", "STOKES")),
     }
 
-    # TODO - why do we sometimes need to round here?
+    # Quantise to 1e-12 deg (3.6 nano-pixel) so the workers' independently computed
+    # X/Y coords agree bitwise with this scaffold: they write back with
+    # to_zarr(region="auto"), which looks the values up in the stored coords and
+    # raises KeyError on a 1-ulp difference. Redundant with the deg->rad->deg
+    # symmetry above -- either alone suffices; keep both.
+    # See wiki design-decisions D36 (#155).
     out_ras = out_ra_deg + np.arange(nx // 2, -(nx // 2), -1) * cell_deg
     out_decs = out_dec_deg + np.arange(-(ny // 2), ny // 2) * cell_deg
     out_ras = np.round(out_ras, decimals=12)

--- a/src/pfb_imaging/utils/astrometry.py
+++ b/src/pfb_imaging/utils/astrometry.py
@@ -154,6 +154,35 @@ def format_coords(ra0, dec0):
 # Pillaged from
 # https://github.com/ratt-ru/solarkat/blob/main/solarkat-pipeline/find_sun_stimela.py
 # obs_lat and obs_lon hardcoded for MeerKAT
+def resolve_target_radec(target, obs_time):
+    """Resolve a ``--target`` string to the image-centre (ra, dec) in radians.
+
+    Two forms are accepted, and they differ in a way that matters to any caller
+    building a shared coordinate axis:
+
+    * ``"HH:MM:SS,DD:MM:SS"`` — a fixed position, identical for every image.
+    * a bare object name (e.g. ``"Sun"``) — a solar-system body, resolved at
+      ``obs_time``, so it **moves** from one output image to the next.
+
+    Args:
+        target: the target string.
+        obs_time: weighted mean MS TIME of the image, in MJD seconds. Used only
+            for the ephemeris form.
+
+    Returns:
+        ``(ra, dec)`` in radians, and ``True`` if the position is
+        time-dependent (the ephemeris form).
+    """
+    parts = target.split(",")
+    if len(parts) == 1:
+        ra, dec = get_coordinates(obs_time, target=target)
+        return ra, dec, True
+    coord = SkyCoord(parts[0], parts[1], frame="fk5", unit=(units.hourangle, units.deg))
+    # deg -> rad here and rad -> deg on the way out, so every consumer of this
+    # reference goes through the same arithmetic (wiki design-decisions D36)
+    return np.deg2rad(coord.ra.value), np.deg2rad(coord.dec.value), False
+
+
 def get_coordinates(obs_time, obs_lat=-30.71323598930457, obs_lon=21.443001467965008, target="Sun"):
     """
     Give location of object given telescope location (defaults to MeerKAT)

--- a/src/pfb_imaging/utils/stokes2im.py
+++ b/src/pfb_imaging/utils/stokes2im.py
@@ -734,6 +734,9 @@ def stokes_image(
     # set corr coords (removing duplicates and sorting)
     corr = list(sorted(set(product)))
 
+    # Quantise to 1e-12 deg so these agree bitwise with the scaffold hci wrote:
+    # the region="auto" write below looks these values up in the stored coords and
+    # raises KeyError on a 1-ulp difference. See wiki design-decisions D36 (#155).
     out_ras = ra_deg + np.arange(nx // 2, -(nx // 2), -1) * cell_deg
     out_decs = dec_deg + np.arange(-(ny // 2), ny // 2) * cell_deg
     out_ras = np.round(out_ras, decimals=12)

--- a/src/pfb_imaging/utils/stokes2im.py
+++ b/src/pfb_imaging/utils/stokes2im.py
@@ -6,7 +6,6 @@ import numexpr as ne
 import numpy as np
 import ray
 import xarray as xr
-from africanus.coordinates import radec_to_lm
 from astropy import units
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
@@ -18,9 +17,9 @@ from scipy.constants import c as lightspeed
 
 from pfb_imaging.operators.gridder import wgridder_conventions
 from pfb_imaging.operators.hessian import hessian_slice_jax
-from pfb_imaging.utils.astrometry import get_coordinates, synthesize_uvw
+from pfb_imaging.utils.astrometry import resolve_target_radec, synthesize_uvw
 from pfb_imaging.utils.beam import reproject_and_interp_scat_beam
-from pfb_imaging.utils.misc import fitcleanbeam, to_unix_time
+from pfb_imaging.utils.misc import fitcleanbeam, radec_to_lm, to_unix_time
 from pfb_imaging.utils.weighting import (
     _compute_counts,
     as_contiguous_readonly_view,
@@ -392,19 +391,10 @@ def stokes_image(
 
     # compute lm coordinates of target if requested
     if target is not None:
-        tmp = target.split(",")
-        if len(tmp) == 1 and tmp[0] == target:
-            obs_time = time_out
-            tra, tdec = get_coordinates(obs_time, target=target)
-        else:  # we assume a HH:MM:SS,DD:MM:SS format has been passed in
-            c = SkyCoord(tmp[0], tmp[1], frame="fk5", unit=(units.hourangle, units.deg))
-            tra = np.deg2rad(c.ra.value)
-            tdec = np.deg2rad(c.dec.value)
-
-        tcoords = np.zeros((1, 2))
-        tcoords[0, 0] = tra
-        tcoords[0, 1] = tdec
-        lm0 = radec_to_lm(tcoords, radec_new[None, :]).squeeze()
+        # same resolver the hci driver uses to place the scaffold's coords, so the
+        # two cannot drift apart (wiki design-decisions D36)
+        tra, tdec, _ = resolve_target_radec(target, time_out)
+        lm0 = radec_to_lm((tra, tdec), radec_new)
         # flip for wgridder conventions
         x0 = -lm0[0]
         y0 = -lm0[1]
@@ -474,12 +464,8 @@ def stokes_image(
         for name, ra, dec in zip(names, ras, decs):
             ra_rad = np.deg2rad(ra)
             dec_rad = np.deg2rad(dec)
-            tcoords = np.zeros((1, 2))
-            tcoords[0, 0] = ra_rad
-            tcoords[0, 1] = dec_rad
             # use initial radec as reference since rephasing happens after beam application
-            coords0 = np.array((radec[0], radec[1]))
-            lm0t = radec_to_lm(tcoords, coords0).squeeze()
+            lm0t = radec_to_lm((ra_rad, dec_rad), radec)
             x0t = lm0t[0]
             y0t = lm0t[1]
             n0t = np.sqrt(1 - x0t**2 - y0t**2)

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -794,3 +794,81 @@ def test_beam_for_band_stokes_order():
     assert [kw["i"] for _, kw in bw.get_rotation_averaged_beam.call_args_list] == ["I", "Q", "U", "V"]
     for index, prod in enumerate("IQUV"):
         assert_allclose(pbeam[index], levels[prod], rtol=1e-6)
+
+
+def test_hci_zarr_coords_survive_an_ulp_hostile_phase_centre(ms_name, tmp_path):
+    """The driver's scaffold coords must match what the workers compute, bitwise.
+
+    Workers write their slabs back with ``to_zarr(region="auto")``, which resolves
+    the target slice by looking their X/Y values up in the stored coords, so a
+    1-ulp disagreement is a hard KeyError rather than a small astrometric error.
+    The two sides reach degrees differently -- the worker via
+    ``rad2deg(deg2rad(...))``, because everything between works in radians -- and
+    that round trip is not the float64 identity for every mantissa. This test
+    picks a phase centre where it demonstrably is not, so the failure lands here
+    instead of on a user's field.
+
+    Two guards keep this working and they are redundant with each other: the
+    driver mirroring the worker's conversion, and the 1e-12 deg quantisation on
+    both sides. Removing either one alone still passes; removing both raises
+    ``KeyError: Not all values of coordinate 'Y' ... were found in the original
+    store`` from inside the Ray task. So this guards the contract, not one
+    mechanism -- see wiki design-decisions D36 (#155) before deleting either.
+    """
+    from astropy import units as u
+    from astropy.coordinates import SkyCoord
+
+    field = xds_from_table(f"{ms_name}::FIELD")[0]
+    ra0, dec0 = (float(v) for v in field.PHASE_DIR.values.squeeze())
+
+    def hostile(coord):
+        """True if this centre's degrees do not survive the deg->rad->deg trip."""
+        return coord.ra.value != np.rad2deg(np.deg2rad(coord.ra.value)) or coord.dec.value != np.rad2deg(
+            np.deg2rad(coord.dec.value)
+        )
+
+    # walk small dec offsets until we land on a centre that actually diverges;
+    # staying within ~0.05 deg keeps the field centre inside the image
+    phase_dir = None
+    for k in range(1, 2001):
+        cand = SkyCoord(ra0 * u.rad, (dec0 + np.deg2rad(2.5e-5 * k)) * u.rad, frame="fk5")
+        as_parsed = SkyCoord(
+            f"{cand.ra.to_string(unit=u.hourangle, sep=':')}",
+            f"{cand.dec.to_string(unit=u.deg, sep=':')}",
+            frame="fk5",
+            unit=(u.hourangle, u.deg),
+        )
+        if hostile(as_parsed):
+            phase_dir = f"{cand.ra.to_string(unit=u.hourangle, sep=':')},{cand.dec.to_string(unit=u.deg, sep=':')}"
+            break
+
+    assert phase_dir is not None, "found no ulp-hostile phase centre near the test MS -- test would be vacuous"
+
+    out = str(tmp_path / "hci_ulp.zarr")
+    hci_core(
+        [ms_name],
+        out,
+        product="I",
+        phase_dir=phase_dir,
+        channels_per_image=-1,
+        integrations_per_image=20,
+        images_per_chunk=3,
+        max_simul_chunks=1,
+        field_of_view=0.5,
+        super_resolution_factor=2.0,
+        nworkers=1,
+        nthreads=1,
+        beam_model=None,
+        robustness=0.0,
+        epsilon=1e-7,
+        overwrite=True,
+        keep_ray_alive=True,
+        log_directory=str(tmp_path / "logs"),
+    )
+
+    # the region="auto" write is the assertion: if the coords disagreed we never
+    # get here. Confirm the slabs actually landed rather than staying empty.
+    ds = xr.open_zarr(out)
+    assert ds.cube.dims == ("STOKES", "FREQ", "TIME", "Y", "X")
+    assert ds.sizes["TIME"] == 3
+    assert np.any(ds.nonzero.values), "no time bin recorded data -- slabs did not land"

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -30,6 +30,7 @@ from pfb_imaging.core.hci import (
 from pfb_imaging.core.hci import (
     hci as hci_core,
 )
+from pfb_imaging.utils.astrometry import resolve_target_radec
 from pfb_imaging.utils.misc import set_image_size
 from pfb_imaging.utils.stokes2im import beam_for_band, beam_gain_for_source
 from pfb_imaging.utils.transients import generate_transient_spectra
@@ -796,7 +797,7 @@ def test_beam_for_band_stokes_order():
         assert_allclose(pbeam[index], levels[prod], rtol=1e-6)
 
 
-def test_hci_zarr_coords_survive_an_ulp_hostile_phase_centre(ms_name, tmp_path):
+def test_hci_zarr_coords_survive_an_ulp_hostile_phase_centre(ms_name, ms_meta, tmp_path):
     """The driver's scaffold coords must match what the workers compute, bitwise.
 
     Workers write their slabs back with ``to_zarr(region="auto")``, which resolves
@@ -851,8 +852,176 @@ def test_hci_zarr_coords_survive_an_ulp_hostile_phase_centre(ms_name, tmp_path):
         product="I",
         phase_dir=phase_dir,
         channels_per_image=-1,
-        integrations_per_image=20,
-        images_per_chunk=3,
+        integrations_per_image=ms_meta.ntime,  # single time bin -- one rephasing pass
+        images_per_chunk=1,
+        max_simul_chunks=1,
+        field_of_view=0.5,
+        super_resolution_factor=2.0,
+        nworkers=1,
+        nthreads=1,
+        beam_model=None,
+        robustness=None,  # natural: the coord contract is weighting-independent
+        epsilon=1e-7,
+        overwrite=True,
+        keep_ray_alive=True,
+        log_directory=str(tmp_path / "logs"),
+    )
+
+    # the region="auto" write is the assertion: if the coords disagreed we never
+    # get here. Confirm the slabs actually landed rather than staying empty.
+    ds = xr.open_zarr(out)
+    assert ds.cube.dims == ("STOKES", "FREQ", "TIME", "Y", "X")
+    assert ds.sizes["TIME"] == 1
+    assert np.any(ds.nonzero.values), "no data recorded -- the slab did not land"
+
+
+def test_hci_target_recentres_the_grid(ms_name, ms_meta, tmp_path):
+    """``--target`` moves the image centre, so the scaffold's coords must move with it.
+
+    The worker centres the grid on the target (``center_x``/``center_y`` from the
+    target's l/m) and labels its X/Y coords from the target's RA/Dec, while the
+    driver's scaffold was built on the phase centre and never saw ``target`` at
+    all. That is a whole-degree disagreement, so ``region="auto"`` cannot resolve
+    the slab and the run dies inside the Ray task. Sources injected about the
+    target must land at their predicted pixels about the image centre.
+    """
+    import dask
+    import dask.array as da
+    from astropy import units as u
+    from astropy.coordinates import SkyCoord
+    from daskms import xds_from_ms, xds_from_table, xds_to_table
+
+    xds0 = xds_from_ms(ms_name, chunks={"row": -1, "chan": -1, "corr": -1})[0]
+    nrow_, nchan_, ncorr_ = xds0.FLAG.shape
+    xds0 = xds0.assign(
+        FLAG=(("row", "chan", "corr"), da.zeros((nrow_, nchan_, ncorr_), dtype=bool, chunks=(-1, -1, -1))),
+        FLAG_ROW=(("row",), da.zeros(nrow_, dtype=bool, chunks=-1)),
+    )
+    dask.compute(xds_to_table(xds0, ms_name, columns=["FLAG", "FLAG_ROW"]))
+
+    out = str(tmp_path / "hci_target.zarr")
+    nx, ny, _, _, _, cell_rad, _ = set_image_size(ms_meta.max_blength, ms_meta.max_freq, 0.5, 2.0)
+
+    field = xds_from_table(f"{ms_name}::FIELD")[0]
+    ra0, dec0 = (float(v) for v in field.PHASE_DIR.values.squeeze())
+
+    # put the target well off the phase centre so a mismatch cannot hide inside
+    # rounding, and round-trip the string exactly as hci/stokes2im parse it
+    dit, djt = 30, -20
+    ra_t, dec_t = _lm_to_radec(dit * cell_rad, djt * cell_rad, ra0, dec0)
+    tc = SkyCoord(ra_t * u.rad, dec_t * u.rad, frame="fk5")
+    target = f"{tc.ra.to_string(unit=u.hourangle, sep=':')},{tc.dec.to_string(unit=u.deg, sep=':')}"
+
+    # sources at offsets from the *phase centre*; the first coincides with the
+    # target and so must land dead centre once the grid is recentred
+    offsets = [(dit, djt), (dit - 25, djt - 18), (dit + 25, djt + 18)]
+    transients = []
+    for k, (di, dj) in enumerate(offsets):
+        ra, dec = _lm_to_radec(di * cell_rad, dj * cell_rad, ra0, dec0)
+        transients.append(
+            {
+                "name": f"src{k}",
+                "time": {"peak_time": 1800.0, "duration": 3000.0, "shape": "gaussian"},
+                "frequency": {"peak_flux": 2.0, "reference_freq": 1.4e9, "spectral_index": 0.0},
+                "position": {"ra": float(np.rad2deg(ra)), "dec": float(np.rad2deg(dec))},
+            }
+        )
+    config_path = tmp_path / "transients_target.yaml"
+    with open(config_path, "w") as f:
+        yaml.safe_dump({"transients": transients}, f)
+
+    hci_core(
+        [ms_name],
+        out,
+        product="I",
+        data_column="DATA-DATA",
+        inject_transients=str(config_path),
+        target=target,
+        channels_per_image=-1,
+        channels_per_bin=-1,
+        integrations_per_image=ms_meta.ntime,  # single time bin
+        images_per_chunk=1,
+        max_simul_chunks=1,
+        field_of_view=0.5,
+        super_resolution_factor=2.0,
+        nworkers=1,
+        nthreads=1,
+        beam_model=None,
+        robustness=None,
+        epsilon=1e-8,
+        overwrite=True,
+        keep_ray_alive=True,
+        log_directory=str(tmp_path / "logs"),
+    )
+
+    ds = xr.open_zarr(out)
+    img = ds.cube.values[0, 0, 0]  # (Y, X)
+
+    for di, dj in offsets:
+        # the grid is centred on the target, so offsets are measured from it
+        ix_pred = nx // 2 - (di - dit)
+        iy_pred = ny // 2 + (dj - djt)
+        lo_y, lo_x = max(0, iy_pred - 5), max(0, ix_pred - 5)
+        win = img[lo_y : iy_pred + 6, lo_x : ix_pred + 6]
+        ly, lx = np.unravel_index(np.argmax(win), win.shape)
+        err = np.hypot(lo_x + lx - ix_pred, lo_y + ly - iy_pred)
+        assert win.max() > 0.0, f"no flux recovered for source at offset ({di},{dj})"
+        assert err <= 1.0, f"source at offset ({di},{dj}) landed {err:.1f} px from prediction"
+
+    # the stored coords must be labelled from the target, not the phase centre
+    assert_allclose(ds.X.values[nx // 2], tc.ra.value, atol=1e-9)
+    assert_allclose(ds.Y.values[ny // 2], tc.dec.value, atol=1e-9)
+
+
+def test_hci_rejects_a_moving_target_across_multiple_time_bins(ms_name, ms_meta, tmp_path):
+    """An ephemeris target moves between images; one shared X/Y axis cannot label both.
+
+    ``--target Sun`` resolves per image (``get_coordinates(time_out)``), so with
+    more than one output time bin there is no single correct labelling for the
+    cube's shared X/Y coords. That must be an up-front error naming the problem,
+    not a KeyError from inside a Ray task once the workers disagree with the
+    scaffold.
+    """
+    out = str(tmp_path / "hci_moving.zarr")
+    with pytest.raises(ValueError, match="solar-system body"):
+        hci_core(
+            [ms_name],
+            out,
+            product="I",
+            target="Sun",
+            channels_per_image=-1,
+            integrations_per_image=20,  # 60 integrations -> 3 time bins
+            images_per_chunk=3,
+            max_simul_chunks=1,
+            field_of_view=0.5,
+            super_resolution_factor=2.0,
+            nworkers=1,
+            nthreads=1,
+            beam_model=None,
+            robustness=0.0,
+            epsilon=1e-7,
+            overwrite=True,
+            keep_ray_alive=True,
+            log_directory=str(tmp_path / "logs"),
+        )
+
+
+def test_hci_accepts_a_moving_target_in_a_single_time_bin(ms_name, ms_meta, tmp_path):
+    """One time bin has one target position, so an ephemeris target is well defined.
+
+    The complement of the multi-bin rejection: with a single output image the
+    driver and the worker both resolve the body at the same ``time_out``, so the
+    scaffold's coords match what the worker writes back and the run completes.
+    """
+    out = str(tmp_path / "hci_moving_ok.zarr")
+    hci_core(
+        [ms_name],
+        out,
+        product="I",
+        target="Sun",
+        channels_per_image=-1,
+        integrations_per_image=ms_meta.ntime,  # single time bin
+        images_per_chunk=1,
         max_simul_chunks=1,
         field_of_view=0.5,
         super_resolution_factor=2.0,
@@ -866,9 +1035,15 @@ def test_hci_zarr_coords_survive_an_ulp_hostile_phase_centre(ms_name, tmp_path):
         log_directory=str(tmp_path / "logs"),
     )
 
-    # the region="auto" write is the assertion: if the coords disagreed we never
-    # get here. Confirm the slabs actually landed rather than staying empty.
     ds = xr.open_zarr(out)
-    assert ds.cube.dims == ("STOKES", "FREQ", "TIME", "Y", "X")
-    assert ds.sizes["TIME"] == 3
-    assert np.any(ds.nonzero.values), "no time bin recorded data -- slabs did not land"
+    assert ds.sizes["TIME"] == 1
+    # the grid must be labelled from the body's position at that image's time,
+    # and the FITS CRVAL must agree with it
+    ra_sun, dec_sun, moving = resolve_target_radec("Sun", float(ds.TIME.values[0]))
+    assert moving
+    nx, ny = ds.sizes["X"], ds.sizes["Y"]
+    assert_allclose(ds.X.values[nx // 2], np.rad2deg(ra_sun), atol=1e-9)
+    assert_allclose(ds.Y.values[ny // 2], np.rad2deg(dec_sun), atol=1e-9)
+    hdr = dict(ds.attrs["fits_header"])
+    assert_allclose(hdr["CRVAL1"], np.rad2deg(ra_sun), atol=1e-9)
+    assert_allclose(hdr["CRVAL2"], np.rad2deg(dec_sun), atol=1e-9)


### PR DESCRIPTION
Answers #155: why `hci`'s zarr X/Y coords need `np.round(..., decimals=12)`, and why the need was intermittent.

## The mechanism

The driver writes a full-cube scaffold, then each Ray worker writes its own slab back with **`to_zarr(region="auto")`** — which resolves the target slice by *looking the incoming coordinate values up in the stored coordinate arrays*, so it needs exact float64 equality.

Both sides compute the coords from the same formula and a bit-identical `cell_deg`. The reference coordinate diverged because the two sides reached degrees differently: the driver took astropy's degrees directly, the worker went deg → rad → deg (everything in between — rephasing, `synthesize_uvw`, `radec_to_lm`, the wgridder — works in radians).

`fl(fl(x·π/180)·180/π)` has no systematic bias (the constants multiply to exactly 1.0 in float64) but the intermediate rounds, so the composition is **not the identity for every mantissa**. Over 4000 random phase centres the pre-fix driver path disagreed with the worker for **13%** of them, worst case 1.42e-14 deg. That is the "sometimes" in the original TODO — it depends on the coordinate's bit pattern, so it reproduces perfectly on one field and never appears on another.

The symptom was a hard `KeyError: Not all values of coordinate 'Y' in the new array were found in the original store` from inside a Ray task, not a small astrometric error.

`decimals=12` is the finest quantum that still absorbs it (13 does not): ~70× the ulp at |coord| ~ 100 deg, and 3.6e-9 pixel at 1″ cells.

## The guards are redundant with each other

The asymmetry itself was fixed at some point by mirroring the conversion in the driver, so both mechanisms now hold independently — verified:

- strip both `np.round` calls → full `tests/test_hci.py` passes
- revert the driver's symmetry fix → passes (the rounding absorbs it)
- remove **both** → reproduces the production `KeyError` end to end

Both are kept: two array ops per image against a failure mode that is silent to introduce and loud to debug.

## Changes

- `core/hci.py`, `utils/stokes2im.py` — replace `# TODO - why do we sometimes need to round here?` with the mechanism and a pointer to D36. No behaviour change.
- `docs/wiki/design-decisions.md` — **D36**, including the explicit warning not to "simplify" the driver's redundant-looking `rad2deg(deg2rad(...))` back to `coord.ra.value`, and the note that quantisation cannot save a path whose reference is genuinely different.
- `tests/test_hci.py` — `test_hci_zarr_coords_survive_an_ulp_hostile_phase_centre`: searches for a phase centre near the test MS that provably fails the round trip (asserting it found one, so the test cannot go vacuous), runs `hci` on it, and checks the slabs landed. Not marked `slow` — its cheapest (only) parametrisation is well under 2 s; the ~12 s it shows when run alone is Ray warm-up that reattaches elsewhere in a full run.
- `CLAUDE.md`, `.claude/rules/testing-and-ci.md` — refresh the fast-loop counts (616/27 → 651/35, ~153 s), stale since the 0.1.0 merge.

Full suite green: `pytest tests/ -m ""` on `test_hci.py` → 22 passed; fast loop → 651 passed.

## Second commit: the `--target` bug this turned up

`--target` is not a label on the hci path — it is passed to ducc as `center_x`/`center_y`, so the **image centre moves off the tangent point** and `stokes_image` labels its `X`/`Y` coords (and `CRVAL`) from the target. `make_dummy_dataset` never looked at `target`, so the scaffold stayed on the phase centre: a whole-degree disagreement, and by D36 that is the same hard `KeyError`.

Behind it sat an earlier failure that had been masking it — `radec_to_lm(tcoords, radec_new[None, :])` handed africanus a `(1, 2)` `phase_centre`, whose implementation unpacks it as two scalars (`pc_ra, pc_dec = …`), so the path died in numba type inference before ever reaching the coords. `--target` had no test coverage on this path, so neither failure was visible.

- **`astrometry.resolve_target_radec(target, obs_time) -> (ra, dec, moving)`**, called by **both** the driver and the worker, so the reference coordinate now has exactly one implementation. That is the same class of bug as D36, so making it one function is the fix rather than papering over a drift after the fact.
- The driver sets both the scaffold coords and the header `CRVAL` from it.
- `stokes2im` now uses the repo's own pure-numpy `misc.radec_to_lm` (identical formula, 1-D `(2,)` convention, already what the imager path uses) at both call sites, removing the `(1, 2)`-vs-`(2,)` trap.
- An **ephemeris target** (a bare body name) moves between images while `X`/`Y` is a single axis shared across `TIME`, so no one labelling is correct for a multi-bin cube. That is now rejected up front with the drift in degrees and the two ways out; a single time bin is allowed and works, because the driver and the worker average the same time slice.
- `integrations_per_image < 1` makes the time loop `range(tlow, tlow + tcounts, integrations_per_image)` empty. That used to surface as an `IndexError` on `out_times[0]` while building the WCS; it now raises where it is caused. (The CLI still advertises `-1` as "dataset per scan", which that loop does not implement — noted in D37, not fixed here.)

Recorded as **D37**. Three tests: `test_hci_target_recentres_the_grid` (astrometry — sources injected about the target must land at their predicted pixels about the image centre; verified to fail with the exact production `KeyError` when the driver's handling is disabled), plus the reject/accept pair for the ephemeris form. Two bugs were caught by these tests rather than by inspection: `np.ndarray.ptp` (removed in numpy 2) in the new error path, and the `integrations_per_image=-1` empty-mapping case.

None are marked `slow` — all three are ~1–1.5 s in a full-file run. The first measurements were much higher (10.3 s and 6.8 s) and turned out to be sticky Ray/ephemeris warm-up plus the `robustness=0.0` COUNTS path, exactly the whack-a-mole the testing rules warn about; the coord contract is weighting-independent, so the ulp test now runs natural.

## Copilot review

Both points taken:
- the `1e-12 deg` code comment claimed "3.6 nano-pixel", but that is a fixed *angle* (3.6 nanoarcsec) and the pixel fraction depends on `cell_deg` — fixed. (D36's own "3.6e-9 pixel" is explicitly qualified to 1″ cells, so it stands.)
- wiki `timestamp` was ahead of the clock — set to the real time.

Closes #155
